### PR TITLE
Copy panda::Run when copying panda::EventBase

### DIFF
--- a/Objects/src/EventBase.cc
+++ b/Objects/src/EventBase.cc
@@ -31,6 +31,8 @@ panda::EventBase::operator=(EventBase const& _src)
   isData = _src.isData;
   weight = _src.weight;
 
+  run = _src.run;
+
   triggers = _src.triggers;
 
   return *this;


### PR DESCRIPTION
Easy one line fix, makes sure panda::EventBase::runNumber and panda::Run::runNumber are in sync and enables one to get the HLT info after an event has been copied. This is half the reason monophoton code wasn't able to read triggers.