### PR TITLE
Trigger degeneracy

### DIFF
--- a/Framework/src/TreeEntry.cc
+++ b/Framework/src/TreeEntry.cc
@@ -71,9 +71,11 @@ panda::TreeEntry::getEntry(TTree& _tree, Long64_t _entry)
   for (unsigned iC(0); iC != collections_.size(); ++iC)
     collections_[iC]->prepareGetEntry(_tree, _entry);
 
+  Int_t retcode = _tree.GetEntry(_entry);
+
   doGetEntry_(_tree, _entry);
 
-  return _tree.GetEntry(_entry);
+  return retcode;
 }
 
 Int_t

--- a/Objects/interface/HLTBits.h
+++ b/Objects/interface/HLTBits.h
@@ -20,7 +20,7 @@ namespace panda {
     void print(std::ostream& = std::cout) const override;
 
     void set(unsigned iB) { if (iB >= 1024) return; words[iB / 64] |= (1 << (iB % 64)); }
-    bool pass(unsigned iB) const { if (iB >= 1024) return false; return ((words[iB / 64] >> (iB % 64)) & 1) != 0; }
+    bool pass(unsigned iB) const { if (iB >= 1024) return false; return (words[iB / 64] & (1 << (iB % 64))) != 0; }
 
     ULong64_t words[16]{};
 

--- a/Objects/src/Run.cc
+++ b/Objects/src/Run.cc
@@ -180,7 +180,7 @@ panda::Run::update(UInt_t _runNumber, TTree& _eventTree)
     if (runNumber == _runNumber)
       break;
   }
-  if (iEntry == runTree->GetEntries()) {
+  if (iEntry == runTree->GetEntries()+1) {
     std::cerr << "Run " << _runNumber << " not found in " << inputFile->GetName() << std::endl;
     throw std::runtime_error("InputError");
   }

--- a/panda.def
+++ b/panda.def
@@ -355,7 +355,7 @@ virtual bool pass() const { return !globalHalo16 && !hbhe && !hbheIso && !ecalDe
 [HLTBits:SINGLE]
 words[16]/l
 void set(unsigned iB) { if (iB >= 1024) return; words[iB / 64] |= (1 << (iB % 64)); }
-bool pass(unsigned iB) const { if (iB >= 1024) return false; return ((words[iB / 64] >> (iB % 64)) & 1) != 0; }
+bool pass(unsigned iB) const { if (iB >= 1024) return false; return (words[iB / 64] & (1 << (iB % 64))) != 0; }
 
 [GenReweight:SINGLE]
 r1f2DW/F


### PR DESCRIPTION
Two changes:

 - `TTree::GetEntry` is called before `EventBase::doGetEntry_` so that the correct runs are read.

 - Exploit the problem in filling the trigger bits to be able to read them in a semi-reasonable way. The only problem is if an event passes the offline cuts and also somehow triggers a trigger shifted by 32 indices. This will need to be rolled back in 003.
