### PR TITLE
Fleshed out print functions for "core" objects.

### DIFF
--- a/Framework/interface/Array.h
+++ b/Framework/interface/Array.h
@@ -68,6 +68,9 @@ namespace panda {
 
     std::vector<UInt_t> sort(ContainerBase::Comparison const&) override;
 
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
+
     typename value_type::datastore data{};
 
   protected:
@@ -190,6 +193,22 @@ namespace panda {
       (*this)[iP] = tmpCollection[sortedIndices[iP]];
 
     return sortedIndices;
+  }
+
+  template<class E>
+  void
+  Array<E>::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
+  {
+    _out << E::typeName() << "Array(" << ArrayBase::size() << ")" << std::endl;
+    ContainerBase::print(_out, _level);
+  }
+
+  template<class E>
+  void
+  Array<E>::dump(std::ostream& _out/* = std::cout*/) const
+  {
+    _out << E::typeName() << "Array(" << ArrayBase::size() << ")" << std::endl;
+    ContainerBase::dump(_out);
   }
 
   /*private*/

--- a/Framework/interface/Collection.h
+++ b/Framework/interface/Collection.h
@@ -83,6 +83,9 @@ namespace panda {
 
     std::vector<UInt_t> sort(ContainerBase::Comparison const&) override;
 
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
+
     data_type data{};
 
   protected:
@@ -225,6 +228,22 @@ namespace panda {
       (*this)[iP] = tmpCollection[sortedIndices[iP]];
 
     return sortedIndices;
+  }
+
+  template<class E>
+  void
+  Collection<E>::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
+  {
+    _out << E::typeName() << "Collection" << std::endl;
+    CollectionBase::print(_out, _level);
+  }
+
+  template<class E>
+  void
+  Collection<E>::dump(std::ostream& _out/* = std::cout*/) const
+  {
+    _out << E::typeName() << "Collection" << std::endl;
+    CollectionBase::dump(_out);
   }
 
   /*protected*/

--- a/Framework/interface/CollectionBase.h
+++ b/Framework/interface/CollectionBase.h
@@ -23,6 +23,9 @@ namespace panda {
     void init() final { clear(); }
     UInt_t size() const final { return size_; }
 
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
+
     //! Resize the container.
     /*!
      * If expanding, init() is invoked on all new elements.

--- a/Framework/interface/ContainerBase.h
+++ b/Framework/interface/ContainerBase.h
@@ -28,6 +28,8 @@ namespace panda {
     void book(TTree&, utils::BranchList const& blist = {"*"}) final;
     char const* getName() const final { return name_; }
     void setName(char const* name) final { name_ = name; }
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     virtual UInt_t size() const = 0;
     virtual Element::datastore& getData() = 0;

--- a/Framework/interface/Element.h
+++ b/Framework/interface/Element.h
@@ -74,6 +74,8 @@ namespace panda {
     ~Element() {}
     Element& operator=(Element const&) { return *this; }
 
+    static char const* typeName() { return "Element"; }
+
     void setStatus(TTree&, utils::BranchList const& blist) final;
     utils::BranchList getStatus(TTree&) const final;
     utils::BranchList getBranchNames(Bool_t fullName = kTRUE) const final;

--- a/Framework/interface/Object.h
+++ b/Framework/interface/Object.h
@@ -81,7 +81,10 @@ namespace panda {
     virtual void setName(char const*) {}
 
     //! Print the object content.
-    virtual void print(std::ostream& = std::cout) const {}
+    virtual void print(std::ostream& out = std::cout, UInt_t level = 1) const { dump(out); }
+
+    //! Dump the object content.
+    virtual void dump(std::ostream& = std::cout) const {}
   };
 
 }

--- a/Framework/interface/Ref.h
+++ b/Framework/interface/Ref.h
@@ -107,7 +107,7 @@ namespace panda {
       return true;
     }
     //! Validity check. Both container and idx must be valid, and idx must not be 0xffffffff.
-    Bool_t isValid() const { return container_ && *container_ && idx_ && (*idx_) < (*container_)->size(); }
+    Bool_t isValid() const { return container_ && *container_ && idx_ && unsigned(*idx_) < (*container_)->size(); }
     //! Initializer
     /*!
      * Invalidates the index by setting it to 0xffffffff.
@@ -128,6 +128,17 @@ namespace panda {
     /*!
      * Throws a runtime_error if container is not valid.
      */
+    //! Accessor to idx
+    /*!
+     * Throws a runtime_error if idx is not valid.
+     */
+    index_type idx() const
+    {
+      if (!idx_)
+        throw std::runtime_error("Invalid index ref");
+  
+      return *idx_;
+    }
     ContainerBase const* container() const
     {
       if (!container_)
@@ -200,12 +211,23 @@ namespace panda {
       return static_cast<E const&>((*container_)->elemAt(*idx_));
     }
     //! Validity check. Both container and idx must be valid, and idx must not be 0xffffffff.
-    Bool_t isValid() const { return container_ && *container_ && idx_ && (*idx_) < (*container_)->size(); }
+    Bool_t isValid() const { return container_ && *container_ && idx_ && unsigned(*idx_) < (*container_)->size(); }
     //! Accessor to idx
     /*!
      * Throws a runtime_error if idx is not valid.
      */
     index_type& idx()
+    {
+      if (!idx_)
+        throw std::runtime_error("Invalid index ref");
+  
+      return *idx_;
+    }
+    //! Accessor to idx
+    /*!
+     * Throws a runtime_error if idx is not valid.
+     */
+    index_type idx() const
     {
       if (!idx_)
         throw std::runtime_error("Invalid index ref");
@@ -231,6 +253,32 @@ namespace panda {
     index_type* idx_{0};
   };
 
+}
+
+template<class E>
+std::ostream& operator<<(std::ostream& _out, panda::Ref<E> const& _ref)
+{
+  _out << "Ref<" << E::typeName() << ">";
+  if (_ref.isValid())
+    _out << " " << _ref.container()->getName() << "(" << _ref.idx() << ")";
+  else
+    _out << " (null)";
+  _out << std::endl;
+
+  return _out;
+}
+
+template<class E>
+std::ostream& operator<<(std::ostream& _out, panda::ConstRef<E> const& _ref)
+{
+  _out << "Ref<" << E::typeName() << ">";
+  if (_ref.isValid())
+    _out << " " << _ref.container()->getName() << "(" << _ref.idx() << ")";
+  else
+    _out << " (null)";
+  _out << std::endl;
+
+  return _out;
 }
 
 #endif

--- a/Framework/interface/RefVector.h
+++ b/Framework/interface/RefVector.h
@@ -69,6 +69,8 @@ namespace panda {
      * Invalidates the index by setting it to 0xffffffff.
      */
     void init() { clear(); }
+    //! Validity check. Both container and idx must be valid, and idx must not be 0xffffffff.
+    Bool_t isValid() const { return container_ && *container_ && indices_; }
     //! Accessor to indices
     /*!
      * Throws a runtime_error if indices is NULL.
@@ -249,6 +251,19 @@ namespace panda {
     return *container_;
   }
 
+}
+
+template<class E>
+std::ostream& operator<<(std::ostream& _out, panda::RefVector<E> const& _ref)
+{
+  _out << "RefVector<" << E::typeName() << ">";
+  if (_ref.isValid())
+    _out << " " << _ref.container()->getName();
+  else
+    _out << " <null>";
+  _out << std::endl;
+
+  return _out;
 }
 
 #endif

--- a/Framework/src/CollectionBase.cc
+++ b/Framework/src/CollectionBase.cc
@@ -20,6 +20,23 @@ panda::CollectionBase::fill(TTree& _tree)
 }
 
 void
+panda::CollectionBase::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
+{
+  _out << "size: " << size() << ", allocated size: " << getData().nmax() << std::endl;
+  ContainerBase::print(_out, _level);
+}
+
+void
+panda::CollectionBase::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "size_ = " << size_ << std::endl;
+  _out << "sizeIn_ = " << sizeIn_ << std::endl;
+  _out << "inputs_  = map(" << inputs_.size() << ")" << std::endl;
+  _out << "outputs_  = map(" << outputs_.size() << ")" << std::endl;
+  ContainerBase::dump(_out);
+}
+
+void
 panda::CollectionBase::resize(UInt_t _size)
 {
   if (_size > getData().nmax()) {

--- a/Framework/src/ContainerBase.cc
+++ b/Framework/src/ContainerBase.cc
@@ -35,3 +35,32 @@ panda::ContainerBase::book(TTree& _tree, utils::BranchList const& _branches/* = 
 {
   doBook_(_tree, _branches);
 }
+
+void
+panda::ContainerBase::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
+{
+  if (name_.Length() != 0)
+    _out << "{" << name_ << "}" << std::endl;
+
+  for (unsigned iE(0); iE != size(); ++iE) {
+    _out << "[" << iE << "]";
+    if (_level > 1)
+      _out << std::endl;
+    else
+      _out << " ";
+    elemAt(iE).print(_out, _level);
+  }
+}
+
+void
+panda::ContainerBase::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "name_ = " << name_ << std::endl;
+  _out << "unitSize_ = " << unitSize_ << std::endl;
+  _out << "array_ (" << (void*)(array_) << "): " << std::endl;
+  for (unsigned iE(0); iE != size(); ++iE) {
+    _out << "[" << iE << "]" << std::endl;
+    elemAt(iE).dump(_out);
+  }
+  _out << std::endl;
+}

--- a/Objects/interface/Electron.h
+++ b/Objects/interface/Electron.h
@@ -74,7 +74,11 @@ namespace panda {
     Electron(datastore&, UInt_t idx);
     ~Electron();
     Electron& operator=(Electron const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "Electron"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     double m() const override { return 5.109989e-4; }
     double combIso() const override { return chIso + std::max(nhIso + phIso - isoPUOffset, Float_t(0.)); }

--- a/Objects/interface/Event.h
+++ b/Objects/interface/Event.h
@@ -29,6 +29,9 @@ namespace panda {
     ~Event() {}
     Event& operator=(Event const&);
 
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
+
     GenReweight genReweight = GenReweight("genReweight");
     PFCandCollection pfCandidates = PFCandCollection("pfCandidates", 2048);
     SuperClusterCollection superClusters = SuperClusterCollection("superClusters", 64);

--- a/Objects/interface/EventBase.h
+++ b/Objects/interface/EventBase.h
@@ -14,6 +14,9 @@ namespace panda {
     ~EventBase() {}
     EventBase& operator=(EventBase const&);
 
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
+
     HLTBits triggers = HLTBits("triggers");
 
     UInt_t runNumber{};

--- a/Objects/interface/EventMonophoton.h
+++ b/Objects/interface/EventMonophoton.h
@@ -26,6 +26,9 @@ namespace panda {
     ~EventMonophoton() {}
     EventMonophoton& operator=(EventMonophoton const&);
 
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
+
     GenReweight genReweight = GenReweight("genReweight");
     SuperClusterCollection superClusters = SuperClusterCollection("superClusters", 64);
     ElectronCollection electrons = ElectronCollection("electrons", 32);

--- a/Objects/interface/EventTPPhoton.h
+++ b/Objects/interface/EventTPPhoton.h
@@ -1,0 +1,60 @@
+#ifndef PandaTree_Objects_EventTPPhoton_h
+#define PandaTree_Objects_EventTPPhoton_h
+#include "EventBase.h"
+#include "Constants.h"
+#include "TPPair.h"
+#include "Lepton.h"
+#include "XPhoton.h"
+#include "Jet.h"
+#include "RecoMet.h"
+#include "Event.h"
+#include "EventMonophoton.h"
+
+namespace panda {
+
+  class EventTPPhoton : public EventBase {
+  public:
+    EventTPPhoton();
+    EventTPPhoton(EventTPPhoton const&);
+    ~EventTPPhoton() {}
+    EventTPPhoton& operator=(EventTPPhoton const&);
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
+
+    TPPairCollection tp = TPPairCollection("tp", 32);
+    LeptonCollection tags = LeptonCollection("tags", 32);
+    LeptonCollection looseTags = LeptonCollection("looseTags", 32);
+    XPhotonCollection probes = XPhotonCollection("probes", 32);
+    JetCollection jets = JetCollection("jets", 64);
+    RecoMet t1Met = RecoMet("t1Met");
+
+    UShort_t npv{};
+    UShort_t npvTrue{};
+    Float_t rho{};
+    UInt_t sample{};
+
+    static utils::BranchList getListOfBranches();
+
+  protected:
+    void doSetStatus_(TTree&, utils::BranchList const&) override;
+    utils::BranchList doGetStatus_(TTree&) const override;
+    utils::BranchList doGetBranchNames_() const override;
+    void doSetAddress_(TTree&, utils::BranchList const&, Bool_t setStatus) override;
+    void doBook_(TTree&, utils::BranchList const&) override;
+    void doGetEntry_(TTree&, Long64_t) override;
+    void doInit_() override;
+
+  public:
+    /* BEGIN CUSTOM EventTPPhoton.h.classdef */
+    EventTPPhoton& operator=(Event const&);
+    EventTPPhoton& operator=(EventMonophoton const&);
+    /* END CUSTOM */
+  };
+
+  /* BEGIN CUSTOM EventTPPhoton.h.global */
+  /* END CUSTOM */
+
+}
+
+#endif

--- a/Objects/interface/FatJet.h
+++ b/Objects/interface/FatJet.h
@@ -82,7 +82,11 @@ namespace panda {
     FatJet(datastore&, UInt_t idx);
     ~FatJet();
     FatJet& operator=(FatJet const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "FatJet"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     double get_ecf(int o_, int N_, int ib_) const;
     bool set_ecf(int o_, int N_, int ib_, float x_);

--- a/Objects/interface/GenJet.h
+++ b/Objects/interface/GenJet.h
@@ -46,7 +46,11 @@ namespace panda {
     GenJet(datastore&, UInt_t idx);
     ~GenJet();
     GenJet& operator=(GenJet const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "GenJet"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     Short_t& pdgid;
 

--- a/Objects/interface/GenParticle.h
+++ b/Objects/interface/GenParticle.h
@@ -47,7 +47,11 @@ namespace panda {
     GenParticle(datastore&, UInt_t idx);
     ~GenParticle();
     GenParticle& operator=(GenParticle const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "GenParticle"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     /* PackedParticle
     UShort_t& packedPt;

--- a/Objects/interface/GenReweight.h
+++ b/Objects/interface/GenReweight.h
@@ -17,7 +17,11 @@ namespace panda {
     GenReweight(GenReweight const&);
     ~GenReweight();
     GenReweight& operator=(GenReweight const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "GenReweight"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     Float_t r1f2DW{};
     Float_t r1f5DW{};

--- a/Objects/interface/HLTBits.h
+++ b/Objects/interface/HLTBits.h
@@ -17,7 +17,11 @@ namespace panda {
     HLTBits(HLTBits const&);
     ~HLTBits();
     HLTBits& operator=(HLTBits const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "HLTBits"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     void set(unsigned iB) { if (iB >= 1024) return; words[iB / 64] |= (1 << (iB % 64)); }
     bool pass(unsigned iB) const { if (iB >= 1024) return false; return (words[iB / 64] & (1 << (iB % 64))) != 0; }

--- a/Objects/interface/Jet.h
+++ b/Objects/interface/Jet.h
@@ -68,7 +68,11 @@ namespace panda {
     Jet(datastore&, UInt_t idx);
     ~Jet();
     Jet& operator=(Jet const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "Jet"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     /* MicroJet
     Float_t& csv;

--- a/Objects/interface/Lepton.h
+++ b/Objects/interface/Lepton.h
@@ -54,7 +54,11 @@ namespace panda {
     Lepton(datastore&, UInt_t idx);
     ~Lepton();
     Lepton& operator=(Lepton const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "Lepton"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     virtual double combIso() const { return 0.; }
 

--- a/Objects/interface/Met.h
+++ b/Objects/interface/Met.h
@@ -17,7 +17,11 @@ namespace panda {
     Met(Met const&);
     ~Met();
     Met& operator=(Met const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "Met"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     virtual TVector2 v() const { TVector2 vec; vec.SetMagPhi(pt, phi); return vec; }
     void setXY(double x, double y) { pt = std::sqrt(x * x + y * y); phi = std::atan2(y, x); }

--- a/Objects/interface/MetFilters.h
+++ b/Objects/interface/MetFilters.h
@@ -17,7 +17,11 @@ namespace panda {
     MetFilters(MetFilters const&);
     ~MetFilters();
     MetFilters& operator=(MetFilters const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "MetFilters"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     virtual bool pass() const { return !globalHalo16 && !hbhe && !hbheIso && !ecalDeadCell && !badsc; }
 

--- a/Objects/interface/MicroJet.h
+++ b/Objects/interface/MicroJet.h
@@ -47,7 +47,11 @@ namespace panda {
     MicroJet(datastore&, UInt_t idx);
     ~MicroJet();
     MicroJet& operator=(MicroJet const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "MicroJet"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     Float_t& csv;
     Float_t& qgl;

--- a/Objects/interface/Muon.h
+++ b/Objects/interface/Muon.h
@@ -57,7 +57,11 @@ namespace panda {
     Muon(datastore&, UInt_t idx);
     ~Muon();
     Muon& operator=(Muon const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "Muon"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     double m() const override { return 1.05658e-2; }
     double combIso() const override { return chIso + std::max(nhIso + phIso - 0.5 * puIso, 0.); }

--- a/Objects/interface/PFCand.h
+++ b/Objects/interface/PFCand.h
@@ -46,7 +46,11 @@ namespace panda {
     PFCand(datastore&, UInt_t idx);
     ~PFCand();
     PFCand& operator=(PFCand const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "PFCand"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     enum PType {
       hp,

--- a/Objects/interface/PackedParticle.h
+++ b/Objects/interface/PackedParticle.h
@@ -41,7 +41,11 @@ namespace panda {
     PackedParticle(datastore&, UInt_t idx);
     ~PackedParticle();
     PackedParticle& operator=(PackedParticle const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "PackedParticle"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     double pt() const override { unpack_(); return pt_; }
     double eta() const override { unpack_(); return eta_; }

--- a/Objects/interface/Particle.h
+++ b/Objects/interface/Particle.h
@@ -34,7 +34,11 @@ namespace panda {
     Particle(datastore&, UInt_t idx);
     ~Particle();
     Particle& operator=(Particle const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "Particle"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     TLorentzVector p4() const { TLorentzVector p4; p4.SetPtEtaPhiM(pt(), eta(), phi(), m()); return p4; }
     double e() const { return std::sqrt(std::pow(pt() * std::cosh(eta()), 2.) + m() * m()); }
@@ -54,15 +58,6 @@ namespace panda {
     virtual void setXYZE(double px, double py, double pz, double e) = 0;
 
     /* BEGIN CUSTOM Particle.h.classdef */
-
-    //! sort comparison by pt
-    /*!
-     * This function takes Elements as arguments to conform with ContainerBase::Comparison
-     * but assumes that both arguments are static_castable to Particle.
-     */
-    static Bool_t PtGreater(Element const& p1, Element const& p2) {
-      return static_cast<Particle const&>(p1).pt() > static_cast<Particle const&>(p2).pt();
-    }
     /* END CUSTOM */
 
     static utils::BranchList getListOfBranches();

--- a/Objects/interface/Particle.h
+++ b/Objects/interface/Particle.h
@@ -58,6 +58,14 @@ namespace panda {
     virtual void setXYZE(double px, double py, double pz, double e) = 0;
 
     /* BEGIN CUSTOM Particle.h.classdef */
+    //! sort comparison by pt
+    /*!
+     * This function takes Elements as arguments to conform with ContainerBase::Comparison
+     * but assumes that both arguments are static_castable to Particle.
+     */
+    static Bool_t PtGreater(Element const& p1, Element const& p2) {
+      return static_cast<Particle const&>(p1).pt() > static_cast<Particle const&>(p2).pt();
+    }
     /* END CUSTOM */
 
     static utils::BranchList getListOfBranches();

--- a/Objects/interface/ParticleM.h
+++ b/Objects/interface/ParticleM.h
@@ -43,7 +43,11 @@ namespace panda {
     ParticleM(datastore&, UInt_t idx);
     ~ParticleM();
     ParticleM& operator=(ParticleM const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "ParticleM"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     double m() const override { return mass_; }
     void setPtEtaPhiM(double pt, double eta, double phi, double m) override;

--- a/Objects/interface/ParticleP.h
+++ b/Objects/interface/ParticleP.h
@@ -40,7 +40,11 @@ namespace panda {
     ParticleP(datastore&, UInt_t idx);
     ~ParticleP();
     ParticleP& operator=(ParticleP const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "ParticleP"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     double pt() const override { return pt_; }
     double eta() const override { return eta_; }

--- a/Objects/interface/Photon.h
+++ b/Objects/interface/Photon.h
@@ -79,7 +79,11 @@ namespace panda {
     Photon(datastore&, UInt_t idx);
     ~Photon();
     Photon& operator=(Photon const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "Photon"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     Float_t& pfPt; // Pt of the dR-closest PF candidate
     Float_t& chIso;

--- a/Objects/interface/RecoMet.h
+++ b/Objects/interface/RecoMet.h
@@ -17,7 +17,11 @@ namespace panda {
     RecoMet(RecoMet const&);
     ~RecoMet();
     RecoMet& operator=(RecoMet const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "RecoMet"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     virtual TVector2 vCorr(int corr = 0) const;
 

--- a/Objects/interface/Recoil.h
+++ b/Objects/interface/Recoil.h
@@ -17,7 +17,11 @@ namespace panda {
     Recoil(Recoil const&);
     ~Recoil();
     Recoil& operator=(Recoil const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "Recoil"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     bool any() const { return met || monoMu || monoE || diMu || diE || gamma; }
 

--- a/Objects/interface/Run.h
+++ b/Objects/interface/Run.h
@@ -12,6 +12,9 @@ namespace panda {
     ~Run() {}
     Run& operator=(Run const&);
 
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
+
     UInt_t runNumber{};
     UInt_t hltMenu{};
     UShort_t hltSize{}; // transient

--- a/Objects/interface/SuperCluster.h
+++ b/Objects/interface/SuperCluster.h
@@ -40,7 +40,11 @@ namespace panda {
     SuperCluster(datastore&, UInt_t idx);
     ~SuperCluster();
     SuperCluster& operator=(SuperCluster const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "SuperCluster"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     Float_t& rawPt;
     Float_t& eta;

--- a/Objects/interface/TPPair.h
+++ b/Objects/interface/TPPair.h
@@ -1,7 +1,7 @@
-#ifndef PandaTree_Objects_Parton_h
-#define PandaTree_Objects_Parton_h
+#ifndef PandaTree_Objects_TPPair_h
+#define PandaTree_Objects_TPPair_h
 #include "Constants.h"
-#include "ParticleM.h"
+#include "../../Framework/interface/Element.h"
 #include "../../Framework/interface/Array.h"
 #include "../../Framework/interface/Collection.h"
 #include "../../Framework/interface/Ref.h"
@@ -9,21 +9,14 @@
 
 namespace panda {
 
-  class Parton : public ParticleM {
+  class TPPair : public Element {
   public:
-    struct datastore : public ParticleM::datastore {
-      datastore() : ParticleM::datastore() {}
+    struct datastore : public Element::datastore {
+      datastore() : Element::datastore() {}
       ~datastore() { deallocate(); }
 
-      /* ParticleP
-      Float_t* pt_{0};
-      Float_t* eta_{0};
-      Float_t* phi_{0};
-      */
-      /* ParticleM
-      Float_t* mass_{0};
-      */
-      Int_t* pdgid{0};
+      Float_t* mass{0};
+      Float_t* mass2{0};
 
       void allocate(UInt_t n) override;
       void deallocate() override;
@@ -36,36 +29,26 @@ namespace panda {
       void resizeVectors_(UInt_t) override;
     };
 
-    typedef Array<Parton> array_type;
-    typedef Collection<Parton> collection_type;
+    typedef Array<TPPair> array_type;
+    typedef Collection<TPPair> collection_type;
 
-    typedef ParticleM base_type;
+    typedef Element base_type;
 
-    Parton(char const* name = "");
-    Parton(Parton const&);
-    Parton(datastore&, UInt_t idx);
-    ~Parton();
-    Parton& operator=(Parton const&);
+    TPPair(char const* name = "");
+    TPPair(TPPair const&);
+    TPPair(datastore&, UInt_t idx);
+    ~TPPair();
+    TPPair& operator=(TPPair const&);
 
-    static char const* typeName() { return "Parton"; }
+    static char const* typeName() { return "TPPair"; }
 
     void print(std::ostream& = std::cout, UInt_t level = 1) const override;
     void dump(std::ostream& = std::cout) const override;
 
-    Int_t& pdgid;
+    Float_t& mass;
+    Float_t& mass2;
 
-  protected:
-    /* ParticleP
-    Float_t& pt_;
-    Float_t& eta_;
-    Float_t& phi_;
-    */
-    /* ParticleM
-    Float_t& mass_;
-    */
-
-  public:
-    /* BEGIN CUSTOM Parton.h.classdef */
+    /* BEGIN CUSTOM TPPair.h.classdef */
     /* END CUSTOM */
 
     static utils::BranchList getListOfBranches();
@@ -73,19 +56,19 @@ namespace panda {
     void destructor() override;
 
   protected:
-    Parton(ArrayBase*);
+    TPPair(ArrayBase*);
 
     void doSetAddress_(TTree&, TString const&, utils::BranchList const& = {"*"}, Bool_t setStatus = kTRUE) override;
     void doBook_(TTree&, TString const&, utils::BranchList const& = {"*"}) override;
     void doInit_() override;
   };
 
-  typedef Array<Parton> PartonArray;
-  typedef Collection<Parton> PartonCollection;
-  typedef Ref<Parton> PartonRef;
-  typedef RefVector<Parton> PartonRefVector;
+  typedef Array<TPPair> TPPairArray;
+  typedef Collection<TPPair> TPPairCollection;
+  typedef Ref<TPPair> TPPairRef;
+  typedef RefVector<TPPair> TPPairRefVector;
 
-  /* BEGIN CUSTOM Parton.h.global */
+  /* BEGIN CUSTOM TPPair.h.global */
   /* END CUSTOM */
 
 }

--- a/Objects/interface/Tau.h
+++ b/Objects/interface/Tau.h
@@ -54,7 +54,11 @@ namespace panda {
     Tau(datastore&, UInt_t idx);
     ~Tau();
     Tau& operator=(Tau const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "Tau"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     Char_t& charge;
     Bool_t& decayMode;

--- a/Objects/interface/XPhoton.h
+++ b/Objects/interface/XPhoton.h
@@ -86,7 +86,11 @@ namespace panda {
     XPhoton(datastore&, UInt_t idx);
     ~XPhoton();
     XPhoton& operator=(XPhoton const&);
-    void print(std::ostream& = std::cout) const override;
+
+    static char const* typeName() { return "XPhoton"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
 
     static double chIsoCuts[2][2][4];
     static double nhIsoCuts[2][2][4];

--- a/Objects/src/Electron.cc
+++ b/Objects/src/Electron.cc
@@ -447,7 +447,6 @@ panda::Electron::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/
 void
 panda::Electron::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   Lepton::dump(_out);
 
   _out << "hltsafe = " << hltsafe << std::endl;

--- a/Objects/src/Electron.cc
+++ b/Objects/src/Electron.cc
@@ -437,10 +437,35 @@ panda::Electron::doInit_()
 }
 
 void
-panda::Electron::print(std::ostream& _out/* = std::cout*/) const
+panda::Electron::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Electron.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::Electron::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  Lepton::dump(_out);
+
+  _out << "hltsafe" << hltsafe << std::endl;
+  _out << "chIsoPh" << chIsoPh << std::endl;
+  _out << "nhIsoPh" << nhIsoPh << std::endl;
+  _out << "phIsoPh" << phIsoPh << std::endl;
+  _out << "ecalIso" << ecalIso << std::endl;
+  _out << "hcalIso" << hcalIso << std::endl;
+  _out << "isoPUOffset" << isoPUOffset << std::endl;
+  _out << "sieie" << sieie << std::endl;
+  _out << "sipip" << sipip << std::endl;
+  _out << "eseed" << eseed << std::endl;
+  _out << "hOverE" << hOverE << std::endl;
+  _out << "rawPt" << rawPt << std::endl;
+  _out << "regPt" << regPt << std::endl;
+  _out << "originalPt" << originalPt << std::endl;
+  _out << "veto" << veto << std::endl;
+  _out << "triggerMatch" << triggerMatch << std::endl;
+  _out << "superCluster" << superCluster << std::endl;
 }
 
 

--- a/Objects/src/Electron.cc
+++ b/Objects/src/Electron.cc
@@ -440,6 +440,7 @@ void
 panda::Electron::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Electron.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -449,23 +450,23 @@ panda::Electron::dump(std::ostream& _out/* = std::cout*/) const
   _out << "<" << typeName() << ">" << std::endl;
   Lepton::dump(_out);
 
-  _out << "hltsafe" << hltsafe << std::endl;
-  _out << "chIsoPh" << chIsoPh << std::endl;
-  _out << "nhIsoPh" << nhIsoPh << std::endl;
-  _out << "phIsoPh" << phIsoPh << std::endl;
-  _out << "ecalIso" << ecalIso << std::endl;
-  _out << "hcalIso" << hcalIso << std::endl;
-  _out << "isoPUOffset" << isoPUOffset << std::endl;
-  _out << "sieie" << sieie << std::endl;
-  _out << "sipip" << sipip << std::endl;
-  _out << "eseed" << eseed << std::endl;
-  _out << "hOverE" << hOverE << std::endl;
-  _out << "rawPt" << rawPt << std::endl;
-  _out << "regPt" << regPt << std::endl;
-  _out << "originalPt" << originalPt << std::endl;
-  _out << "veto" << veto << std::endl;
-  _out << "triggerMatch" << triggerMatch << std::endl;
-  _out << "superCluster" << superCluster << std::endl;
+  _out << "hltsafe = " << hltsafe << std::endl;
+  _out << "chIsoPh = " << chIsoPh << std::endl;
+  _out << "nhIsoPh = " << nhIsoPh << std::endl;
+  _out << "phIsoPh = " << phIsoPh << std::endl;
+  _out << "ecalIso = " << ecalIso << std::endl;
+  _out << "hcalIso = " << hcalIso << std::endl;
+  _out << "isoPUOffset = " << isoPUOffset << std::endl;
+  _out << "sieie = " << sieie << std::endl;
+  _out << "sipip = " << sipip << std::endl;
+  _out << "eseed = " << eseed << std::endl;
+  _out << "hOverE = " << hOverE << std::endl;
+  _out << "rawPt = " << rawPt << std::endl;
+  _out << "regPt = " << regPt << std::endl;
+  _out << "originalPt = " << originalPt << std::endl;
+  _out << "veto = " << veto << std::endl;
+  _out << "triggerMatch = " << triggerMatch << std::endl;
+  _out << "superCluster = " << superCluster << std::endl;
 }
 
 

--- a/Objects/src/Electron.cc
+++ b/Objects/src/Electron.cc
@@ -440,7 +440,24 @@ void
 panda::Electron::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Electron.cc.print */
-  dump(_out);
+  if (_level >= 3) {
+    Electron::dump(_out);
+    
+    _out << "combIso = " << combIso() << std::endl;
+    _out << "combRelIso = " << combIso() / pt() << std::endl;
+  }
+  else if (_level == 2) {
+    Lepton::print(_out, _level);
+    
+    _out << "rawPt = " << rawPt << std::endl;
+    _out << "hltsafe = " << hltsafe << std::endl;
+    _out << "veto = " << veto << std::endl;
+
+    _out << "combIso = " << combIso() << std::endl;
+    _out << "combRelIso = " << combIso() / pt() << std::endl;
+  }
+  else
+    return;
   /* END CUSTOM */
 }
 

--- a/Objects/src/Event.cc
+++ b/Objects/src/Event.cc
@@ -193,7 +193,21 @@ void
 panda::Event::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Event.cc.print */
-  dump(_out);
+  if (_level > 2) {
+    _out << "why am I here?" << std::endl;
+    dump(_out);
+  }
+  else if (_level > 1) {
+    // debug level
+    EventBase::print(_out, _level);
+    
+    _out << "npv = " << npv << std::endl;
+    _out << "npvTrue = " << npvTrue << std::endl;
+    _out << "rho = " << rho << std::endl;
+    _out << "rhoCentralCalo = " << rhoCentralCalo << std::endl;
+  }
+  else 
+    return;
   /* END CUSTOM */
 }
 

--- a/Objects/src/Event.cc
+++ b/Objects/src/Event.cc
@@ -193,11 +193,10 @@ void
 panda::Event::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Event.cc.print */
-  if (_level > 2) {
-    _out << "why am I here?" << std::endl;
-    dump(_out);
+  if (_level >= 3) {
+    Event::dump(_out);
   }
-  else if (_level > 1) {
+  else if (_level == 2) {
     // debug level
     EventBase::print(_out, _level);
     

--- a/Objects/src/Event.cc
+++ b/Objects/src/Event.cc
@@ -202,10 +202,10 @@ panda::Event::dump(std::ostream& _out/* = std::cout*/) const
 {
   EventBase::dump(_out);
 
-  _out << "npv" << npv << std::endl;
-  _out << "npvTrue" << npvTrue << std::endl;
-  _out << "rho" << rho << std::endl;
-  _out << "rhoCentralCalo" << rhoCentralCalo << std::endl;
+  _out << "npv = " << npv << std::endl;
+  _out << "npvTrue = " << npvTrue << std::endl;
+  _out << "rho = " << rho << std::endl;
+  _out << "rhoCentralCalo = " << rhoCentralCalo << std::endl;
 
   genReweight.dump(_out);
   pfCandidates.dump(_out);

--- a/Objects/src/Event.cc
+++ b/Objects/src/Event.cc
@@ -188,6 +188,64 @@ panda::Event::operator=(Event const& _src)
   return *this;
 }
 
+
+void
+panda::Event::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
+{
+  /* BEGIN CUSTOM Event.cc.print */
+  dump(_out);
+  /* END CUSTOM */
+}
+
+void
+panda::Event::dump(std::ostream& _out/* = std::cout*/) const
+{
+  EventBase::dump(_out);
+
+  _out << "npv" << npv << std::endl;
+  _out << "npvTrue" << npvTrue << std::endl;
+  _out << "rho" << rho << std::endl;
+  _out << "rhoCentralCalo" << rhoCentralCalo << std::endl;
+
+  genReweight.dump(_out);
+  pfCandidates.dump(_out);
+  superClusters.dump(_out);
+  electrons.dump(_out);
+  muons.dump(_out);
+  taus.dump(_out);
+  photons.dump(_out);
+  chsAK4Jets.dump(_out);
+  puppiAK4Jets.dump(_out);
+  chsAK8Jets.dump(_out);
+  chsAK8Subjets.dump(_out);
+  chsCA15Jets.dump(_out);
+  chsCA15Subjets.dump(_out);
+  puppiAK8Jets.dump(_out);
+  puppiAK8Subjets.dump(_out);
+  puppiCA15Jets.dump(_out);
+  puppiCA15Subjets.dump(_out);
+  ak4GenJets.dump(_out);
+  ak8GenJets.dump(_out);
+  ca15GenJets.dump(_out);
+  genParticles.dump(_out);
+  partons.dump(_out);
+  pfMet.dump(_out);
+  puppiMet.dump(_out);
+  rawMet.dump(_out);
+  caloMet.dump(_out);
+  noMuMet.dump(_out);
+  noHFMet.dump(_out);
+  trkMet.dump(_out);
+  neutralMet.dump(_out);
+  photonMet.dump(_out);
+  hfMet.dump(_out);
+  genMet.dump(_out);
+  metMuOnlyFix.dump(_out);
+  metNoFix.dump(_out);
+  metFilters.dump(_out);
+  recoil.dump(_out);
+
+}
 /*static*/
 panda::utils::BranchList
 panda::Event::getListOfBranches()

--- a/Objects/src/EventBase.cc
+++ b/Objects/src/EventBase.cc
@@ -43,6 +43,27 @@ panda::EventBase::operator=(EventBase const& _src)
   return *this;
 }
 
+
+void
+panda::EventBase::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
+{
+  /* BEGIN CUSTOM EventBase.cc.print */
+  dump(_out);
+  /* END CUSTOM */
+}
+
+void
+panda::EventBase::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "runNumber" << runNumber << std::endl;
+  _out << "lumiNumber" << lumiNumber << std::endl;
+  _out << "eventNumber" << eventNumber << std::endl;
+  _out << "isData" << isData << std::endl;
+  _out << "weight" << weight << std::endl;
+
+  triggers.dump(_out);
+
+}
 /*static*/
 panda::utils::BranchList
 panda::EventBase::getListOfBranches()
@@ -112,7 +133,6 @@ void
 panda::EventBase::doGetEntry_(TTree& _tree, Long64_t _entry)
 {
   /* BEGIN CUSTOM EventBase.cc.doGetEntry_ */
-  run.update(runNumber, _tree);
   /* END CUSTOM */
 }
 
@@ -130,15 +150,4 @@ panda::EventBase::doInit_()
 
 
 /* BEGIN CUSTOM EventBase.cc.global */
-
-Bool_t
-panda::EventBase::triggerFired(UInt_t _token) const
-{
-  UInt_t idx(run.getTriggerIndex(_token));
-  if (idx < run.triggerSize())
-    return triggers.pass(idx);
-  else
-    return false;
-}
-
 /* END CUSTOM */

--- a/Objects/src/EventBase.cc
+++ b/Objects/src/EventBase.cc
@@ -55,11 +55,11 @@ panda::EventBase::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*
 void
 panda::EventBase::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "runNumber" << runNumber << std::endl;
-  _out << "lumiNumber" << lumiNumber << std::endl;
-  _out << "eventNumber" << eventNumber << std::endl;
-  _out << "isData" << isData << std::endl;
-  _out << "weight" << weight << std::endl;
+  _out << "runNumber = " << runNumber << std::endl;
+  _out << "lumiNumber = " << lumiNumber << std::endl;
+  _out << "eventNumber = " << eventNumber << std::endl;
+  _out << "isData = " << isData << std::endl;
+  _out << "weight = " << weight << std::endl;
 
   triggers.dump(_out);
 
@@ -133,6 +133,7 @@ void
 panda::EventBase::doGetEntry_(TTree& _tree, Long64_t _entry)
 {
   /* BEGIN CUSTOM EventBase.cc.doGetEntry_ */
+  run.update(runNumber, _tree);
   /* END CUSTOM */
 }
 
@@ -150,4 +151,13 @@ panda::EventBase::doInit_()
 
 
 /* BEGIN CUSTOM EventBase.cc.global */
+Bool_t
+panda::EventBase::triggerFired(UInt_t _token) const
+{
+  UInt_t idx(run.getTriggerIndex(_token));
+  if (idx < run.triggerSize())
+    return triggers.pass(idx);
+  else
+    return false;
+}
 /* END CUSTOM */

--- a/Objects/src/EventBase.cc
+++ b/Objects/src/EventBase.cc
@@ -48,7 +48,19 @@ void
 panda::EventBase::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM EventBase.cc.print */
-  dump(_out);
+  if (_level > 2) {
+    dump(_out);
+  }
+  else if (_level > 1) {
+    // debug level
+    _out << "runNumber = " << runNumber << std::endl;
+    _out << "lumiNumber = " << lumiNumber << std::endl;
+    _out << "eventNumber = " << eventNumber << std::endl;
+    _out << "isData = " << isData << std::endl;
+    _out << "weight = " << weight << std::endl;
+  }
+  else
+    return;
   /* END CUSTOM */
 }
 

--- a/Objects/src/EventBase.cc
+++ b/Objects/src/EventBase.cc
@@ -48,10 +48,10 @@ void
 panda::EventBase::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM EventBase.cc.print */
-  if (_level > 2) {
-    dump(_out);
+  if (_level >= 3) {
+    EventBase::dump(_out);
   }
-  else if (_level > 1) {
+  else if (_level == 2) {
     // debug level
     _out << "runNumber = " << runNumber << std::endl;
     _out << "lumiNumber = " << lumiNumber << std::endl;

--- a/Objects/src/EventMonophoton.cc
+++ b/Objects/src/EventMonophoton.cc
@@ -106,7 +106,21 @@ void
 panda::EventMonophoton::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM EventMonophoton.cc.print */
-  dump(_out);
+  if (_level > 2) {
+    _out << "why am I here?" << std::endl;
+    dump(_out);
+  }
+  else if (_level > 1) {
+    // debug level
+    EventBase::print(_out, _level);
+
+    _out << "npv = " << npv << std::endl;
+    _out << "npvTrue = " << npvTrue << std::endl;
+    _out << "rho = " << rho << std::endl;
+    _out << "rhoCentralCalo = " << rhoCentralCalo << std::endl;
+  }
+  else 
+    return;
   /* END CUSTOM */
 }
 

--- a/Objects/src/EventMonophoton.cc
+++ b/Objects/src/EventMonophoton.cc
@@ -115,10 +115,10 @@ panda::EventMonophoton::dump(std::ostream& _out/* = std::cout*/) const
 {
   EventBase::dump(_out);
 
-  _out << "npv" << npv << std::endl;
-  _out << "npvTrue" << npvTrue << std::endl;
-  _out << "rho" << rho << std::endl;
-  _out << "rhoCentralCalo" << rhoCentralCalo << std::endl;
+  _out << "npv = " << npv << std::endl;
+  _out << "npvTrue = " << npvTrue << std::endl;
+  _out << "rho = " << rho << std::endl;
+  _out << "rhoCentralCalo = " << rhoCentralCalo << std::endl;
 
   genReweight.dump(_out);
   superClusters.dump(_out);

--- a/Objects/src/EventMonophoton.cc
+++ b/Objects/src/EventMonophoton.cc
@@ -101,6 +101,43 @@ panda::EventMonophoton::operator=(EventMonophoton const& _src)
   return *this;
 }
 
+
+void
+panda::EventMonophoton::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
+{
+  /* BEGIN CUSTOM EventMonophoton.cc.print */
+  dump(_out);
+  /* END CUSTOM */
+}
+
+void
+panda::EventMonophoton::dump(std::ostream& _out/* = std::cout*/) const
+{
+  EventBase::dump(_out);
+
+  _out << "npv" << npv << std::endl;
+  _out << "npvTrue" << npvTrue << std::endl;
+  _out << "rho" << rho << std::endl;
+  _out << "rhoCentralCalo" << rhoCentralCalo << std::endl;
+
+  genReweight.dump(_out);
+  superClusters.dump(_out);
+  electrons.dump(_out);
+  muons.dump(_out);
+  taus.dump(_out);
+  photons.dump(_out);
+  jets.dump(_out);
+  genJets.dump(_out);
+  genParticles.dump(_out);
+  partons.dump(_out);
+  t1Met.dump(_out);
+  rawMet.dump(_out);
+  caloMet.dump(_out);
+  metMuOnlyFix.dump(_out);
+  metNoFix.dump(_out);
+  metFilters.dump(_out);
+
+}
 /*static*/
 panda::utils::BranchList
 panda::EventMonophoton::getListOfBranches()

--- a/Objects/src/EventMonophoton.cc
+++ b/Objects/src/EventMonophoton.cc
@@ -106,11 +106,10 @@ void
 panda::EventMonophoton::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM EventMonophoton.cc.print */
-  if (_level > 2) {
-    _out << "why am I here?" << std::endl;
-    dump(_out);
+  if (_level >= 3) {
+    EventMonophoton::dump(_out);
   }
-  else if (_level > 1) {
+  else if (_level == 2) {
     // debug level
     EventBase::print(_out, _level);
 

--- a/Objects/src/EventTPPhoton.cc
+++ b/Objects/src/EventTPPhoton.cc
@@ -1,0 +1,217 @@
+#include "../interface/EventTPPhoton.h"
+
+panda::EventTPPhoton::EventTPPhoton() :
+  EventBase()
+{
+  std::vector<Object*> myObjects{{&tp, &tags, &looseTags, &probes, &jets, &t1Met}};
+  objects_.insert(objects_.end(), myObjects.begin(), myObjects.end());
+  std::vector<CollectionBase*> myCollections{{&tp, &tags, &looseTags, &probes, &jets}};
+  collections_.insert(collections_.end(), myCollections.begin(), myCollections.end());
+}
+
+panda::EventTPPhoton::EventTPPhoton(EventTPPhoton const& _src) :
+  EventBase(_src),
+  tp(_src.tp),
+  tags(_src.tags),
+  looseTags(_src.looseTags),
+  probes(_src.probes),
+  jets(_src.jets),
+  t1Met(_src.t1Met),
+  npv(_src.npv),
+  npvTrue(_src.npvTrue),
+  rho(_src.rho),
+  sample(_src.sample)
+{
+  std::vector<Object*> myObjects{{&tp, &tags, &looseTags, &probes, &jets, &t1Met}};
+  objects_.insert(objects_.end(), myObjects.begin(), myObjects.end());
+  std::vector<CollectionBase*> myCollections{{&tp, &tags, &looseTags, &probes, &jets}};
+  collections_.insert(collections_.end(), myCollections.begin(), myCollections.end());
+
+  /* BEGIN CUSTOM EventTPPhoton.cc.copy_ctor */
+  /* END CUSTOM */
+}
+
+panda::EventTPPhoton&
+panda::EventTPPhoton::operator=(EventTPPhoton const& _src)
+{
+  EventBase::operator=(_src);
+
+  /* BEGIN CUSTOM EventTPPhoton.cc.operator= */
+  /* END CUSTOM */
+
+  npv = _src.npv;
+  npvTrue = _src.npvTrue;
+  rho = _src.rho;
+  sample = _src.sample;
+
+  tp = _src.tp;
+  tags = _src.tags;
+  looseTags = _src.looseTags;
+  probes = _src.probes;
+  jets = _src.jets;
+  t1Met = _src.t1Met;
+
+  return *this;
+}
+
+
+void
+panda::EventTPPhoton::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
+{
+  /* BEGIN CUSTOM EventTPPhoton.cc.print */
+  dump(_out);
+  /* END CUSTOM */
+}
+
+void
+panda::EventTPPhoton::dump(std::ostream& _out/* = std::cout*/) const
+{
+  EventBase::dump(_out);
+
+  _out << "npv" << npv << std::endl;
+  _out << "npvTrue" << npvTrue << std::endl;
+  _out << "rho" << rho << std::endl;
+  _out << "sample" << sample << std::endl;
+
+  tp.dump(_out);
+  tags.dump(_out);
+  looseTags.dump(_out);
+  probes.dump(_out);
+  jets.dump(_out);
+  t1Met.dump(_out);
+
+}
+/*static*/
+panda::utils::BranchList
+panda::EventTPPhoton::getListOfBranches()
+{
+  utils::BranchList blist;
+  blist += EventBase::getListOfBranches();
+
+  blist += {"npv", "npvTrue", "rho", "sample"};
+  blist += TPPair::getListOfBranches().fullNames("tp");
+  blist += Lepton::getListOfBranches().fullNames("tags");
+  blist += Lepton::getListOfBranches().fullNames("looseTags");
+  blist += XPhoton::getListOfBranches().fullNames("probes");
+  blist += Jet::getListOfBranches().fullNames("jets");
+  blist += RecoMet::getListOfBranches().fullNames("t1Met");
+  return blist;
+}
+
+/*protected*/
+void
+panda::EventTPPhoton::doSetStatus_(TTree& _tree, utils::BranchList const& _branches)
+{
+  EventBase::doSetStatus_(_tree, _branches);
+  utils::setStatus(_tree, "", "npv", _branches);
+  utils::setStatus(_tree, "", "npvTrue", _branches);
+  utils::setStatus(_tree, "", "rho", _branches);
+  utils::setStatus(_tree, "", "sample", _branches);
+}
+
+/*protected*/
+panda::utils::BranchList
+panda::EventTPPhoton::doGetStatus_(TTree& _tree) const
+{
+  utils::BranchList blist;
+  blist += EventBase::doGetStatus_(_tree);
+
+  blist.push_back(utils::getStatus(_tree, "", "npv"));
+  blist.push_back(utils::getStatus(_tree, "", "npvTrue"));
+  blist.push_back(utils::getStatus(_tree, "", "rho"));
+  blist.push_back(utils::getStatus(_tree, "", "sample"));
+  return blist;
+}
+
+/*protected*/
+panda::utils::BranchList
+panda::EventTPPhoton::doGetBranchNames_() const
+{
+  return getListOfBranches();
+}
+
+/*protected*/
+void
+panda::EventTPPhoton::doSetAddress_(TTree& _tree, utils::BranchList const& _branches, Bool_t _setStatus)
+{
+  EventBase::doSetAddress_(_tree, _branches, _setStatus);
+
+  utils::setAddress(_tree, "", "npv", &npv, _branches, _setStatus);
+  utils::setAddress(_tree, "", "npvTrue", &npvTrue, _branches, _setStatus);
+  utils::setAddress(_tree, "", "rho", &rho, _branches, _setStatus);
+  utils::setAddress(_tree, "", "sample", &sample, _branches, _setStatus);
+}
+
+/*protected*/
+void
+panda::EventTPPhoton::doBook_(TTree& _tree, utils::BranchList const& _branches)
+{
+  EventBase::doBook_(_tree, _branches);
+
+  utils::book(_tree, "", "npv", "", 's', &npv, _branches);
+  utils::book(_tree, "", "npvTrue", "", 's', &npvTrue, _branches);
+  utils::book(_tree, "", "rho", "", 'F', &rho, _branches);
+  utils::book(_tree, "", "sample", "", 'i', &sample, _branches);
+}
+
+/*protected*/
+void
+panda::EventTPPhoton::doGetEntry_(TTree& _tree, Long64_t _entry)
+{
+  EventBase::doGetEntry_(_tree, _entry);
+
+  /* BEGIN CUSTOM EventTPPhoton.cc.doGetEntry_ */
+  /* END CUSTOM */
+}
+
+void
+panda::EventTPPhoton::doInit_()
+{
+  EventBase::doInit_();
+
+  npv = 0;
+  npvTrue = 0;
+  rho = 0.;
+  sample = 0;
+  /* BEGIN CUSTOM EventTPPhoton.cc.doInit_ */
+  /* END CUSTOM */
+}
+
+
+/* BEGIN CUSTOM EventTPPhoton.cc.global */
+panda::EventTPPhoton&
+panda::EventTPPhoton::operator=(Event const& _src)
+{
+  EventBase::operator=(_src);
+
+  npv = _src.npv;
+  npvTrue = _src.npvTrue;
+  rho = _src.rho;
+
+  jets = _src.chsAK4Jets;
+  t1Met = _src.pfMet;
+
+  jets.data.matchedGenJetContainer_ = 0;
+  jets.data.constituentsContainer_ = 0;
+
+  return *this;
+}
+
+panda::EventTPPhoton&
+panda::EventTPPhoton::operator=(EventMonophoton const& _src)
+{
+  EventBase::operator=(_src);
+
+  npv = _src.npv;
+  npvTrue = _src.npvTrue;
+  rho = _src.rho;
+
+  jets = _src.jets;
+  t1Met = _src.t1Met;
+
+  jets.data.matchedGenJetContainer_ = 0;
+  jets.data.constituentsContainer_ = 0;
+
+  return *this;
+}
+/* END CUSTOM */

--- a/Objects/src/EventTPPhoton.cc
+++ b/Objects/src/EventTPPhoton.cc
@@ -68,10 +68,10 @@ panda::EventTPPhoton::dump(std::ostream& _out/* = std::cout*/) const
 {
   EventBase::dump(_out);
 
-  _out << "npv" << npv << std::endl;
-  _out << "npvTrue" << npvTrue << std::endl;
-  _out << "rho" << rho << std::endl;
-  _out << "sample" << sample << std::endl;
+  _out << "npv = " << npv << std::endl;
+  _out << "npvTrue = " << npvTrue << std::endl;
+  _out << "rho = " << rho << std::endl;
+  _out << "sample = " << sample << std::endl;
 
   tp.dump(_out);
   tags.dump(_out);

--- a/Objects/src/FatJet.cc
+++ b/Objects/src/FatJet.cc
@@ -353,10 +353,30 @@ panda::FatJet::doInit_()
 }
 
 void
-panda::FatJet::print(std::ostream& _out/* = std::cout*/) const
+panda::FatJet::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM FatJet.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::FatJet::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  Jet::dump(_out);
+
+  _out << "tau1" << tau1 << std::endl;
+  _out << "tau2" << tau2 << std::endl;
+  _out << "tau3" << tau3 << std::endl;
+  _out << "mSD" << mSD << std::endl;
+  _out << "tau1SD" << tau1SD << std::endl;
+  _out << "tau2SD" << tau2SD << std::endl;
+  _out << "tau3SD" << tau3SD << std::endl;
+  _out << "htt_mass" << htt_mass << std::endl;
+  _out << "htt_frec" << htt_frec << std::endl;
+  _out << "double_sub" << double_sub << std::endl;
+  _out << "ecfs" << ecfs << std::endl;
+  _out << "subjets" << subjets << std::endl;
 }
 
 double

--- a/Objects/src/FatJet.cc
+++ b/Objects/src/FatJet.cc
@@ -363,7 +363,6 @@ panda::FatJet::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) 
 void
 panda::FatJet::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   Jet::dump(_out);
 
   _out << "tau1 = " << tau1 << std::endl;

--- a/Objects/src/FatJet.cc
+++ b/Objects/src/FatJet.cc
@@ -356,6 +356,7 @@ void
 panda::FatJet::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM FatJet.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -365,18 +366,18 @@ panda::FatJet::dump(std::ostream& _out/* = std::cout*/) const
   _out << "<" << typeName() << ">" << std::endl;
   Jet::dump(_out);
 
-  _out << "tau1" << tau1 << std::endl;
-  _out << "tau2" << tau2 << std::endl;
-  _out << "tau3" << tau3 << std::endl;
-  _out << "mSD" << mSD << std::endl;
-  _out << "tau1SD" << tau1SD << std::endl;
-  _out << "tau2SD" << tau2SD << std::endl;
-  _out << "tau3SD" << tau3SD << std::endl;
-  _out << "htt_mass" << htt_mass << std::endl;
-  _out << "htt_frec" << htt_frec << std::endl;
-  _out << "double_sub" << double_sub << std::endl;
-  _out << "ecfs" << ecfs << std::endl;
-  _out << "subjets" << subjets << std::endl;
+  _out << "tau1 = " << tau1 << std::endl;
+  _out << "tau2 = " << tau2 << std::endl;
+  _out << "tau3 = " << tau3 << std::endl;
+  _out << "mSD = " << mSD << std::endl;
+  _out << "tau1SD = " << tau1SD << std::endl;
+  _out << "tau2SD = " << tau2SD << std::endl;
+  _out << "tau3SD = " << tau3SD << std::endl;
+  _out << "htt_mass = " << htt_mass << std::endl;
+  _out << "htt_frec = " << htt_frec << std::endl;
+  _out << "double_sub = " << double_sub << std::endl;
+  _out << "ecfs = " << ecfs << std::endl;
+  _out << "subjets = " << subjets << std::endl;
 }
 
 double

--- a/Objects/src/GenJet.cc
+++ b/Objects/src/GenJet.cc
@@ -165,10 +165,19 @@ panda::GenJet::doInit_()
 }
 
 void
-panda::GenJet::print(std::ostream& _out/* = std::cout*/) const
+panda::GenJet::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM GenJet.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::GenJet::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  ParticleM::dump(_out);
+
+  _out << "pdgid" << pdgid << std::endl;
 }
 
 /* BEGIN CUSTOM GenJet.cc.global */

--- a/Objects/src/GenJet.cc
+++ b/Objects/src/GenJet.cc
@@ -175,7 +175,6 @@ panda::GenJet::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) 
 void
 panda::GenJet::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   ParticleM::dump(_out);
 
   _out << "pdgid = " << pdgid << std::endl;

--- a/Objects/src/GenJet.cc
+++ b/Objects/src/GenJet.cc
@@ -168,6 +168,7 @@ void
 panda::GenJet::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM GenJet.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -177,7 +178,7 @@ panda::GenJet::dump(std::ostream& _out/* = std::cout*/) const
   _out << "<" << typeName() << ">" << std::endl;
   ParticleM::dump(_out);
 
-  _out << "pdgid" << pdgid << std::endl;
+  _out << "pdgid = " << pdgid << std::endl;
 }
 
 /* BEGIN CUSTOM GenJet.cc.global */

--- a/Objects/src/GenParticle.cc
+++ b/Objects/src/GenParticle.cc
@@ -216,9 +216,9 @@ panda::GenParticle::dump(std::ostream& _out/* = std::cout*/) const
   _out << "<" << typeName() << ">" << std::endl;
   PackedParticle::dump(_out);
 
-  _out << "pdgid" << pdgid << std::endl;
-  _out << "statusFlags" << statusFlags << std::endl;
-  _out << "parent" << parent << std::endl;
+  _out << "pdgid = " << pdgid << std::endl;
+  _out << "statusFlags = " << statusFlags << std::endl;
+  _out << "parent = " << parent << std::endl;
 }
 
 /* BEGIN CUSTOM GenParticle.cc.global */

--- a/Objects/src/GenParticle.cc
+++ b/Objects/src/GenParticle.cc
@@ -213,7 +213,6 @@ panda::GenParticle::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 
 void
 panda::GenParticle::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   PackedParticle::dump(_out);
 
   _out << "pdgid = " << pdgid << std::endl;

--- a/Objects/src/GenParticle.cc
+++ b/Objects/src/GenParticle.cc
@@ -199,7 +199,7 @@ panda::GenParticle::doInit_()
 }
 
 void
-panda::GenParticle::print(std::ostream& _out/* = std::cout*/) const
+panda::GenParticle::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM GenParticle.cc.print */
   _out << "GenParticle " << pdgid << " (" << pt() << ", " << eta() << ", " << phi() << ") "
@@ -208,6 +208,17 @@ panda::GenParticle::print(std::ostream& _out/* = std::cout*/) const
     _out << ((statusFlags >> i) & 1);
   _out << std::endl;
   /* END CUSTOM */
+}
+
+void
+panda::GenParticle::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  PackedParticle::dump(_out);
+
+  _out << "pdgid" << pdgid << std::endl;
+  _out << "statusFlags" << statusFlags << std::endl;
+  _out << "parent" << parent << std::endl;
 }
 
 /* BEGIN CUSTOM GenParticle.cc.global */

--- a/Objects/src/GenReweight.cc
+++ b/Objects/src/GenReweight.cc
@@ -135,10 +135,24 @@ panda::GenReweight::doGetBranchNames_(Bool_t _fullName) const
 }
 
 void
-panda::GenReweight::print(std::ostream& _out/* = std::cout*/) const
+panda::GenReweight::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM GenReweight.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::GenReweight::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  _out << "r1f2DW" << r1f2DW << std::endl;
+  _out << "r1f5DW" << r1f5DW << std::endl;
+  _out << "r2f1DW" << r2f1DW << std::endl;
+  _out << "r2f2DW" << r2f2DW << std::endl;
+  _out << "r5f1DW" << r5f1DW << std::endl;
+  _out << "r5f5DW" << r5f5DW << std::endl;
+  _out << "pdfDW" << pdfDW << std::endl;
+  _out << "genParam" << genParam << std::endl;
 }
 
 /* BEGIN CUSTOM GenReweight.cc.global */

--- a/Objects/src/GenReweight.cc
+++ b/Objects/src/GenReweight.cc
@@ -145,7 +145,6 @@ panda::GenReweight::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 
 void
 panda::GenReweight::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   _out << "r1f2DW = " << r1f2DW << std::endl;
   _out << "r1f5DW = " << r1f5DW << std::endl;
   _out << "r2f1DW = " << r2f1DW << std::endl;

--- a/Objects/src/GenReweight.cc
+++ b/Objects/src/GenReweight.cc
@@ -138,6 +138,7 @@ void
 panda::GenReweight::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM GenReweight.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -145,14 +146,14 @@ void
 panda::GenReweight::dump(std::ostream& _out/* = std::cout*/) const
 {
   _out << "<" << typeName() << ">" << std::endl;
-  _out << "r1f2DW" << r1f2DW << std::endl;
-  _out << "r1f5DW" << r1f5DW << std::endl;
-  _out << "r2f1DW" << r2f1DW << std::endl;
-  _out << "r2f2DW" << r2f2DW << std::endl;
-  _out << "r5f1DW" << r5f1DW << std::endl;
-  _out << "r5f5DW" << r5f5DW << std::endl;
-  _out << "pdfDW" << pdfDW << std::endl;
-  _out << "genParam" << genParam << std::endl;
+  _out << "r1f2DW = " << r1f2DW << std::endl;
+  _out << "r1f5DW = " << r1f5DW << std::endl;
+  _out << "r2f1DW = " << r2f1DW << std::endl;
+  _out << "r2f2DW = " << r2f2DW << std::endl;
+  _out << "r5f1DW = " << r5f1DW << std::endl;
+  _out << "r5f5DW = " << r5f5DW << std::endl;
+  _out << "pdfDW = " << pdfDW << std::endl;
+  _out << "genParam = " << genParam << std::endl;
 }
 
 /* BEGIN CUSTOM GenReweight.cc.global */

--- a/Objects/src/HLTBits.cc
+++ b/Objects/src/HLTBits.cc
@@ -89,7 +89,6 @@ panda::HLTBits::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/)
 void
 panda::HLTBits::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   _out << "words = " << words << std::endl;
 }
 

--- a/Objects/src/HLTBits.cc
+++ b/Objects/src/HLTBits.cc
@@ -82,6 +82,7 @@ void
 panda::HLTBits::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM HLTBits.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -89,7 +90,7 @@ void
 panda::HLTBits::dump(std::ostream& _out/* = std::cout*/) const
 {
   _out << "<" << typeName() << ">" << std::endl;
-  _out << "words" << words << std::endl;
+  _out << "words = " << words << std::endl;
 }
 
 

--- a/Objects/src/HLTBits.cc
+++ b/Objects/src/HLTBits.cc
@@ -79,10 +79,17 @@ panda::HLTBits::doGetBranchNames_(Bool_t _fullName) const
 }
 
 void
-panda::HLTBits::print(std::ostream& _out/* = std::cout*/) const
+panda::HLTBits::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM HLTBits.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::HLTBits::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  _out << "words" << words << std::endl;
 }
 
 

--- a/Objects/src/Jet.cc
+++ b/Objects/src/Jet.cc
@@ -414,7 +414,6 @@ panda::Jet::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) con
 void
 panda::Jet::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   MicroJet::dump(_out);
 
   _out << "rawPt = " << rawPt << std::endl;

--- a/Objects/src/Jet.cc
+++ b/Objects/src/Jet.cc
@@ -407,7 +407,23 @@ void
 panda::Jet::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Jet.cc.print */
-  dump(_out);
+  if (_level >= 3) {
+    Jet::dump(_out);
+  }
+  else if (_level == 2) {
+    MicroJet::print(_out, _level);
+
+    _out << "rawPt = " << rawPt << std::endl;
+    _out << "area = " << area << std::endl;
+    _out << "nhf = " << nhf << std::endl;
+    _out << "chf = " << chf << std::endl;
+    _out << "puid = " << puid << std::endl;
+    _out << "loose = " << loose << std::endl;
+    _out << "tight = " << tight << std::endl;
+    _out << "monojet = " << monojet << std::endl;
+  }
+  else
+    return;
   /* END CUSTOM */
 }
 

--- a/Objects/src/Jet.cc
+++ b/Objects/src/Jet.cc
@@ -407,6 +407,7 @@ void
 panda::Jet::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Jet.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -416,21 +417,21 @@ panda::Jet::dump(std::ostream& _out/* = std::cout*/) const
   _out << "<" << typeName() << ">" << std::endl;
   MicroJet::dump(_out);
 
-  _out << "rawPt" << rawPt << std::endl;
-  _out << "ptCorrUp" << ptCorrUp << std::endl;
-  _out << "ptCorrDown" << ptCorrDown << std::endl;
-  _out << "ptSmear" << ptSmear << std::endl;
-  _out << "ptSmearUp" << ptSmearUp << std::endl;
-  _out << "ptSmearDown" << ptSmearDown << std::endl;
-  _out << "area" << area << std::endl;
-  _out << "nhf" << nhf << std::endl;
-  _out << "chf" << chf << std::endl;
-  _out << "puid" << puid << std::endl;
-  _out << "loose" << loose << std::endl;
-  _out << "tight" << tight << std::endl;
-  _out << "monojet" << monojet << std::endl;
-  _out << "matchedGenJet" << matchedGenJet << std::endl;
-  _out << "constituents" << constituents << std::endl;
+  _out << "rawPt = " << rawPt << std::endl;
+  _out << "ptCorrUp = " << ptCorrUp << std::endl;
+  _out << "ptCorrDown = " << ptCorrDown << std::endl;
+  _out << "ptSmear = " << ptSmear << std::endl;
+  _out << "ptSmearUp = " << ptSmearUp << std::endl;
+  _out << "ptSmearDown = " << ptSmearDown << std::endl;
+  _out << "area = " << area << std::endl;
+  _out << "nhf = " << nhf << std::endl;
+  _out << "chf = " << chf << std::endl;
+  _out << "puid = " << puid << std::endl;
+  _out << "loose = " << loose << std::endl;
+  _out << "tight = " << tight << std::endl;
+  _out << "monojet = " << monojet << std::endl;
+  _out << "matchedGenJet = " << matchedGenJet << std::endl;
+  _out << "constituents = " << constituents << std::endl;
 }
 
 /* BEGIN CUSTOM Jet.cc.global */

--- a/Objects/src/Jet.cc
+++ b/Objects/src/Jet.cc
@@ -404,10 +404,33 @@ panda::Jet::doInit_()
 }
 
 void
-panda::Jet::print(std::ostream& _out/* = std::cout*/) const
+panda::Jet::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Jet.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::Jet::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  MicroJet::dump(_out);
+
+  _out << "rawPt" << rawPt << std::endl;
+  _out << "ptCorrUp" << ptCorrUp << std::endl;
+  _out << "ptCorrDown" << ptCorrDown << std::endl;
+  _out << "ptSmear" << ptSmear << std::endl;
+  _out << "ptSmearUp" << ptSmearUp << std::endl;
+  _out << "ptSmearDown" << ptSmearDown << std::endl;
+  _out << "area" << area << std::endl;
+  _out << "nhf" << nhf << std::endl;
+  _out << "chf" << chf << std::endl;
+  _out << "puid" << puid << std::endl;
+  _out << "loose" << loose << std::endl;
+  _out << "tight" << tight << std::endl;
+  _out << "monojet" << monojet << std::endl;
+  _out << "matchedGenJet" << matchedGenJet << std::endl;
+  _out << "constituents" << constituents << std::endl;
 }
 
 /* BEGIN CUSTOM Jet.cc.global */

--- a/Objects/src/Lepton.cc
+++ b/Objects/src/Lepton.cc
@@ -321,7 +321,20 @@ void
 panda::Lepton::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Lepton.cc.print */
-  dump(_out);
+  if (_level >= 3) {
+    Lepton::dump(_out);
+  }
+  else if (_level == 2) {
+    ParticleP::print(_out, _level);
+
+    _out << "pfPt = " << pfPt << std::endl;
+    _out << "charge = " << charge << std::endl;
+    _out << "loose = " << loose << std::endl;
+    _out << "medium = " << medium << std::endl;
+    _out << "tight = " << tight << std::endl;
+  }
+  else
+    return;
   /* END CUSTOM */
 }
 

--- a/Objects/src/Lepton.cc
+++ b/Objects/src/Lepton.cc
@@ -321,6 +321,7 @@ void
 panda::Lepton::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Lepton.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -330,16 +331,16 @@ panda::Lepton::dump(std::ostream& _out/* = std::cout*/) const
   _out << "<" << typeName() << ">" << std::endl;
   ParticleP::dump(_out);
 
-  _out << "pfPt" << pfPt << std::endl;
-  _out << "charge" << charge << std::endl;
-  _out << "loose" << loose << std::endl;
-  _out << "medium" << medium << std::endl;
-  _out << "tight" << tight << std::endl;
-  _out << "chIso" << chIso << std::endl;
-  _out << "nhIso" << nhIso << std::endl;
-  _out << "phIso" << phIso << std::endl;
-  _out << "puIso" << puIso << std::endl;
-  _out << "matchedGen" << matchedGen << std::endl;
+  _out << "pfPt = " << pfPt << std::endl;
+  _out << "charge = " << charge << std::endl;
+  _out << "loose = " << loose << std::endl;
+  _out << "medium = " << medium << std::endl;
+  _out << "tight = " << tight << std::endl;
+  _out << "chIso = " << chIso << std::endl;
+  _out << "nhIso = " << nhIso << std::endl;
+  _out << "phIso = " << phIso << std::endl;
+  _out << "puIso = " << puIso << std::endl;
+  _out << "matchedGen = " << matchedGen << std::endl;
 }
 
 

--- a/Objects/src/Lepton.cc
+++ b/Objects/src/Lepton.cc
@@ -318,10 +318,28 @@ panda::Lepton::doInit_()
 }
 
 void
-panda::Lepton::print(std::ostream& _out/* = std::cout*/) const
+panda::Lepton::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Lepton.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::Lepton::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  ParticleP::dump(_out);
+
+  _out << "pfPt" << pfPt << std::endl;
+  _out << "charge" << charge << std::endl;
+  _out << "loose" << loose << std::endl;
+  _out << "medium" << medium << std::endl;
+  _out << "tight" << tight << std::endl;
+  _out << "chIso" << chIso << std::endl;
+  _out << "nhIso" << nhIso << std::endl;
+  _out << "phIso" << phIso << std::endl;
+  _out << "puIso" << puIso << std::endl;
+  _out << "matchedGen" << matchedGen << std::endl;
 }
 
 

--- a/Objects/src/Lepton.cc
+++ b/Objects/src/Lepton.cc
@@ -328,7 +328,6 @@ panda::Lepton::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) 
 void
 panda::Lepton::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   ParticleP::dump(_out);
 
   _out << "pfPt = " << pfPt << std::endl;

--- a/Objects/src/Met.cc
+++ b/Objects/src/Met.cc
@@ -88,10 +88,18 @@ panda::Met::doGetBranchNames_(Bool_t _fullName) const
 }
 
 void
-panda::Met::print(std::ostream& _out/* = std::cout*/) const
+panda::Met::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Met.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::Met::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  _out << "pt" << pt << std::endl;
+  _out << "phi" << phi << std::endl;
 }
 
 

--- a/Objects/src/Met.cc
+++ b/Objects/src/Met.cc
@@ -91,6 +91,7 @@ void
 panda::Met::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Met.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -98,8 +99,8 @@ void
 panda::Met::dump(std::ostream& _out/* = std::cout*/) const
 {
   _out << "<" << typeName() << ">" << std::endl;
-  _out << "pt" << pt << std::endl;
-  _out << "phi" << phi << std::endl;
+  _out << "pt = " << pt << std::endl;
+  _out << "phi = " << phi << std::endl;
 }
 
 

--- a/Objects/src/Met.cc
+++ b/Objects/src/Met.cc
@@ -98,7 +98,6 @@ panda::Met::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) con
 void
 panda::Met::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   _out << "pt = " << pt << std::endl;
   _out << "phi = " << phi << std::endl;
 }

--- a/Objects/src/Met.cc
+++ b/Objects/src/Met.cc
@@ -91,7 +91,8 @@ void
 panda::Met::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Met.cc.print */
-  dump(_out);
+  _out << getName() << std::endl;
+  Met::dump(_out);
   /* END CUSTOM */
 }
 

--- a/Objects/src/MetFilters.cc
+++ b/Objects/src/MetFilters.cc
@@ -144,10 +144,25 @@ panda::MetFilters::doGetBranchNames_(Bool_t _fullName) const
 }
 
 void
-panda::MetFilters::print(std::ostream& _out/* = std::cout*/) const
+panda::MetFilters::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM MetFilters.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::MetFilters::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  _out << "globalHalo16" << globalHalo16 << std::endl;
+  _out << "hbhe" << hbhe << std::endl;
+  _out << "hbheIso" << hbheIso << std::endl;
+  _out << "ecalDeadCell" << ecalDeadCell << std::endl;
+  _out << "badsc" << badsc << std::endl;
+  _out << "badMuons" << badMuons << std::endl;
+  _out << "duplicateMuons" << duplicateMuons << std::endl;
+  _out << "dupECALClusters" << dupECALClusters << std::endl;
+  _out << "unfixedECALHits" << unfixedECALHits << std::endl;
 }
 
 

--- a/Objects/src/MetFilters.cc
+++ b/Objects/src/MetFilters.cc
@@ -154,7 +154,6 @@ panda::MetFilters::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1
 void
 panda::MetFilters::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   _out << "globalHalo16 = " << globalHalo16 << std::endl;
   _out << "hbhe = " << hbhe << std::endl;
   _out << "hbheIso = " << hbheIso << std::endl;

--- a/Objects/src/MetFilters.cc
+++ b/Objects/src/MetFilters.cc
@@ -147,6 +147,7 @@ void
 panda::MetFilters::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM MetFilters.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -154,15 +155,15 @@ void
 panda::MetFilters::dump(std::ostream& _out/* = std::cout*/) const
 {
   _out << "<" << typeName() << ">" << std::endl;
-  _out << "globalHalo16" << globalHalo16 << std::endl;
-  _out << "hbhe" << hbhe << std::endl;
-  _out << "hbheIso" << hbheIso << std::endl;
-  _out << "ecalDeadCell" << ecalDeadCell << std::endl;
-  _out << "badsc" << badsc << std::endl;
-  _out << "badMuons" << badMuons << std::endl;
-  _out << "duplicateMuons" << duplicateMuons << std::endl;
-  _out << "dupECALClusters" << dupECALClusters << std::endl;
-  _out << "unfixedECALHits" << unfixedECALHits << std::endl;
+  _out << "globalHalo16 = " << globalHalo16 << std::endl;
+  _out << "hbhe = " << hbhe << std::endl;
+  _out << "hbheIso = " << hbheIso << std::endl;
+  _out << "ecalDeadCell = " << ecalDeadCell << std::endl;
+  _out << "badsc = " << badsc << std::endl;
+  _out << "badMuons = " << badMuons << std::endl;
+  _out << "duplicateMuons = " << duplicateMuons << std::endl;
+  _out << "dupECALClusters = " << dupECALClusters << std::endl;
+  _out << "unfixedECALHits = " << unfixedECALHits << std::endl;
 }
 
 

--- a/Objects/src/MicroJet.cc
+++ b/Objects/src/MicroJet.cc
@@ -192,7 +192,6 @@ panda::MicroJet::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/
 void
 panda::MicroJet::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   ParticleM::dump(_out);
 
   _out << "csv = " << csv << std::endl;

--- a/Objects/src/MicroJet.cc
+++ b/Objects/src/MicroJet.cc
@@ -185,6 +185,7 @@ void
 panda::MicroJet::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM MicroJet.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -194,8 +195,8 @@ panda::MicroJet::dump(std::ostream& _out/* = std::cout*/) const
   _out << "<" << typeName() << ">" << std::endl;
   ParticleM::dump(_out);
 
-  _out << "csv" << csv << std::endl;
-  _out << "qgl" << qgl << std::endl;
+  _out << "csv = " << csv << std::endl;
+  _out << "qgl = " << qgl << std::endl;
 }
 
 /* BEGIN CUSTOM MicroJet.cc.global */

--- a/Objects/src/MicroJet.cc
+++ b/Objects/src/MicroJet.cc
@@ -185,7 +185,7 @@ void
 panda::MicroJet::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM MicroJet.cc.print */
-  dump(_out);
+  MicroJet::dump(_out);
   /* END CUSTOM */
 }
 

--- a/Objects/src/MicroJet.cc
+++ b/Objects/src/MicroJet.cc
@@ -182,10 +182,20 @@ panda::MicroJet::doInit_()
 }
 
 void
-panda::MicroJet::print(std::ostream& _out/* = std::cout*/) const
+panda::MicroJet::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM MicroJet.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::MicroJet::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  ParticleM::dump(_out);
+
+  _out << "csv" << csv << std::endl;
+  _out << "qgl" << qgl << std::endl;
 }
 
 /* BEGIN CUSTOM MicroJet.cc.global */

--- a/Objects/src/Muon.cc
+++ b/Objects/src/Muon.cc
@@ -182,10 +182,20 @@ panda::Muon::doInit_()
 }
 
 void
-panda::Muon::print(std::ostream& _out/* = std::cout*/) const
+panda::Muon::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Muon.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::Muon::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  Lepton::dump(_out);
+
+  _out << "mediumBtoF" << mediumBtoF << std::endl;
+  _out << "triggerMatch" << triggerMatch << std::endl;
 }
 
 

--- a/Objects/src/Muon.cc
+++ b/Objects/src/Muon.cc
@@ -192,7 +192,6 @@ panda::Muon::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) co
 void
 panda::Muon::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   Lepton::dump(_out);
 
   _out << "mediumBtoF = " << mediumBtoF << std::endl;

--- a/Objects/src/Muon.cc
+++ b/Objects/src/Muon.cc
@@ -185,6 +185,7 @@ void
 panda::Muon::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Muon.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -194,8 +195,8 @@ panda::Muon::dump(std::ostream& _out/* = std::cout*/) const
   _out << "<" << typeName() << ">" << std::endl;
   Lepton::dump(_out);
 
-  _out << "mediumBtoF" << mediumBtoF << std::endl;
-  _out << "triggerMatch" << triggerMatch << std::endl;
+  _out << "mediumBtoF = " << mediumBtoF << std::endl;
+  _out << "triggerMatch = " << triggerMatch << std::endl;
 }
 
 

--- a/Objects/src/Muon.cc
+++ b/Objects/src/Muon.cc
@@ -185,7 +185,20 @@ void
 panda::Muon::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Muon.cc.print */
-  dump(_out);
+  if (_level >= 3) {
+    Muon::dump(_out);
+    
+    _out << "combIso = " << combIso() << std::endl;
+    _out << "combRelIso = " << combIso() / pt() << std::endl;
+  }
+  else if (_level == 2) {
+    Lepton::print(_out, _level);
+    
+    _out << "combIso = " << combIso() << std::endl;
+    _out << "combRelIso = " << combIso() / pt() << std::endl;
+  }
+  else
+    return;
   /* END CUSTOM */
 }
 

--- a/Objects/src/PFCand.cc
+++ b/Objects/src/PFCand.cc
@@ -214,7 +214,6 @@ panda::PFCand::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) 
 void
 panda::PFCand::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   PackedParticle::dump(_out);
 
   _out << "packedPuppiW = " << packedPuppiW << std::endl;

--- a/Objects/src/PFCand.cc
+++ b/Objects/src/PFCand.cc
@@ -207,6 +207,7 @@ void
 panda::PFCand::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM PFCand.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -216,9 +217,9 @@ panda::PFCand::dump(std::ostream& _out/* = std::cout*/) const
   _out << "<" << typeName() << ">" << std::endl;
   PackedParticle::dump(_out);
 
-  _out << "packedPuppiW" << packedPuppiW << std::endl;
-  _out << "packedPuppiWNoLepDiff" << packedPuppiWNoLepDiff << std::endl;
-  _out << "ptype" << ptype << std::endl;
+  _out << "packedPuppiW = " << packedPuppiW << std::endl;
+  _out << "packedPuppiWNoLepDiff = " << packedPuppiWNoLepDiff << std::endl;
+  _out << "ptype = " << ptype << std::endl;
 }
 
 

--- a/Objects/src/PFCand.cc
+++ b/Objects/src/PFCand.cc
@@ -204,10 +204,21 @@ panda::PFCand::doInit_()
 }
 
 void
-panda::PFCand::print(std::ostream& _out/* = std::cout*/) const
+panda::PFCand::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM PFCand.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::PFCand::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  PackedParticle::dump(_out);
+
+  _out << "packedPuppiW" << packedPuppiW << std::endl;
+  _out << "packedPuppiWNoLepDiff" << packedPuppiWNoLepDiff << std::endl;
+  _out << "ptype" << ptype << std::endl;
 }
 
 

--- a/Objects/src/PackedParticle.cc
+++ b/Objects/src/PackedParticle.cc
@@ -221,214 +221,24 @@ panda::PackedParticle::doInit_()
 }
 
 void
-panda::PackedParticle::print(std::ostream& _out/* = std::cout*/) const
+panda::PackedParticle::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM PackedParticle.cc.print */
   /* END CUSTOM */
 }
 
+void
+panda::PackedParticle::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  Particle::dump(_out);
+
+  _out << "packedPt" << packedPt << std::endl;
+  _out << "packedEta" << packedEta << std::endl;
+  _out << "packedPhi" << packedPhi << std::endl;
+  _out << "packedM" << packedM << std::endl;
+}
+
 
 /* BEGIN CUSTOM PackedParticle.cc.global */
-
-panda::PackingHelper::PackingHelper()
-{
-  // ==== mantissatable ===
-  // -- zero --
-  mantissatable[0] = 0;
-  // -- denorm --
-  for (unsigned int i = 1; i <= 1023; ++i) {
-    unsigned m = (i<<13);
-    unsigned e = 0;
-    while ((m & 0x00800000) == 0) { // While not normalized
-      e -= 0x00800000; // Decrement exponent (1<<23)
-      m <<= 1; // Shift mantissa
-    }
-    m &= ~0x00800000; // Clear leading 1 bit
-    e += 0x38800000; // Adjust bias ((127-14)<<23)
-    mantissatable[i] = m | e; 
-  }
-  // -- norm --
-  for (unsigned int i = 1024; i <= 2047; ++i)
-    mantissatable[i] = 0x38000000 + ((i - 1024) << 13);
-
-  // ==== exponenttable ===
-  exponenttable[0] = 0;
-  for (unsigned int i = 1; i <= 30; ++i)
-    exponenttable[i] = i << 23;
-  exponenttable[31] = 0x47800000;
-  exponenttable[32] = 0x80000000u;
-  for (unsigned int i = 33; i <= 62; ++i)
-    exponenttable[i] = 0x80000000u | ((i - 32) << 23);
-  exponenttable[63] = 0xC7800000;
- 
-  // ==== offsettable ====
-  for (unsigned int i = 0; i <= 63; ++i)
-    offsettable[i] = ((i == 0 || i == 32) ? 0 : 1024);
-
-  for (unsigned i = 0; i < 256; ++i) {
-    int e = int(i) - 127;
-    if (e < -24) { // Very small numbers map to zero
-      basetable[i | 0x000] = 0x0000;
-      basetable[i | 0x100] = 0x8000;
-      shifttable[i | 0x000] = 24;
-      shifttable[i | 0x100] = 24;
-    }
-    else if (e < -14) { // Small numbers map to denorms
-      basetable[i | 0x000] = (0x0400 >> (-e - 14));
-      basetable[i | 0x100] = (0x0400 >> (-e - 14)) | 0x8000;
-      shifttable[i | 0x000] = -e - 1;
-      shifttable[i | 0x100] = -e - 1;
-    }
-    else if (e <= 15) { // Normal numbers just lose precision
-      basetable[i | 0x000] = ((e + 15) << 10);
-      basetable[i | 0x100] = ((e + 15) << 10) | 0x8000;
-      shifttable[i | 0x000] = 13;
-      shifttable[i | 0x100] = 13;
-    }
-    else if (e < 128) { // Large numbers map to Infinity
-      basetable[i | 0x000] = 0x7C00;
-      basetable[i | 0x100] = 0xFC00;
-      shifttable[i | 0x000] = 24;
-      shifttable[i | 0x100] = 24;
-    }
-    else { // Infinity and NaN's stay Infinity and NaN's
-      basetable[i | 0x000] = 0x7C00;
-      basetable[i | 0x100] = 0xFC00;
-      shifttable[i | 0x000] = 13;
-      shifttable[i | 0x100] = 13;
-    }
-  }
-}
-
-UShort_t
-panda::PackingHelper::packUnbound(Double_t x) const
-{
-  // Implementation copied from DataFormats/PatCandidates/interface/libminifloat.h
-  // float32to16
-
-  union {
-    float flt;
-    uint32_t i32;
-  } conv;
-
-  conv.flt = x;
-  if (shifttable[(conv.i32>>23)&0x1ff] == 13) {
-    uint16_t base2 = (conv.i32&0x007fffff)>>12;
-    uint16_t base = base2 >> 1;
-    if (((base2 & 1) != 0) && (base < 1023)) base++;
-    return basetable[(conv.i32>>23)&0x1ff]+base; 
-  }
-  else
-    return basetable[(conv.i32>>23)&0x1ff]+((conv.i32&0x007fffff)>>shifttable[(conv.i32>>23)&0x1ff]);
-}
-
-Double_t
-panda::PackingHelper::unpackUnbound(UShort_t p) const
-{
-  union {
-    float flt;
-    uint32_t i32;
-  } conv;
-
-  conv.i32 = mantissatable[offsettable[p>>10]+(p&0x3ff)]+exponenttable[p>>10];
-  return conv.flt;
-}
-
-Char_t
-panda::PackingHelper::pack8LogBound(Double_t x, Double_t min, Double_t max, UChar_t baseminus1) const
-{
-  if (baseminus1 > 127)
-    baseminus1 = 127;
-
-  double l(std::log(std::abs(x)));
-  Char_t r;
-  if (l < min)
-    r = 0;
-  else if (l >= max)
-    r = baseminus1;
-  else
-    r = std::round((l - min) / (max - min) * baseminus1);
-
-  if (x < 0.) {
-    if (r == 0)
-      r = -1;
-    else
-      r *= -1;
-  }
-  return r;
-}
-
-Double_t
-panda::PackingHelper::unpack8LogBound(Char_t i, Double_t min, Double_t max, UChar_t baseminus1) const
-{
-  if (baseminus1 > 127)
-    baseminus1 = 127;
-
-  double l;
-  if (std::abs(i) == baseminus1)
-    l = max;
-  else
-    l = min + std::abs(i) * (max - min) / baseminus1;
-
-  double val(std::exp(l));
-  if (i < 0)
-    return -val;
-  else
-    return val;
-}
-
-/*static*/
-void
-panda::PackedParticle::setPtEtaPhiM(double pt, double eta, double phi, double m)
-{
-  pt_ = pt;
-  eta_ = eta;
-  phi_ = phi;
-  mass_ = m;
-  unpacked_ = true;
-  pack_();
-}
-
-void
-panda::PackedParticle::setXYZE(double px, double py, double pz, double e)
-{
-  pt_ = std::sqrt(px * px + py * py);
-  double p(std::sqrt(px * px + py * py + pz * pz));
-  eta_ = 0.5 * std::log((p + pz) / (p - pz));
-  phi_ = std::atan2(py, px);
-  mass_ = std::sqrt(e * e - p * p);
-  unpacked_ = true;
-  pack_();
-}
-
-void
-panda::PackedParticle::pack_()
-{
-  packedPt = PackingHelper::singleton().packUnbound(pt_);
-  packedEta = std::round(eta_ / 6.0f * std::numeric_limits<Short_t>::max());
-  packedPhi = std::round(phi_/3.2f*std::numeric_limits<Short_t>::max());
-  packedM = PackingHelper::singleton().packUnbound(pt_);
-
-  packMore_();
-}
-
-void
-panda::PackedParticle::unpack_() const
-{
-  if (unpacked_)
-    return;
-
-  pt_ = PackingHelper::singleton().unpackUnbound(packedPt);
-  // shift particle phi to break degeneracies in angular separations
-  // plus introduce a pseudo-random sign of the shift
-  double shift(pt_ < 1. ? 0.1 * pt_ : 0.1 / pt_);
-  double sign((int(pt_ * 10.) % 2 == 0) ? 1 : -1);
-  phi_ = (packedPhi + sign * shift) * 3.2f / std::numeric_limits<Short_t>::max();
-  mass_ = PackingHelper::singleton().unpackUnbound(packedM);
-  eta_ = packedEta * 6.0f / std::numeric_limits<Short_t>::max();
-
-  unpackMore_();
-
-  unpacked_ = true;
-}
 /* END CUSTOM */

--- a/Objects/src/PackedParticle.cc
+++ b/Objects/src/PackedParticle.cc
@@ -224,6 +224,7 @@ void
 panda::PackedParticle::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM PackedParticle.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -233,12 +234,214 @@ panda::PackedParticle::dump(std::ostream& _out/* = std::cout*/) const
   _out << "<" << typeName() << ">" << std::endl;
   Particle::dump(_out);
 
-  _out << "packedPt" << packedPt << std::endl;
-  _out << "packedEta" << packedEta << std::endl;
-  _out << "packedPhi" << packedPhi << std::endl;
-  _out << "packedM" << packedM << std::endl;
+  _out << "packedPt = " << packedPt << std::endl;
+  _out << "packedEta = " << packedEta << std::endl;
+  _out << "packedPhi = " << packedPhi << std::endl;
+  _out << "packedM = " << packedM << std::endl;
 }
 
 
 /* BEGIN CUSTOM PackedParticle.cc.global */
+panda::PackingHelper::PackingHelper()
+{
+  // ==== mantissatable ===
+  // -- zero --
+  mantissatable[0] = 0;
+  // -- denorm --
+  for (unsigned int i = 1; i <= 1023; ++i) {
+    unsigned m = (i<<13);
+    unsigned e = 0;
+    while ((m & 0x00800000) == 0) { // While not normalized
+      e -= 0x00800000; // Decrement exponent (1<<23)
+      m <<= 1; // Shift mantissa
+    }
+    m &= ~0x00800000; // Clear leading 1 bit
+    e += 0x38800000; // Adjust bias ((127-14)<<23)
+    mantissatable[i] = m | e; 
+  }
+  // -- norm --
+  for (unsigned int i = 1024; i <= 2047; ++i)
+    mantissatable[i] = 0x38000000 + ((i - 1024) << 13);
+
+  // ==== exponenttable ===
+  exponenttable[0] = 0;
+  for (unsigned int i = 1; i <= 30; ++i)
+    exponenttable[i] = i << 23;
+  exponenttable[31] = 0x47800000;
+  exponenttable[32] = 0x80000000u;
+  for (unsigned int i = 33; i <= 62; ++i)
+    exponenttable[i] = 0x80000000u | ((i - 32) << 23);
+  exponenttable[63] = 0xC7800000;
+ 
+  // ==== offsettable ====
+  for (unsigned int i = 0; i <= 63; ++i)
+    offsettable[i] = ((i == 0 || i == 32) ? 0 : 1024);
+
+  for (unsigned i = 0; i < 256; ++i) {
+    int e = int(i) - 127;
+    if (e < -24) { // Very small numbers map to zero
+      basetable[i | 0x000] = 0x0000;
+      basetable[i | 0x100] = 0x8000;
+      shifttable[i | 0x000] = 24;
+      shifttable[i | 0x100] = 24;
+    }
+    else if (e < -14) { // Small numbers map to denorms
+      basetable[i | 0x000] = (0x0400 >> (-e - 14));
+      basetable[i | 0x100] = (0x0400 >> (-e - 14)) | 0x8000;
+      shifttable[i | 0x000] = -e - 1;
+      shifttable[i | 0x100] = -e - 1;
+    }
+    else if (e <= 15) { // Normal numbers just lose precision
+      basetable[i | 0x000] = ((e + 15) << 10);
+      basetable[i | 0x100] = ((e + 15) << 10) | 0x8000;
+      shifttable[i | 0x000] = 13;
+      shifttable[i | 0x100] = 13;
+    }
+    else if (e < 128) { // Large numbers map to Infinity
+      basetable[i | 0x000] = 0x7C00;
+      basetable[i | 0x100] = 0xFC00;
+      shifttable[i | 0x000] = 24;
+      shifttable[i | 0x100] = 24;
+    }
+    else { // Infinity and NaN's stay Infinity and NaN's
+      basetable[i | 0x000] = 0x7C00;
+      basetable[i | 0x100] = 0xFC00;
+      shifttable[i | 0x000] = 13;
+      shifttable[i | 0x100] = 13;
+    }
+  }
+}
+
+UShort_t
+panda::PackingHelper::packUnbound(Double_t x) const
+{
+  // Implementation copied from DataFormats/PatCandidates/interface/libminifloat.h
+  // float32to16
+
+  union {
+    float flt;
+    uint32_t i32;
+  } conv;
+
+  conv.flt = x;
+  if (shifttable[(conv.i32>>23)&0x1ff] == 13) {
+    uint16_t base2 = (conv.i32&0x007fffff)>>12;
+    uint16_t base = base2 >> 1;
+    if (((base2 & 1) != 0) && (base < 1023)) base++;
+    return basetable[(conv.i32>>23)&0x1ff]+base; 
+  }
+  else
+    return basetable[(conv.i32>>23)&0x1ff]+((conv.i32&0x007fffff)>>shifttable[(conv.i32>>23)&0x1ff]);
+}
+
+Double_t
+panda::PackingHelper::unpackUnbound(UShort_t p) const
+{
+  union {
+    float flt;
+    uint32_t i32;
+  } conv;
+
+  conv.i32 = mantissatable[offsettable[p>>10]+(p&0x3ff)]+exponenttable[p>>10];
+  return conv.flt;
+}
+
+Char_t
+panda::PackingHelper::pack8LogBound(Double_t x, Double_t min, Double_t max, UChar_t baseminus1) const
+{
+  if (baseminus1 > 127)
+    baseminus1 = 127;
+
+  double l(std::log(std::abs(x)));
+  Char_t r;
+  if (l < min)
+    r = 0;
+  else if (l >= max)
+    r = baseminus1;
+  else
+    r = std::round((l - min) / (max - min) * baseminus1);
+
+  if (x < 0.) {
+    if (r == 0)
+      r = -1;
+    else
+      r *= -1;
+  }
+  return r;
+}
+
+Double_t
+panda::PackingHelper::unpack8LogBound(Char_t i, Double_t min, Double_t max, UChar_t baseminus1) const
+{
+  if (baseminus1 > 127)
+    baseminus1 = 127;
+
+  double l;
+  if (std::abs(i) == baseminus1)
+    l = max;
+  else
+    l = min + std::abs(i) * (max - min) / baseminus1;
+
+  double val(std::exp(l));
+  if (i < 0)
+    return -val;
+  else
+    return val;
+}
+
+/*static*/
+void
+panda::PackedParticle::setPtEtaPhiM(double pt, double eta, double phi, double m)
+{
+  pt_ = pt;
+  eta_ = eta;
+  phi_ = phi;
+  mass_ = m;
+  unpacked_ = true;
+  pack_();
+}
+
+void
+panda::PackedParticle::setXYZE(double px, double py, double pz, double e)
+{
+  pt_ = std::sqrt(px * px + py * py);
+  double p(std::sqrt(px * px + py * py + pz * pz));
+  eta_ = 0.5 * std::log((p + pz) / (p - pz));
+  phi_ = std::atan2(py, px);
+  mass_ = std::sqrt(e * e - p * p);
+  unpacked_ = true;
+  pack_();
+}
+
+void
+panda::PackedParticle::pack_()
+{
+  packedPt = PackingHelper::singleton().packUnbound(pt_);
+  packedEta = std::round(eta_ / 6.0f * std::numeric_limits<Short_t>::max());
+  packedPhi = std::round(phi_/3.2f*std::numeric_limits<Short_t>::max());
+  packedM = PackingHelper::singleton().packUnbound(pt_);
+
+  packMore_();
+}
+
+void
+panda::PackedParticle::unpack_() const
+{
+  if (unpacked_)
+    return;
+
+  pt_ = PackingHelper::singleton().unpackUnbound(packedPt);
+  // shift particle phi to break degeneracies in angular separations
+  // plus introduce a pseudo-random sign of the shift
+  double shift(pt_ < 1. ? 0.1 * pt_ : 0.1 / pt_);
+  double sign((int(pt_ * 10.) % 2 == 0) ? 1 : -1);
+  phi_ = (packedPhi + sign * shift) * 3.2f / std::numeric_limits<Short_t>::max();
+  mass_ = PackingHelper::singleton().unpackUnbound(packedM);
+  eta_ = packedEta * 6.0f / std::numeric_limits<Short_t>::max();
+
+  unpackMore_();
+
+  unpacked_ = true;
+}
+
 /* END CUSTOM */

--- a/Objects/src/PackedParticle.cc
+++ b/Objects/src/PackedParticle.cc
@@ -231,7 +231,6 @@ panda::PackedParticle::print(std::ostream& _out/* = std::cout*/, UInt_t _level/*
 void
 panda::PackedParticle::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   Particle::dump(_out);
 
   _out << "packedPt = " << packedPt << std::endl;

--- a/Objects/src/Particle.cc
+++ b/Objects/src/Particle.cc
@@ -129,7 +129,7 @@ void
 panda::Particle::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Particle.cc.print */
-  dump(_out);
+  Particle::dump(_out);
   /* END CUSTOM */
 }
 

--- a/Objects/src/Particle.cc
+++ b/Objects/src/Particle.cc
@@ -126,10 +126,16 @@ panda::Particle::doInit_()
 }
 
 void
-panda::Particle::print(std::ostream& _out/* = std::cout*/) const
+panda::Particle::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Particle.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::Particle::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
 }
 
 

--- a/Objects/src/Particle.cc
+++ b/Objects/src/Particle.cc
@@ -129,6 +129,7 @@ void
 panda::Particle::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Particle.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 

--- a/Objects/src/Particle.cc
+++ b/Objects/src/Particle.cc
@@ -136,7 +136,6 @@ panda::Particle::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/
 void
 panda::Particle::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
 }
 
 

--- a/Objects/src/ParticleM.cc
+++ b/Objects/src/ParticleM.cc
@@ -175,7 +175,6 @@ panda::ParticleM::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*
 void
 panda::ParticleM::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   ParticleP::dump(_out);
 
   _out << "mass_ = " << mass_ << std::endl;

--- a/Objects/src/ParticleM.cc
+++ b/Objects/src/ParticleM.cc
@@ -168,6 +168,7 @@ void
 panda::ParticleM::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM ParticleM.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -177,7 +178,7 @@ panda::ParticleM::dump(std::ostream& _out/* = std::cout*/) const
   _out << "<" << typeName() << ">" << std::endl;
   ParticleP::dump(_out);
 
-  _out << "mass_" << mass_ << std::endl;
+  _out << "mass_ = " << mass_ << std::endl;
 }
 
 void

--- a/Objects/src/ParticleM.cc
+++ b/Objects/src/ParticleM.cc
@@ -168,7 +168,7 @@ void
 panda::ParticleM::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM ParticleM.cc.print */
-  dump(_out);
+  ParticleM::dump(_out);
   /* END CUSTOM */
 }
 

--- a/Objects/src/ParticleM.cc
+++ b/Objects/src/ParticleM.cc
@@ -165,10 +165,19 @@ panda::ParticleM::doInit_()
 }
 
 void
-panda::ParticleM::print(std::ostream& _out/* = std::cout*/) const
+panda::ParticleM::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM ParticleM.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::ParticleM::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  ParticleP::dump(_out);
+
+  _out << "mass_" << mass_ << std::endl;
 }
 
 void

--- a/Objects/src/ParticleP.cc
+++ b/Objects/src/ParticleP.cc
@@ -202,7 +202,7 @@ void
 panda::ParticleP::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM ParticleP.cc.print */
-  dump(_out);
+  ParticleP::dump(_out);
   /* END CUSTOM */
 }
 

--- a/Objects/src/ParticleP.cc
+++ b/Objects/src/ParticleP.cc
@@ -199,10 +199,21 @@ panda::ParticleP::doInit_()
 }
 
 void
-panda::ParticleP::print(std::ostream& _out/* = std::cout*/) const
+panda::ParticleP::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM ParticleP.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::ParticleP::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  Particle::dump(_out);
+
+  _out << "pt_" << pt_ << std::endl;
+  _out << "eta_" << eta_ << std::endl;
+  _out << "phi_" << phi_ << std::endl;
 }
 
 void

--- a/Objects/src/ParticleP.cc
+++ b/Objects/src/ParticleP.cc
@@ -202,6 +202,7 @@ void
 panda::ParticleP::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM ParticleP.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -211,9 +212,9 @@ panda::ParticleP::dump(std::ostream& _out/* = std::cout*/) const
   _out << "<" << typeName() << ">" << std::endl;
   Particle::dump(_out);
 
-  _out << "pt_" << pt_ << std::endl;
-  _out << "eta_" << eta_ << std::endl;
-  _out << "phi_" << phi_ << std::endl;
+  _out << "pt_ = " << pt_ << std::endl;
+  _out << "eta_ = " << eta_ << std::endl;
+  _out << "phi_ = " << phi_ << std::endl;
 }
 
 void

--- a/Objects/src/ParticleP.cc
+++ b/Objects/src/ParticleP.cc
@@ -209,7 +209,6 @@ panda::ParticleP::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*
 void
 panda::ParticleP::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   Particle::dump(_out);
 
   _out << "pt_ = " << pt_ << std::endl;

--- a/Objects/src/Parton.cc
+++ b/Objects/src/Parton.cc
@@ -165,10 +165,19 @@ panda::Parton::doInit_()
 }
 
 void
-panda::Parton::print(std::ostream& _out/* = std::cout*/) const
+panda::Parton::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Parton.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::Parton::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  ParticleM::dump(_out);
+
+  _out << "pdgid" << pdgid << std::endl;
 }
 
 /* BEGIN CUSTOM Parton.cc.global */

--- a/Objects/src/Parton.cc
+++ b/Objects/src/Parton.cc
@@ -175,7 +175,6 @@ panda::Parton::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) 
 void
 panda::Parton::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   ParticleM::dump(_out);
 
   _out << "pdgid = " << pdgid << std::endl;

--- a/Objects/src/Parton.cc
+++ b/Objects/src/Parton.cc
@@ -168,6 +168,7 @@ void
 panda::Parton::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Parton.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -177,7 +178,7 @@ panda::Parton::dump(std::ostream& _out/* = std::cout*/) const
   _out << "<" << typeName() << ">" << std::endl;
   ParticleM::dump(_out);
 
-  _out << "pdgid" << pdgid << std::endl;
+  _out << "pdgid = " << pdgid << std::endl;
 }
 
 /* BEGIN CUSTOM Parton.cc.global */

--- a/Objects/src/Photon.cc
+++ b/Objects/src/Photon.cc
@@ -719,7 +719,6 @@ panda::Photon::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) 
 void
 panda::Photon::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   ParticleP::dump(_out);
 
   _out << "pfPt = " << pfPt << std::endl;

--- a/Objects/src/Photon.cc
+++ b/Objects/src/Photon.cc
@@ -712,7 +712,30 @@ void
 panda::Photon::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Photon.cc.print */
-  dump(_out);
+  /*
+  if (_level >= 3) {
+    dump(_out);
+  }
+  else
+  */ 
+  if (_level == 2) {
+    ParticleP::print(_out, _level);
+    
+    _out << "pfPt = " << pfPt << std::endl;
+    _out << "rawPt = " << rawPt << std::endl;
+    _out << "hOverE = " << hOverE << std::endl;
+    _out << "chIso = " << chIso << std::endl;
+    _out << "chIsoMax = " << chIsoMax << std::endl;
+    _out << "nhIso = " << nhIso << std::endl;
+    _out << "phIso = " << phIso << std::endl;
+    _out << "sieie = " << sieie << std::endl;
+    _out << "sipip = " << sipip << std::endl;
+    _out << "mipEnergy = " << mipEnergy << std::endl;
+    _out << "time = " << time << std::endl;
+    _out << "pixelVeto = " << pixelVeto << std::endl;
+  }
+  else
+    return;
   /* END CUSTOM */
 }
 

--- a/Objects/src/Photon.cc
+++ b/Objects/src/Photon.cc
@@ -709,10 +709,51 @@ panda::Photon::doInit_()
 }
 
 void
-panda::Photon::print(std::ostream& _out/* = std::cout*/) const
+panda::Photon::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Photon.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::Photon::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  ParticleP::dump(_out);
+
+  _out << "pfPt" << pfPt << std::endl;
+  _out << "chIso" << chIso << std::endl;
+  _out << "chIsoMax" << chIsoMax << std::endl;
+  _out << "nhIso" << nhIso << std::endl;
+  _out << "phIso" << phIso << std::endl;
+  _out << "sieie" << sieie << std::endl;
+  _out << "sipip" << sipip << std::endl;
+  _out << "hOverE" << hOverE << std::endl;
+  _out << "genIso" << genIso << std::endl;
+  _out << "mipEnergy" << mipEnergy << std::endl;
+  _out << "emax" << emax << std::endl;
+  _out << "e2nd" << e2nd << std::endl;
+  _out << "eleft" << eleft << std::endl;
+  _out << "eright" << eright << std::endl;
+  _out << "etop" << etop << std::endl;
+  _out << "ebottom" << ebottom << std::endl;
+  _out << "r9" << r9 << std::endl;
+  _out << "etaWidth" << etaWidth << std::endl;
+  _out << "phiWidth" << phiWidth << std::endl;
+  _out << "time" << time << std::endl;
+  _out << "timeSpan" << timeSpan << std::endl;
+  _out << "rawPt" << rawPt << std::endl;
+  _out << "regPt" << regPt << std::endl;
+  _out << "originalPt" << originalPt << std::endl;
+  _out << "loose" << loose << std::endl;
+  _out << "medium" << medium << std::endl;
+  _out << "tight" << tight << std::endl;
+  _out << "highpt" << highpt << std::endl;
+  _out << "pixelVeto" << pixelVeto << std::endl;
+  _out << "csafeVeto" << csafeVeto << std::endl;
+  _out << "triggerMatch" << triggerMatch << std::endl;
+  _out << "superCluster" << superCluster << std::endl;
+  _out << "matchedGen" << matchedGen << std::endl;
 }
 
 /* BEGIN CUSTOM Photon.cc.global */

--- a/Objects/src/Photon.cc
+++ b/Objects/src/Photon.cc
@@ -712,13 +712,10 @@ void
 panda::Photon::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Photon.cc.print */
-  /*
   if (_level >= 3) {
-    dump(_out);
+    Photon::dump(_out);
   }
-  else
-  */ 
-  if (_level == 2) {
+  else if (_level == 2) {
     ParticleP::print(_out, _level);
     
     _out << "pfPt = " << pfPt << std::endl;

--- a/Objects/src/Photon.cc
+++ b/Objects/src/Photon.cc
@@ -712,6 +712,7 @@ void
 panda::Photon::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Photon.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -721,39 +722,39 @@ panda::Photon::dump(std::ostream& _out/* = std::cout*/) const
   _out << "<" << typeName() << ">" << std::endl;
   ParticleP::dump(_out);
 
-  _out << "pfPt" << pfPt << std::endl;
-  _out << "chIso" << chIso << std::endl;
-  _out << "chIsoMax" << chIsoMax << std::endl;
-  _out << "nhIso" << nhIso << std::endl;
-  _out << "phIso" << phIso << std::endl;
-  _out << "sieie" << sieie << std::endl;
-  _out << "sipip" << sipip << std::endl;
-  _out << "hOverE" << hOverE << std::endl;
-  _out << "genIso" << genIso << std::endl;
-  _out << "mipEnergy" << mipEnergy << std::endl;
-  _out << "emax" << emax << std::endl;
-  _out << "e2nd" << e2nd << std::endl;
-  _out << "eleft" << eleft << std::endl;
-  _out << "eright" << eright << std::endl;
-  _out << "etop" << etop << std::endl;
-  _out << "ebottom" << ebottom << std::endl;
-  _out << "r9" << r9 << std::endl;
-  _out << "etaWidth" << etaWidth << std::endl;
-  _out << "phiWidth" << phiWidth << std::endl;
-  _out << "time" << time << std::endl;
-  _out << "timeSpan" << timeSpan << std::endl;
-  _out << "rawPt" << rawPt << std::endl;
-  _out << "regPt" << regPt << std::endl;
-  _out << "originalPt" << originalPt << std::endl;
-  _out << "loose" << loose << std::endl;
-  _out << "medium" << medium << std::endl;
-  _out << "tight" << tight << std::endl;
-  _out << "highpt" << highpt << std::endl;
-  _out << "pixelVeto" << pixelVeto << std::endl;
-  _out << "csafeVeto" << csafeVeto << std::endl;
-  _out << "triggerMatch" << triggerMatch << std::endl;
-  _out << "superCluster" << superCluster << std::endl;
-  _out << "matchedGen" << matchedGen << std::endl;
+  _out << "pfPt = " << pfPt << std::endl;
+  _out << "chIso = " << chIso << std::endl;
+  _out << "chIsoMax = " << chIsoMax << std::endl;
+  _out << "nhIso = " << nhIso << std::endl;
+  _out << "phIso = " << phIso << std::endl;
+  _out << "sieie = " << sieie << std::endl;
+  _out << "sipip = " << sipip << std::endl;
+  _out << "hOverE = " << hOverE << std::endl;
+  _out << "genIso = " << genIso << std::endl;
+  _out << "mipEnergy = " << mipEnergy << std::endl;
+  _out << "emax = " << emax << std::endl;
+  _out << "e2nd = " << e2nd << std::endl;
+  _out << "eleft = " << eleft << std::endl;
+  _out << "eright = " << eright << std::endl;
+  _out << "etop = " << etop << std::endl;
+  _out << "ebottom = " << ebottom << std::endl;
+  _out << "r9 = " << r9 << std::endl;
+  _out << "etaWidth = " << etaWidth << std::endl;
+  _out << "phiWidth = " << phiWidth << std::endl;
+  _out << "time = " << time << std::endl;
+  _out << "timeSpan = " << timeSpan << std::endl;
+  _out << "rawPt = " << rawPt << std::endl;
+  _out << "regPt = " << regPt << std::endl;
+  _out << "originalPt = " << originalPt << std::endl;
+  _out << "loose = " << loose << std::endl;
+  _out << "medium = " << medium << std::endl;
+  _out << "tight = " << tight << std::endl;
+  _out << "highpt = " << highpt << std::endl;
+  _out << "pixelVeto = " << pixelVeto << std::endl;
+  _out << "csafeVeto = " << csafeVeto << std::endl;
+  _out << "triggerMatch = " << triggerMatch << std::endl;
+  _out << "superCluster = " << superCluster << std::endl;
+  _out << "matchedGen = " << matchedGen << std::endl;
 }
 
 /* BEGIN CUSTOM Photon.cc.global */

--- a/Objects/src/RecoMet.cc
+++ b/Objects/src/RecoMet.cc
@@ -158,7 +158,15 @@ void
 panda::RecoMet::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM RecoMet.cc.print */
-  dump(_out);
+  if (_level >= 3) {
+    _out << getName() << std::endl;
+    RecoMet::dump(_out);
+  }
+  else if (_level == 2) {
+    Met::print(_out, _level);
+    
+    _out << "sumETRaw = " << sumETRaw << std::endl;
+  }
   /* END CUSTOM */
 }
 

--- a/Objects/src/RecoMet.cc
+++ b/Objects/src/RecoMet.cc
@@ -155,10 +155,27 @@ panda::RecoMet::doGetBranchNames_(Bool_t _fullName) const
 }
 
 void
-panda::RecoMet::print(std::ostream& _out/* = std::cout*/) const
+panda::RecoMet::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM RecoMet.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::RecoMet::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  Met::dump(_out);
+
+  _out << "sumETRaw" << sumETRaw << std::endl;
+  _out << "ptCorrUp" << ptCorrUp << std::endl;
+  _out << "phiCorrUp" << phiCorrUp << std::endl;
+  _out << "ptCorrDown" << ptCorrDown << std::endl;
+  _out << "phiCorrDown" << phiCorrDown << std::endl;
+  _out << "ptUnclUp" << ptUnclUp << std::endl;
+  _out << "phiUnclUp" << phiUnclUp << std::endl;
+  _out << "ptUnclDown" << ptUnclDown << std::endl;
+  _out << "phiUnclDown" << phiUnclDown << std::endl;
 }
 
 TVector2

--- a/Objects/src/RecoMet.cc
+++ b/Objects/src/RecoMet.cc
@@ -165,7 +165,6 @@ panda::RecoMet::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/)
 void
 panda::RecoMet::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   Met::dump(_out);
 
   _out << "sumETRaw = " << sumETRaw << std::endl;

--- a/Objects/src/RecoMet.cc
+++ b/Objects/src/RecoMet.cc
@@ -158,6 +158,7 @@ void
 panda::RecoMet::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM RecoMet.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -167,15 +168,15 @@ panda::RecoMet::dump(std::ostream& _out/* = std::cout*/) const
   _out << "<" << typeName() << ">" << std::endl;
   Met::dump(_out);
 
-  _out << "sumETRaw" << sumETRaw << std::endl;
-  _out << "ptCorrUp" << ptCorrUp << std::endl;
-  _out << "phiCorrUp" << phiCorrUp << std::endl;
-  _out << "ptCorrDown" << ptCorrDown << std::endl;
-  _out << "phiCorrDown" << phiCorrDown << std::endl;
-  _out << "ptUnclUp" << ptUnclUp << std::endl;
-  _out << "phiUnclUp" << phiUnclUp << std::endl;
-  _out << "ptUnclDown" << ptUnclDown << std::endl;
-  _out << "phiUnclDown" << phiUnclDown << std::endl;
+  _out << "sumETRaw = " << sumETRaw << std::endl;
+  _out << "ptCorrUp = " << ptCorrUp << std::endl;
+  _out << "phiCorrUp = " << phiCorrUp << std::endl;
+  _out << "ptCorrDown = " << ptCorrDown << std::endl;
+  _out << "phiCorrDown = " << phiCorrDown << std::endl;
+  _out << "ptUnclUp = " << ptUnclUp << std::endl;
+  _out << "phiUnclUp = " << phiUnclUp << std::endl;
+  _out << "ptUnclDown = " << ptUnclDown << std::endl;
+  _out << "phiUnclDown = " << phiUnclDown << std::endl;
 }
 
 TVector2

--- a/Objects/src/Recoil.cc
+++ b/Objects/src/Recoil.cc
@@ -131,6 +131,7 @@ void
 panda::Recoil::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Recoil.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -138,13 +139,13 @@ void
 panda::Recoil::dump(std::ostream& _out/* = std::cout*/) const
 {
   _out << "<" << typeName() << ">" << std::endl;
-  _out << "met" << met << std::endl;
-  _out << "monoMu" << monoMu << std::endl;
-  _out << "monoE" << monoE << std::endl;
-  _out << "diMu" << diMu << std::endl;
-  _out << "diE" << diE << std::endl;
-  _out << "gamma" << gamma << std::endl;
-  _out << "max" << max << std::endl;
+  _out << "met = " << met << std::endl;
+  _out << "monoMu = " << monoMu << std::endl;
+  _out << "monoE = " << monoE << std::endl;
+  _out << "diMu = " << diMu << std::endl;
+  _out << "diE = " << diE << std::endl;
+  _out << "gamma = " << gamma << std::endl;
+  _out << "max = " << max << std::endl;
 }
 
 

--- a/Objects/src/Recoil.cc
+++ b/Objects/src/Recoil.cc
@@ -138,7 +138,6 @@ panda::Recoil::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) 
 void
 panda::Recoil::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   _out << "met = " << met << std::endl;
   _out << "monoMu = " << monoMu << std::endl;
   _out << "monoE = " << monoE << std::endl;

--- a/Objects/src/Recoil.cc
+++ b/Objects/src/Recoil.cc
@@ -128,10 +128,23 @@ panda::Recoil::doGetBranchNames_(Bool_t _fullName) const
 }
 
 void
-panda::Recoil::print(std::ostream& _out/* = std::cout*/) const
+panda::Recoil::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Recoil.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::Recoil::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  _out << "met" << met << std::endl;
+  _out << "monoMu" << monoMu << std::endl;
+  _out << "monoE" << monoE << std::endl;
+  _out << "diMu" << diMu << std::endl;
+  _out << "diE" << diE << std::endl;
+  _out << "gamma" << gamma << std::endl;
+  _out << "max" << max << std::endl;
 }
 
 

--- a/Objects/src/Run.cc
+++ b/Objects/src/Run.cc
@@ -63,9 +63,9 @@ panda::Run::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) con
 void
 panda::Run::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "runNumber" << runNumber << std::endl;
-  _out << "hltMenu" << hltMenu << std::endl;
-  _out << "hltSize" << hltSize << std::endl;
+  _out << "runNumber = " << runNumber << std::endl;
+  _out << "hltMenu = " << hltMenu << std::endl;
+  _out << "hltSize = " << hltSize << std::endl;
 
 }
 /*static*/

--- a/Objects/src/Run.cc
+++ b/Objects/src/Run.cc
@@ -51,6 +51,23 @@ panda::Run::operator=(Run const& _src)
   return *this;
 }
 
+
+void
+panda::Run::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
+{
+  /* BEGIN CUSTOM Run.cc.print */
+  dump(_out);
+  /* END CUSTOM */
+}
+
+void
+panda::Run::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "runNumber" << runNumber << std::endl;
+  _out << "hltMenu" << hltMenu << std::endl;
+  _out << "hltSize" << hltSize << std::endl;
+
+}
 /*static*/
 panda::utils::BranchList
 panda::Run::getListOfBranches()

--- a/Objects/src/SuperCluster.cc
+++ b/Objects/src/SuperCluster.cc
@@ -193,6 +193,7 @@ void
 panda::SuperCluster::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM SuperCluster.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -200,9 +201,9 @@ void
 panda::SuperCluster::dump(std::ostream& _out/* = std::cout*/) const
 {
   _out << "<" << typeName() << ">" << std::endl;
-  _out << "rawPt" << rawPt << std::endl;
-  _out << "eta" << eta << std::endl;
-  _out << "phi" << phi << std::endl;
+  _out << "rawPt = " << rawPt << std::endl;
+  _out << "eta = " << eta << std::endl;
+  _out << "phi = " << phi << std::endl;
 }
 
 /* BEGIN CUSTOM SuperCluster.cc.global */

--- a/Objects/src/SuperCluster.cc
+++ b/Objects/src/SuperCluster.cc
@@ -200,7 +200,6 @@ panda::SuperCluster::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* =
 void
 panda::SuperCluster::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   _out << "rawPt = " << rawPt << std::endl;
   _out << "eta = " << eta << std::endl;
   _out << "phi = " << phi << std::endl;

--- a/Objects/src/SuperCluster.cc
+++ b/Objects/src/SuperCluster.cc
@@ -190,10 +190,19 @@ panda::SuperCluster::doInit_()
 }
 
 void
-panda::SuperCluster::print(std::ostream& _out/* = std::cout*/) const
+panda::SuperCluster::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM SuperCluster.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::SuperCluster::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  _out << "rawPt" << rawPt << std::endl;
+  _out << "eta" << eta << std::endl;
+  _out << "phi" << phi << std::endl;
 }
 
 /* BEGIN CUSTOM SuperCluster.cc.global */

--- a/Objects/src/TPPair.cc
+++ b/Objects/src/TPPair.cc
@@ -1,0 +1,191 @@
+#include "../interface/TPPair.h"
+
+/*static*/
+panda::utils::BranchList
+panda::TPPair::getListOfBranches()
+{
+  utils::BranchList blist;
+  blist += {"mass", "mass2"};
+  return blist;
+}
+
+void
+panda::TPPair::datastore::allocate(UInt_t _nmax)
+{
+  Element::datastore::allocate(_nmax);
+
+  mass = new Float_t[nmax_];
+  mass2 = new Float_t[nmax_];
+}
+
+void
+panda::TPPair::datastore::deallocate()
+{
+  Element::datastore::deallocate();
+
+  delete [] mass;
+  mass = 0;
+  delete [] mass2;
+  mass2 = 0;
+}
+
+void
+panda::TPPair::datastore::setStatus(TTree& _tree, TString const& _name, utils::BranchList const& _branches)
+{
+  Element::datastore::setStatus(_tree, _name, _branches);
+
+  utils::setStatus(_tree, _name, "mass", _branches);
+  utils::setStatus(_tree, _name, "mass2", _branches);
+}
+
+panda::utils::BranchList
+panda::TPPair::datastore::getStatus(TTree& _tree, TString const& _name) const
+{
+  utils::BranchList blist(Element::datastore::getStatus(_tree, _name));
+
+  blist.push_back(utils::getStatus(_tree, _name, "mass"));
+  blist.push_back(utils::getStatus(_tree, _name, "mass2"));
+
+  return blist;
+}
+
+void
+panda::TPPair::datastore::setAddress(TTree& _tree, TString const& _name, utils::BranchList const& _branches/* = {"*"}*/, Bool_t _setStatus/* = kTRUE*/)
+{
+  Element::datastore::setAddress(_tree, _name, _branches, _setStatus);
+
+  utils::setAddress(_tree, _name, "mass", mass, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "mass2", mass2, _branches, _setStatus);
+}
+
+void
+panda::TPPair::datastore::book(TTree& _tree, TString const& _name, utils::BranchList const& _branches/* = {"*"}*/, Bool_t _dynamic/* = kTRUE*/)
+{
+  Element::datastore::book(_tree, _name, _branches, _dynamic);
+
+  TString size(_dynamic ? "[" + _name + ".size]" : TString::Format("[%d]", nmax_));
+
+  utils::book(_tree, _name, "mass", size, 'F', mass, _branches);
+  utils::book(_tree, _name, "mass2", size, 'F', mass2, _branches);
+}
+
+void
+panda::TPPair::datastore::releaseTree(TTree& _tree, TString const& _name)
+{
+  Element::datastore::releaseTree(_tree, _name);
+
+  utils::resetAddress(_tree, _name, "mass");
+  utils::resetAddress(_tree, _name, "mass2");
+}
+
+void
+panda::TPPair::datastore::resizeVectors_(UInt_t _size)
+{
+  Element::datastore::resizeVectors_(_size);
+
+}
+
+
+panda::utils::BranchList
+panda::TPPair::datastore::getBranchNames(TString const& _name/* = ""*/) const
+{
+  return TPPair::getListOfBranches().fullNames(_name);
+}
+
+panda::TPPair::TPPair(char const* _name/* = ""*/) :
+  Element(new TPPairArray(1, _name)),
+  mass(gStore.getData(this).mass[0]),
+  mass2(gStore.getData(this).mass2[0])
+{
+}
+
+panda::TPPair::TPPair(TPPair const& _src) :
+  Element(new TPPairArray(1, gStore.getName(&_src))),
+  mass(gStore.getData(this).mass[0]),
+  mass2(gStore.getData(this).mass2[0])
+{
+  Element::operator=(_src);
+
+  mass = _src.mass;
+  mass2 = _src.mass2;
+}
+
+panda::TPPair::TPPair(datastore& _data, UInt_t _idx) :
+  Element(_data, _idx),
+  mass(_data.mass[_idx]),
+  mass2(_data.mass2[_idx])
+{
+}
+
+panda::TPPair::TPPair(ArrayBase* _array) :
+  Element(_array),
+  mass(gStore.getData(this).mass[0]),
+  mass2(gStore.getData(this).mass2[0])
+{
+}
+
+panda::TPPair::~TPPair()
+{
+  destructor();
+  gStore.free(this);
+}
+
+void
+panda::TPPair::destructor()
+{
+  /* BEGIN CUSTOM TPPair.cc.destructor */
+  /* END CUSTOM */
+
+  Element::destructor();
+}
+
+panda::TPPair&
+panda::TPPair::operator=(TPPair const& _src)
+{
+  mass = _src.mass;
+  mass2 = _src.mass2;
+
+  return *this;
+}
+
+void
+panda::TPPair::doSetAddress_(TTree& _tree, TString const& _name, utils::BranchList const& _branches/* = {"*"}*/, Bool_t _setStatus/* = kTRUE*/)
+{
+  utils::setAddress(_tree, _name, "mass", &mass, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "mass2", &mass2, _branches, _setStatus);
+}
+
+void
+panda::TPPair::doBook_(TTree& _tree, TString const& _name, utils::BranchList const& _branches/* = {"*"}*/)
+{
+  utils::book(_tree, _name, "mass", "", 'F', &mass, _branches);
+  utils::book(_tree, _name, "mass2", "", 'F', &mass2, _branches);
+}
+
+void
+panda::TPPair::doInit_()
+{
+  mass = 0.;
+  mass2 = 0.;
+
+  /* BEGIN CUSTOM TPPair.cc.doInit_ */
+  /* END CUSTOM */
+}
+
+void
+panda::TPPair::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
+{
+  /* BEGIN CUSTOM TPPair.cc.print */
+  /* END CUSTOM */
+}
+
+void
+panda::TPPair::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  _out << "mass" << mass << std::endl;
+  _out << "mass2" << mass2 << std::endl;
+}
+
+/* BEGIN CUSTOM TPPair.cc.global */
+/* END CUSTOM */

--- a/Objects/src/TPPair.cc
+++ b/Objects/src/TPPair.cc
@@ -176,6 +176,7 @@ void
 panda::TPPair::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM TPPair.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -183,8 +184,8 @@ void
 panda::TPPair::dump(std::ostream& _out/* = std::cout*/) const
 {
   _out << "<" << typeName() << ">" << std::endl;
-  _out << "mass" << mass << std::endl;
-  _out << "mass2" << mass2 << std::endl;
+  _out << "mass = " << mass << std::endl;
+  _out << "mass2 = " << mass2 << std::endl;
 }
 
 /* BEGIN CUSTOM TPPair.cc.global */

--- a/Objects/src/TPPair.cc
+++ b/Objects/src/TPPair.cc
@@ -183,7 +183,6 @@ panda::TPPair::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) 
 void
 panda::TPPair::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   _out << "mass = " << mass << std::endl;
   _out << "mass2 = " << mass2 << std::endl;
 }

--- a/Objects/src/Tau.cc
+++ b/Objects/src/Tau.cc
@@ -277,7 +277,6 @@ panda::Tau::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) con
 void
 panda::Tau::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   ParticleM::dump(_out);
 
   _out << "charge = " << charge << std::endl;

--- a/Objects/src/Tau.cc
+++ b/Objects/src/Tau.cc
@@ -267,10 +267,25 @@ panda::Tau::doInit_()
 }
 
 void
-panda::Tau::print(std::ostream& _out/* = std::cout*/) const
+panda::Tau::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Tau.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::Tau::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  ParticleM::dump(_out);
+
+  _out << "charge" << charge << std::endl;
+  _out << "decayMode" << decayMode << std::endl;
+  _out << "decayModeNew" << decayModeNew << std::endl;
+  _out << "looseIsoMVA" << looseIsoMVA << std::endl;
+  _out << "iso" << iso << std::endl;
+  _out << "isoDeltaBetaCorr" << isoDeltaBetaCorr << std::endl;
+  _out << "matchedGen" << matchedGen << std::endl;
 }
 
 /* BEGIN CUSTOM Tau.cc.global */

--- a/Objects/src/Tau.cc
+++ b/Objects/src/Tau.cc
@@ -270,6 +270,7 @@ void
 panda::Tau::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM Tau.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -279,13 +280,13 @@ panda::Tau::dump(std::ostream& _out/* = std::cout*/) const
   _out << "<" << typeName() << ">" << std::endl;
   ParticleM::dump(_out);
 
-  _out << "charge" << charge << std::endl;
-  _out << "decayMode" << decayMode << std::endl;
-  _out << "decayModeNew" << decayModeNew << std::endl;
-  _out << "looseIsoMVA" << looseIsoMVA << std::endl;
-  _out << "iso" << iso << std::endl;
-  _out << "isoDeltaBetaCorr" << isoDeltaBetaCorr << std::endl;
-  _out << "matchedGen" << matchedGen << std::endl;
+  _out << "charge = " << charge << std::endl;
+  _out << "decayMode = " << decayMode << std::endl;
+  _out << "decayModeNew = " << decayModeNew << std::endl;
+  _out << "looseIsoMVA = " << looseIsoMVA << std::endl;
+  _out << "iso = " << iso << std::endl;
+  _out << "isoDeltaBetaCorr = " << isoDeltaBetaCorr << std::endl;
+  _out << "matchedGen = " << matchedGen << std::endl;
 }
 
 /* BEGIN CUSTOM Tau.cc.global */

--- a/Objects/src/XPhoton.cc
+++ b/Objects/src/XPhoton.cc
@@ -278,10 +278,25 @@ panda::XPhoton::doInit_()
 }
 
 void
-panda::XPhoton::print(std::ostream& _out/* = std::cout*/) const
+panda::XPhoton::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM XPhoton.cc.print */
   /* END CUSTOM */
+}
+
+void
+panda::XPhoton::dump(std::ostream& _out/* = std::cout*/) const
+{
+  _out << "<" << typeName() << ">" << std::endl;
+  Photon::dump(_out);
+
+  _out << "scEta" << scEta << std::endl;
+  _out << "scRawPt" << scRawPt << std::endl;
+  _out << "chIsoS15" << chIsoS15 << std::endl;
+  _out << "nhIsoS15" << nhIsoS15 << std::endl;
+  _out << "phIsoS15" << phIsoS15 << std::endl;
+  _out << "e4" << e4 << std::endl;
+  _out << "isEB" << isEB << std::endl;
 }
 
 

--- a/Objects/src/XPhoton.cc
+++ b/Objects/src/XPhoton.cc
@@ -281,13 +281,10 @@ void
 panda::XPhoton::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM XPhoton.cc.print */
-  /*
   if (_level >= 3) {
-    dump(_out);
+    XPhoton::dump(_out);
   }
-  else
-  */ 
-  if (_level == 2) {
+  else if (_level == 2) {
     Photon::print(_out, _level);
 
     _out << "scEta = " << scEta << std::endl;

--- a/Objects/src/XPhoton.cc
+++ b/Objects/src/XPhoton.cc
@@ -281,7 +281,25 @@ void
 panda::XPhoton::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM XPhoton.cc.print */
-  dump(_out);
+  /*
+  if (_level >= 3) {
+    dump(_out);
+  }
+  else
+  */ 
+  if (_level == 2) {
+    Photon::print(_out, _level);
+
+    _out << "scEta = " << scEta << std::endl;
+    _out << "scRawPt = " << scRawPt << std::endl;
+    _out << "chIsoS15 = " << chIsoS15 << std::endl;
+    _out << "nhIsoS15 = " << nhIsoS15 << std::endl;
+    _out << "phIsoS15 = " << phIsoS15 << std::endl;
+    _out << "e4 = " << e4 << std::endl;
+    _out << "isEB = " << isEB << std::endl;
+  }
+  else
+    return;
   /* END CUSTOM */
 }
 

--- a/Objects/src/XPhoton.cc
+++ b/Objects/src/XPhoton.cc
@@ -281,6 +281,7 @@ void
 panda::XPhoton::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
 {
   /* BEGIN CUSTOM XPhoton.cc.print */
+  dump(_out);
   /* END CUSTOM */
 }
 
@@ -290,13 +291,13 @@ panda::XPhoton::dump(std::ostream& _out/* = std::cout*/) const
   _out << "<" << typeName() << ">" << std::endl;
   Photon::dump(_out);
 
-  _out << "scEta" << scEta << std::endl;
-  _out << "scRawPt" << scRawPt << std::endl;
-  _out << "chIsoS15" << chIsoS15 << std::endl;
-  _out << "nhIsoS15" << nhIsoS15 << std::endl;
-  _out << "phIsoS15" << phIsoS15 << std::endl;
-  _out << "e4" << e4 << std::endl;
-  _out << "isEB" << isEB << std::endl;
+  _out << "scEta = " << scEta << std::endl;
+  _out << "scRawPt = " << scRawPt << std::endl;
+  _out << "chIsoS15 = " << chIsoS15 << std::endl;
+  _out << "nhIsoS15 = " << nhIsoS15 << std::endl;
+  _out << "phIsoS15 = " << phIsoS15 << std::endl;
+  _out << "e4 = " << e4 << std::endl;
+  _out << "isEB = " << isEB << std::endl;
 }
 
 

--- a/Objects/src/XPhoton.cc
+++ b/Objects/src/XPhoton.cc
@@ -288,7 +288,6 @@ panda::XPhoton::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/)
 void
 panda::XPhoton::dump(std::ostream& _out/* = std::cout*/) const
 {
-  _out << "<" << typeName() << ">" << std::endl;
   Photon::dump(_out);
 
   _out << "scEta = " << scEta << std::endl;

--- a/defs/monophoton.def
+++ b/defs/monophoton.def
@@ -20,6 +20,10 @@ static double const phIsoCuts[2][2][4]{{{0.81, 0.28, 0.08, 2.75}, {0.83, 0.39, 0
 static double const sieieCuts[2][2][4]{{{0.0102, 0.0102, 0.0100, 0.0105}, {0.0274, 0.0268, 0.0268, 0.028}}, {{0.01031, 0.01022, 0.00994, 0.0105}, {0.03013, 0.03001, 0.03000, 0.028}}};
 static double const hOverECuts[2][2][4]{{{0.05, 0.05, 0.05, 0.05}, {0.05, 0.05, 0.05, 0.05}},               {{0.0597, 0.0396, 0.0269, 0.05}, {0.0481, 0.0219, 0.0213, 0.05}}};
 
+[TPPair]
+mass/F
+mass2/F
+
 {EventMonophoton>EventBase}
 npv/s
 npvTrue/s
@@ -50,3 +54,17 @@ photons.matchedGen->genParticles
 genParticles.parent->genParticles
 jets.matchedGenJet->genJets
 #include "Event.h"
+
+{EventTPPhoton>EventBase}
+npv/s
+npvTrue/s
+rho/F
+sample/i
+tp/TPPairCollection(32)
+tags/LeptonCollection(32)
+looseTags/LeptonCollection(32)
+probes/XPhotonCollection(32)
+jets/JetCollection(64)
+t1Met/RecoMet
+#include "Event.h"
+#include "EventMonophoton.h"

--- a/lib/panda/branch.py
+++ b/lib/panda/branch.py
@@ -242,4 +242,4 @@ class Branch(Definition):
         out.writeline(self.initializer)
 
     def write_dump(self, out):
-        out.writeline('_out << "{name}" << {name} << std::endl;'.format(name = self.name))
+        out.writeline('_out << "{name} = " << {name} << std::endl;'.format(name = self.name))

--- a/lib/panda/branch.py
+++ b/lib/panda/branch.py
@@ -240,3 +240,6 @@ class Branch(Definition):
 
     def write_init(self, out, context):
         out.writeline(self.initializer)
+
+    def write_dump(self, out):
+        out.writeline('_out << "{name}" << {name} << std::endl;'.format(name = self.name))

--- a/lib/panda/objbranch.py
+++ b/lib/panda/objbranch.py
@@ -70,3 +70,6 @@ class ObjBranch(Definition):
 
     def write_init(self, out):
         out.writeline('{name}.init();'.format(name = self.name))
+
+    def write_dump(self, out):
+        out.writeline('{name}.dump(_out);'.format(name = self.name))

--- a/lib/panda/output.py
+++ b/lib/panda/output.py
@@ -21,12 +21,13 @@ class FileOutput(object):
                     if matches is None:
                         continue
     
-                    block = line
+                    block = []
                     while True:
                         line = original.readline()
-                        block += line
                         if not line or '/* END CUSTOM */' in line:
                             break
+
+                        block.append(line[:-1]) # remove the trailing newline character
     
                     self.custom_blocks[matches.group(1)] = block
                 
@@ -57,10 +58,12 @@ class FileOutput(object):
         self._file.write((line_end + '\n').join(indented_lines) + '\n')
 
     def write_custom_block(self, block_name, default = ''):
-        try:
-            self.write(self.custom_blocks[block_name])
-        except KeyError:
-            self.writeline('/* BEGIN CUSTOM ' + block_name + ' */')
+        self.writeline('/* BEGIN CUSTOM ' + block_name + ' */')
+
+        if block_name not in self.custom_blocks or len(self.custom_blocks[block_name]) == 0:
             if default:
                 self.writeline(default)
-            self.writeline('/* END CUSTOM */')
+        else:
+            self.write('\n'.join(self.custom_blocks[block_name]) + '\n')
+
+        self.writeline('/* END CUSTOM */')

--- a/lib/panda/output.py
+++ b/lib/panda/output.py
@@ -56,9 +56,11 @@ class FileOutput(object):
 
         self._file.write((line_end + '\n').join(indented_lines) + '\n')
 
-    def write_custom_block(self, block_name):
+    def write_custom_block(self, block_name, default = ''):
         try:
             self.write(self.custom_blocks[block_name])
         except KeyError:
             self.writeline('/* BEGIN CUSTOM ' + block_name + ' */')
+            if default:
+                self.writeline(default)
             self.writeline('/* END CUSTOM */')

--- a/lib/panda/physics.py
+++ b/lib/panda/physics.py
@@ -621,8 +621,6 @@ class PhysicsObject(Definition, Object):
         src.writeline('{')
         src.indent += 1
 
-        src.writeline('_out << "<" << typeName() << ">" << std::endl;')
-
         if self.parent not in ['Singlet', 'Element']:
             src.writeline('{parent}::dump(_out);'.format(parent = self.parent))
             src.newline()

--- a/lib/panda/refbranch.py
+++ b/lib/panda/refbranch.py
@@ -160,3 +160,6 @@ class RefBranch(Branch):
         for depth in range(len(self.arrdef)):
             out.indent -= 1
             out.writeline('}')
+
+    def write_dump(self, out):
+        out.writeline('_out << "{name}" << {name} << std::endl;'.format(name = self.refname))

--- a/lib/panda/refbranch.py
+++ b/lib/panda/refbranch.py
@@ -162,4 +162,4 @@ class RefBranch(Branch):
             out.writeline('}')
 
     def write_dump(self, out):
-        out.writeline('_out << "{name}" << {name} << std::endl;'.format(name = self.refname))
+        out.writeline('_out << "{name} = " << {name} << std::endl;'.format(name = self.refname))

--- a/lib/panda/tree.py
+++ b/lib/panda/tree.py
@@ -58,6 +58,11 @@ class Tree(Definition, Object):
         header.writeline('~{name}() {{}}'.format(name = self.name)) # destructor
         header.writeline('{name}& operator=({name} const&);'.format(name = self.name)) # assignment operator
 
+        header.newline()
+
+        header.writeline('void print(std::ostream& = std::cout, UInt_t level = 1) const override;')
+        header.writeline('void dump(std::ostream& = std::cout) const override;')
+
         if len(self.functions) != 0:
             header.newline()
             for function in self.functions:
@@ -207,6 +212,37 @@ class Tree(Definition, Object):
         src.indent -= 1
         src.writeline('}')
         src.newline()
+
+        src.newline()
+        src.writeline('void')
+        src.writeline('{NAMESPACE}::{name}::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const'.format(NAMESPACE = NAMESPACE, name = self.name))
+        src.writeline('{')
+        src.indent += 1
+        src.write_custom_block('{name}.cc.print'.format(name = self.name), default = 'dump(_out);')
+        src.indent -= 1
+        src.writeline('}')
+
+        src.newline()
+        src.writeline('void')
+        src.writeline('{NAMESPACE}::{name}::dump(std::ostream& _out/* = std::cout*/) const'.format(NAMESPACE = NAMESPACE, name = self.name))
+        src.writeline('{')
+        src.indent += 1
+
+        if self.parent != 'TreeEntry':
+            src.writeline('{parent}::dump(_out);'.format(parent = self.parent))
+            src.newline()
+
+        if len(self.branches) != 0:
+            for branch in self.branches:
+                branch.write_dump(src)
+            src.newline()
+        if len(self.objbranches) != 0:
+            for objbranch in self.objbranches:
+                objbranch.write_dump(src)
+            src.newline()
+        
+        src.indent -= 1
+        src.writeline('}')
 
         src.writeline('/*static*/')
         src.writeline('panda::utils::BranchList')

--- a/obj/LinkDef.h
+++ b/obj/LinkDef.h
@@ -25,10 +25,12 @@
 #include "../Objects/interface/GenReweight.h"
 #include "../Objects/interface/Recoil.h"
 #include "../Objects/interface/XPhoton.h"
+#include "../Objects/interface/TPPair.h"
 #include "../Objects/interface/EventBase.h"
 #include "../Objects/interface/Event.h"
 #include "../Objects/interface/Run.h"
 #include "../Objects/interface/EventMonophoton.h"
+#include "../Objects/interface/EventTPPhoton.h"
 
 #ifdef __CLING__
 #pragma link off all globals;
@@ -73,6 +75,7 @@
 #pragma link C++ class panda::GenReweight;
 #pragma link C++ class panda::Recoil;
 #pragma link C++ class panda::XPhoton;
+#pragma link C++ class panda::TPPair;
 #pragma link C++ class panda::Array<panda::Particle>;
 #pragma link C++ class panda::Collection<panda::Particle>;
 #pragma link C++ class panda::Array<panda::PackedParticle>;
@@ -109,6 +112,8 @@
 #pragma link C++ class panda::Collection<panda::FatJet>;
 #pragma link C++ class panda::Array<panda::XPhoton>;
 #pragma link C++ class panda::Collection<panda::XPhoton>;
+#pragma link C++ class panda::Array<panda::TPPair>;
+#pragma link C++ class panda::Collection<panda::TPPair>;
 #pragma link C++ typedef panda::ParticleArray;
 #pragma link C++ typedef panda::ParticleCollection;
 #pragma link C++ typedef panda::PackedParticleArray;
@@ -145,9 +150,12 @@
 #pragma link C++ typedef panda::FatJetCollection;
 #pragma link C++ typedef panda::XPhotonArray;
 #pragma link C++ typedef panda::XPhotonCollection;
+#pragma link C++ typedef panda::TPPairArray;
+#pragma link C++ typedef panda::TPPairCollection;
 #pragma link C++ class panda::EventBase;
 #pragma link C++ class panda::Event;
 #pragma link C++ class panda::Run;
 #pragma link C++ class panda::EventMonophoton;
+#pragma link C++ class panda::EventTPPhoton;
 
 #endif


### PR DESCRIPTION
The brute force dump strategy is a bit too much information for full event dumps, so I wrote actual print functions for the "core" objects for monophoton. I believe I covered all the commonly used classes besides generator level info and fat jets. 

Print function has a few levels of output:
3 --> print everything, replicates dump functionality plus maybe some additional functions that aren't members of the class (see Muons.cc)
2 --> debug level, prints only variables that are commonly used in analyses
1--> info level, probably never want this to happen per event, so nothing special right now
0 --> silent, don't print anything

This PR should probably be merged after yutaro's  #PR #13 