### PR TITLE
fixing packing of mass

### DIFF
--- a/Objects/src/PackedParticle.cc
+++ b/Objects/src/PackedParticle.cc
@@ -418,7 +418,7 @@ panda::PackedParticle::pack_()
   packedPt = PackingHelper::singleton().packUnbound(pt_);
   packedEta = std::round(eta_ / 6.0f * std::numeric_limits<Short_t>::max());
   packedPhi = std::round(phi_/3.2f*std::numeric_limits<Short_t>::max());
-  packedM = PackingHelper::singleton().packUnbound(pt_);
+  packedM = PackingHelper::singleton().packUnbound(mass_);
 
   packMore_();
 }


### PR DESCRIPTION
Reported by @dabercro . We were packing pt_ -> packedM instead of mass_ -> packedM. Fixed.