### PR TITLE
EGM tweaks

### DIFF
--- a/Objects/interface/Electron.h
+++ b/Objects/interface/Electron.h
@@ -70,8 +70,8 @@ namespace panda {
       Float_t* sipip{0};
       Float_t* eseed{0};
       Float_t* hOverE{0};
-      Float_t* rawPt{0};
       Float_t* regPt{0};
+      Float_t* smearedPt{0};
       Float_t* originalPt{0};
       Bool_t* veto{0};
       Bool_t (*triggerMatch)[nTriggerObjects]{0};
@@ -133,8 +133,8 @@ namespace panda {
     Float_t& sipip;
     Float_t& eseed;
     Float_t& hOverE;
-    Float_t& rawPt;
     Float_t& regPt;
+    Float_t& smearedPt;
     Float_t& originalPt;
     Bool_t& veto;
     Bool_t (&triggerMatch)[nTriggerObjects];

--- a/Objects/interface/Photon.h
+++ b/Objects/interface/Photon.h
@@ -66,8 +66,8 @@ namespace panda {
       Float_t* phiWidth{0};
       Float_t* time{0};
       Float_t* timeSpan{0};
-      Float_t* rawPt{0};
       Float_t* regPt{0};
+      Float_t* smearedPt{0};
       Float_t* originalPt{0};
       Bool_t* loose{0};
       Bool_t* medium{0};
@@ -131,8 +131,8 @@ namespace panda {
     Float_t& phiWidth;
     Float_t& time;
     Float_t& timeSpan;
-    Float_t& rawPt;
     Float_t& regPt;
+    Float_t& smearedPt;
     Float_t& originalPt;
     Bool_t& loose;
     Bool_t& medium;

--- a/Objects/interface/XPhoton.h
+++ b/Objects/interface/XPhoton.h
@@ -48,8 +48,8 @@ namespace panda {
       Float_t* phiWidth{0};
       Float_t* time{0};
       Float_t* timeSpan{0};
-      Float_t* rawPt{0};
       Float_t* regPt{0};
+      Float_t* smearedPt{0};
       Float_t* originalPt{0};
       Bool_t* loose{0};
       Bool_t* medium{0};
@@ -131,8 +131,8 @@ namespace panda {
     Float_t& phiWidth;
     Float_t& time;
     Float_t& timeSpan;
-    Float_t& rawPt;
     Float_t& regPt;
+    Float_t& smearedPt;
     Float_t& originalPt;
     Bool_t& loose;
     Bool_t& medium;

--- a/Objects/src/Electron.cc
+++ b/Objects/src/Electron.cc
@@ -24,7 +24,7 @@ panda::Electron::getListOfBranches()
 {
   utils::BranchList blist;
   blist += Lepton::getListOfBranches();
-  blist += {"hltsafe", "chIsoPh", "nhIsoPh", "phIsoPh", "ecalIso", "hcalIso", "isoPUOffset", "sieie", "sipip", "eseed", "hOverE", "rawPt", "regPt", "originalPt", "veto", "triggerMatch", "superCluster_"};
+  blist += {"hltsafe", "chIsoPh", "nhIsoPh", "phIsoPh", "ecalIso", "hcalIso", "isoPUOffset", "sieie", "sipip", "eseed", "hOverE", "regPt", "smearedPt", "originalPt", "veto", "triggerMatch", "superCluster_"};
   return blist;
 }
 
@@ -44,8 +44,8 @@ panda::Electron::datastore::allocate(UInt_t _nmax)
   sipip = new Float_t[nmax_];
   eseed = new Float_t[nmax_];
   hOverE = new Float_t[nmax_];
-  rawPt = new Float_t[nmax_];
   regPt = new Float_t[nmax_];
+  smearedPt = new Float_t[nmax_];
   originalPt = new Float_t[nmax_];
   veto = new Bool_t[nmax_];
   triggerMatch = new Bool_t[nmax_][nTriggerObjects];
@@ -79,10 +79,10 @@ panda::Electron::datastore::deallocate()
   eseed = 0;
   delete [] hOverE;
   hOverE = 0;
-  delete [] rawPt;
-  rawPt = 0;
   delete [] regPt;
   regPt = 0;
+  delete [] smearedPt;
+  smearedPt = 0;
   delete [] originalPt;
   originalPt = 0;
   delete [] veto;
@@ -109,8 +109,8 @@ panda::Electron::datastore::setStatus(TTree& _tree, TString const& _name, utils:
   utils::setStatus(_tree, _name, "sipip", _branches);
   utils::setStatus(_tree, _name, "eseed", _branches);
   utils::setStatus(_tree, _name, "hOverE", _branches);
-  utils::setStatus(_tree, _name, "rawPt", _branches);
   utils::setStatus(_tree, _name, "regPt", _branches);
+  utils::setStatus(_tree, _name, "smearedPt", _branches);
   utils::setStatus(_tree, _name, "originalPt", _branches);
   utils::setStatus(_tree, _name, "veto", _branches);
   utils::setStatus(_tree, _name, "triggerMatch", _branches);
@@ -133,8 +133,8 @@ panda::Electron::datastore::getStatus(TTree& _tree, TString const& _name) const
   blist.push_back(utils::getStatus(_tree, _name, "sipip"));
   blist.push_back(utils::getStatus(_tree, _name, "eseed"));
   blist.push_back(utils::getStatus(_tree, _name, "hOverE"));
-  blist.push_back(utils::getStatus(_tree, _name, "rawPt"));
   blist.push_back(utils::getStatus(_tree, _name, "regPt"));
+  blist.push_back(utils::getStatus(_tree, _name, "smearedPt"));
   blist.push_back(utils::getStatus(_tree, _name, "originalPt"));
   blist.push_back(utils::getStatus(_tree, _name, "veto"));
   blist.push_back(utils::getStatus(_tree, _name, "triggerMatch"));
@@ -159,8 +159,8 @@ panda::Electron::datastore::setAddress(TTree& _tree, TString const& _name, utils
   utils::setAddress(_tree, _name, "sipip", sipip, _branches, _setStatus);
   utils::setAddress(_tree, _name, "eseed", eseed, _branches, _setStatus);
   utils::setAddress(_tree, _name, "hOverE", hOverE, _branches, _setStatus);
-  utils::setAddress(_tree, _name, "rawPt", rawPt, _branches, _setStatus);
   utils::setAddress(_tree, _name, "regPt", regPt, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "smearedPt", smearedPt, _branches, _setStatus);
   utils::setAddress(_tree, _name, "originalPt", originalPt, _branches, _setStatus);
   utils::setAddress(_tree, _name, "veto", veto, _branches, _setStatus);
   utils::setAddress(_tree, _name, "triggerMatch", triggerMatch, _branches, _setStatus);
@@ -185,8 +185,8 @@ panda::Electron::datastore::book(TTree& _tree, TString const& _name, utils::Bran
   utils::book(_tree, _name, "sipip", size, 'F', sipip, _branches);
   utils::book(_tree, _name, "eseed", size, 'F', eseed, _branches);
   utils::book(_tree, _name, "hOverE", size, 'F', hOverE, _branches);
-  utils::book(_tree, _name, "rawPt", size, 'F', rawPt, _branches);
   utils::book(_tree, _name, "regPt", size, 'F', regPt, _branches);
+  utils::book(_tree, _name, "smearedPt", size, 'F', smearedPt, _branches);
   utils::book(_tree, _name, "originalPt", size, 'F', originalPt, _branches);
   utils::book(_tree, _name, "veto", size, 'O', veto, _branches);
   utils::book(_tree, _name, "triggerMatch", size + TString::Format("[%d]", nTriggerObjects), 'O', triggerMatch, _branches);
@@ -209,8 +209,8 @@ panda::Electron::datastore::releaseTree(TTree& _tree, TString const& _name)
   utils::resetAddress(_tree, _name, "sipip");
   utils::resetAddress(_tree, _name, "eseed");
   utils::resetAddress(_tree, _name, "hOverE");
-  utils::resetAddress(_tree, _name, "rawPt");
   utils::resetAddress(_tree, _name, "regPt");
+  utils::resetAddress(_tree, _name, "smearedPt");
   utils::resetAddress(_tree, _name, "originalPt");
   utils::resetAddress(_tree, _name, "veto");
   utils::resetAddress(_tree, _name, "triggerMatch");
@@ -244,8 +244,8 @@ panda::Electron::Electron(char const* _name/* = ""*/) :
   sipip(gStore.getData(this).sipip[0]),
   eseed(gStore.getData(this).eseed[0]),
   hOverE(gStore.getData(this).hOverE[0]),
-  rawPt(gStore.getData(this).rawPt[0]),
   regPt(gStore.getData(this).regPt[0]),
+  smearedPt(gStore.getData(this).smearedPt[0]),
   originalPt(gStore.getData(this).originalPt[0]),
   veto(gStore.getData(this).veto[0]),
   triggerMatch(gStore.getData(this).triggerMatch[0]),
@@ -266,8 +266,8 @@ panda::Electron::Electron(Electron const& _src) :
   sipip(gStore.getData(this).sipip[0]),
   eseed(gStore.getData(this).eseed[0]),
   hOverE(gStore.getData(this).hOverE[0]),
-  rawPt(gStore.getData(this).rawPt[0]),
   regPt(gStore.getData(this).regPt[0]),
+  smearedPt(gStore.getData(this).smearedPt[0]),
   originalPt(gStore.getData(this).originalPt[0]),
   veto(gStore.getData(this).veto[0]),
   triggerMatch(gStore.getData(this).triggerMatch[0]),
@@ -286,8 +286,8 @@ panda::Electron::Electron(Electron const& _src) :
   sipip = _src.sipip;
   eseed = _src.eseed;
   hOverE = _src.hOverE;
-  rawPt = _src.rawPt;
   regPt = _src.regPt;
+  smearedPt = _src.smearedPt;
   originalPt = _src.originalPt;
   veto = _src.veto;
   std::memcpy(triggerMatch, _src.triggerMatch, sizeof(Bool_t) * nTriggerObjects);
@@ -307,8 +307,8 @@ panda::Electron::Electron(datastore& _data, UInt_t _idx) :
   sipip(_data.sipip[_idx]),
   eseed(_data.eseed[_idx]),
   hOverE(_data.hOverE[_idx]),
-  rawPt(_data.rawPt[_idx]),
   regPt(_data.regPt[_idx]),
+  smearedPt(_data.smearedPt[_idx]),
   originalPt(_data.originalPt[_idx]),
   veto(_data.veto[_idx]),
   triggerMatch(_data.triggerMatch[_idx]),
@@ -329,8 +329,8 @@ panda::Electron::Electron(ArrayBase* _array) :
   sipip(gStore.getData(this).sipip[0]),
   eseed(gStore.getData(this).eseed[0]),
   hOverE(gStore.getData(this).hOverE[0]),
-  rawPt(gStore.getData(this).rawPt[0]),
   regPt(gStore.getData(this).regPt[0]),
+  smearedPt(gStore.getData(this).smearedPt[0]),
   originalPt(gStore.getData(this).originalPt[0]),
   veto(gStore.getData(this).veto[0]),
   triggerMatch(gStore.getData(this).triggerMatch[0]),
@@ -369,8 +369,8 @@ panda::Electron::operator=(Electron const& _src)
   sipip = _src.sipip;
   eseed = _src.eseed;
   hOverE = _src.hOverE;
-  rawPt = _src.rawPt;
   regPt = _src.regPt;
+  smearedPt = _src.smearedPt;
   originalPt = _src.originalPt;
   veto = _src.veto;
   std::memcpy(triggerMatch, _src.triggerMatch, sizeof(Bool_t) * nTriggerObjects);
@@ -395,8 +395,8 @@ panda::Electron::doSetAddress_(TTree& _tree, TString const& _name, utils::Branch
   utils::setAddress(_tree, _name, "sipip", &sipip, _branches, _setStatus);
   utils::setAddress(_tree, _name, "eseed", &eseed, _branches, _setStatus);
   utils::setAddress(_tree, _name, "hOverE", &hOverE, _branches, _setStatus);
-  utils::setAddress(_tree, _name, "rawPt", &rawPt, _branches, _setStatus);
   utils::setAddress(_tree, _name, "regPt", &regPt, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "smearedPt", &smearedPt, _branches, _setStatus);
   utils::setAddress(_tree, _name, "originalPt", &originalPt, _branches, _setStatus);
   utils::setAddress(_tree, _name, "veto", &veto, _branches, _setStatus);
   utils::setAddress(_tree, _name, "triggerMatch", triggerMatch, _branches, _setStatus);
@@ -419,8 +419,8 @@ panda::Electron::doBook_(TTree& _tree, TString const& _name, utils::BranchList c
   utils::book(_tree, _name, "sipip", "", 'F', &sipip, _branches);
   utils::book(_tree, _name, "eseed", "", 'F', &eseed, _branches);
   utils::book(_tree, _name, "hOverE", "", 'F', &hOverE, _branches);
-  utils::book(_tree, _name, "rawPt", "", 'F', &rawPt, _branches);
   utils::book(_tree, _name, "regPt", "", 'F', &regPt, _branches);
+  utils::book(_tree, _name, "smearedPt", "", 'F', &smearedPt, _branches);
   utils::book(_tree, _name, "originalPt", "", 'F', &originalPt, _branches);
   utils::book(_tree, _name, "veto", "", 'O', &veto, _branches);
   utils::book(_tree, _name, "triggerMatch", TString::Format("[%d]", nTriggerObjects), 'O', triggerMatch, _branches);
@@ -443,8 +443,8 @@ panda::Electron::doInit_()
   sipip = 0.;
   eseed = 0.;
   hOverE = 0.;
-  rawPt = 0.;
   regPt = 0.;
+  smearedPt = 0.;
   originalPt = -1.;
   veto = false;
   for (auto& p0 : triggerMatch) p0 = false;
@@ -467,7 +467,8 @@ panda::Electron::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/
   else if (_level == 2) {
     Lepton::print(_out, _level);
     
-    _out << "rawPt = " << rawPt << std::endl;
+    _out << "smearedPt = " << smearedPt << std::endl;
+    _out << "regPt = " << regPt << std::endl;
     _out << "hltsafe = " << hltsafe << std::endl;
     _out << "veto = " << veto << std::endl;
 
@@ -495,8 +496,8 @@ panda::Electron::dump(std::ostream& _out/* = std::cout*/) const
   _out << "sipip = " << sipip << std::endl;
   _out << "eseed = " << eseed << std::endl;
   _out << "hOverE = " << hOverE << std::endl;
-  _out << "rawPt = " << rawPt << std::endl;
   _out << "regPt = " << regPt << std::endl;
+  _out << "smearedPt = " << smearedPt << std::endl;
   _out << "originalPt = " << originalPt << std::endl;
   _out << "veto = " << veto << std::endl;
   _out << "triggerMatch = " << triggerMatch << std::endl;

--- a/Objects/src/Photon.cc
+++ b/Objects/src/Photon.cc
@@ -25,7 +25,7 @@ panda::Photon::getListOfBranches()
 {
   utils::BranchList blist;
   blist += ParticleP::getListOfBranches();
-  blist += {"pfPt", "chIso", "chIsoMax", "nhIso", "phIso", "sieie", "sipip", "hOverE", "genIso", "mipEnergy", "emax", "e2nd", "eleft", "eright", "etop", "ebottom", "r9", "etaWidth", "phiWidth", "time", "timeSpan", "rawPt", "regPt", "originalPt", "loose", "medium", "tight", "highpt", "pixelVeto", "csafeVeto", "triggerMatch", "superCluster_", "matchedPF_", "matchedGen_"};
+  blist += {"pfPt", "chIso", "chIsoMax", "nhIso", "phIso", "sieie", "sipip", "hOverE", "genIso", "mipEnergy", "emax", "e2nd", "eleft", "eright", "etop", "ebottom", "r9", "etaWidth", "phiWidth", "time", "timeSpan", "regPt", "smearedPt", "originalPt", "loose", "medium", "tight", "highpt", "pixelVeto", "csafeVeto", "triggerMatch", "superCluster_", "matchedPF_", "matchedGen_"};
   return blist;
 }
 
@@ -55,8 +55,8 @@ panda::Photon::datastore::allocate(UInt_t _nmax)
   phiWidth = new Float_t[nmax_];
   time = new Float_t[nmax_];
   timeSpan = new Float_t[nmax_];
-  rawPt = new Float_t[nmax_];
   regPt = new Float_t[nmax_];
+  smearedPt = new Float_t[nmax_];
   originalPt = new Float_t[nmax_];
   loose = new Bool_t[nmax_];
   medium = new Bool_t[nmax_];
@@ -117,10 +117,10 @@ panda::Photon::datastore::deallocate()
   time = 0;
   delete [] timeSpan;
   timeSpan = 0;
-  delete [] rawPt;
-  rawPt = 0;
   delete [] regPt;
   regPt = 0;
+  delete [] smearedPt;
+  smearedPt = 0;
   delete [] originalPt;
   originalPt = 0;
   delete [] loose;
@@ -171,8 +171,8 @@ panda::Photon::datastore::setStatus(TTree& _tree, TString const& _name, utils::B
   utils::setStatus(_tree, _name, "phiWidth", _branches);
   utils::setStatus(_tree, _name, "time", _branches);
   utils::setStatus(_tree, _name, "timeSpan", _branches);
-  utils::setStatus(_tree, _name, "rawPt", _branches);
   utils::setStatus(_tree, _name, "regPt", _branches);
+  utils::setStatus(_tree, _name, "smearedPt", _branches);
   utils::setStatus(_tree, _name, "originalPt", _branches);
   utils::setStatus(_tree, _name, "loose", _branches);
   utils::setStatus(_tree, _name, "medium", _branches);
@@ -212,8 +212,8 @@ panda::Photon::datastore::getStatus(TTree& _tree, TString const& _name) const
   blist.push_back(utils::getStatus(_tree, _name, "phiWidth"));
   blist.push_back(utils::getStatus(_tree, _name, "time"));
   blist.push_back(utils::getStatus(_tree, _name, "timeSpan"));
-  blist.push_back(utils::getStatus(_tree, _name, "rawPt"));
   blist.push_back(utils::getStatus(_tree, _name, "regPt"));
+  blist.push_back(utils::getStatus(_tree, _name, "smearedPt"));
   blist.push_back(utils::getStatus(_tree, _name, "originalPt"));
   blist.push_back(utils::getStatus(_tree, _name, "loose"));
   blist.push_back(utils::getStatus(_tree, _name, "medium"));
@@ -255,8 +255,8 @@ panda::Photon::datastore::setAddress(TTree& _tree, TString const& _name, utils::
   utils::setAddress(_tree, _name, "phiWidth", phiWidth, _branches, _setStatus);
   utils::setAddress(_tree, _name, "time", time, _branches, _setStatus);
   utils::setAddress(_tree, _name, "timeSpan", timeSpan, _branches, _setStatus);
-  utils::setAddress(_tree, _name, "rawPt", rawPt, _branches, _setStatus);
   utils::setAddress(_tree, _name, "regPt", regPt, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "smearedPt", smearedPt, _branches, _setStatus);
   utils::setAddress(_tree, _name, "originalPt", originalPt, _branches, _setStatus);
   utils::setAddress(_tree, _name, "loose", loose, _branches, _setStatus);
   utils::setAddress(_tree, _name, "medium", medium, _branches, _setStatus);
@@ -298,8 +298,8 @@ panda::Photon::datastore::book(TTree& _tree, TString const& _name, utils::Branch
   utils::book(_tree, _name, "phiWidth", size, 'F', phiWidth, _branches);
   utils::book(_tree, _name, "time", size, 'F', time, _branches);
   utils::book(_tree, _name, "timeSpan", size, 'F', timeSpan, _branches);
-  utils::book(_tree, _name, "rawPt", size, 'F', rawPt, _branches);
   utils::book(_tree, _name, "regPt", size, 'F', regPt, _branches);
+  utils::book(_tree, _name, "smearedPt", size, 'F', smearedPt, _branches);
   utils::book(_tree, _name, "originalPt", size, 'F', originalPt, _branches);
   utils::book(_tree, _name, "loose", size, 'O', loose, _branches);
   utils::book(_tree, _name, "medium", size, 'O', medium, _branches);
@@ -339,8 +339,8 @@ panda::Photon::datastore::releaseTree(TTree& _tree, TString const& _name)
   utils::resetAddress(_tree, _name, "phiWidth");
   utils::resetAddress(_tree, _name, "time");
   utils::resetAddress(_tree, _name, "timeSpan");
-  utils::resetAddress(_tree, _name, "rawPt");
   utils::resetAddress(_tree, _name, "regPt");
+  utils::resetAddress(_tree, _name, "smearedPt");
   utils::resetAddress(_tree, _name, "originalPt");
   utils::resetAddress(_tree, _name, "loose");
   utils::resetAddress(_tree, _name, "medium");
@@ -391,8 +391,8 @@ panda::Photon::Photon(char const* _name/* = ""*/) :
   phiWidth(gStore.getData(this).phiWidth[0]),
   time(gStore.getData(this).time[0]),
   timeSpan(gStore.getData(this).timeSpan[0]),
-  rawPt(gStore.getData(this).rawPt[0]),
   regPt(gStore.getData(this).regPt[0]),
+  smearedPt(gStore.getData(this).smearedPt[0]),
   originalPt(gStore.getData(this).originalPt[0]),
   loose(gStore.getData(this).loose[0]),
   medium(gStore.getData(this).medium[0]),
@@ -430,8 +430,8 @@ panda::Photon::Photon(Photon const& _src) :
   phiWidth(gStore.getData(this).phiWidth[0]),
   time(gStore.getData(this).time[0]),
   timeSpan(gStore.getData(this).timeSpan[0]),
-  rawPt(gStore.getData(this).rawPt[0]),
   regPt(gStore.getData(this).regPt[0]),
+  smearedPt(gStore.getData(this).smearedPt[0]),
   originalPt(gStore.getData(this).originalPt[0]),
   loose(gStore.getData(this).loose[0]),
   medium(gStore.getData(this).medium[0]),
@@ -467,8 +467,8 @@ panda::Photon::Photon(Photon const& _src) :
   phiWidth = _src.phiWidth;
   time = _src.time;
   timeSpan = _src.timeSpan;
-  rawPt = _src.rawPt;
   regPt = _src.regPt;
+  smearedPt = _src.smearedPt;
   originalPt = _src.originalPt;
   loose = _src.loose;
   medium = _src.medium;
@@ -505,8 +505,8 @@ panda::Photon::Photon(datastore& _data, UInt_t _idx) :
   phiWidth(_data.phiWidth[_idx]),
   time(_data.time[_idx]),
   timeSpan(_data.timeSpan[_idx]),
-  rawPt(_data.rawPt[_idx]),
   regPt(_data.regPt[_idx]),
+  smearedPt(_data.smearedPt[_idx]),
   originalPt(_data.originalPt[_idx]),
   loose(_data.loose[_idx]),
   medium(_data.medium[_idx]),
@@ -544,8 +544,8 @@ panda::Photon::Photon(ArrayBase* _array) :
   phiWidth(gStore.getData(this).phiWidth[0]),
   time(gStore.getData(this).time[0]),
   timeSpan(gStore.getData(this).timeSpan[0]),
-  rawPt(gStore.getData(this).rawPt[0]),
   regPt(gStore.getData(this).regPt[0]),
+  smearedPt(gStore.getData(this).smearedPt[0]),
   originalPt(gStore.getData(this).originalPt[0]),
   loose(gStore.getData(this).loose[0]),
   medium(gStore.getData(this).medium[0]),
@@ -601,8 +601,8 @@ panda::Photon::operator=(Photon const& _src)
   phiWidth = _src.phiWidth;
   time = _src.time;
   timeSpan = _src.timeSpan;
-  rawPt = _src.rawPt;
   regPt = _src.regPt;
+  smearedPt = _src.smearedPt;
   originalPt = _src.originalPt;
   loose = _src.loose;
   medium = _src.medium;
@@ -644,8 +644,8 @@ panda::Photon::doSetAddress_(TTree& _tree, TString const& _name, utils::BranchLi
   utils::setAddress(_tree, _name, "phiWidth", &phiWidth, _branches, _setStatus);
   utils::setAddress(_tree, _name, "time", &time, _branches, _setStatus);
   utils::setAddress(_tree, _name, "timeSpan", &timeSpan, _branches, _setStatus);
-  utils::setAddress(_tree, _name, "rawPt", &rawPt, _branches, _setStatus);
   utils::setAddress(_tree, _name, "regPt", &regPt, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "smearedPt", &smearedPt, _branches, _setStatus);
   utils::setAddress(_tree, _name, "originalPt", &originalPt, _branches, _setStatus);
   utils::setAddress(_tree, _name, "loose", &loose, _branches, _setStatus);
   utils::setAddress(_tree, _name, "medium", &medium, _branches, _setStatus);
@@ -685,8 +685,8 @@ panda::Photon::doBook_(TTree& _tree, TString const& _name, utils::BranchList con
   utils::book(_tree, _name, "phiWidth", "", 'F', &phiWidth, _branches);
   utils::book(_tree, _name, "time", "", 'F', &time, _branches);
   utils::book(_tree, _name, "timeSpan", "", 'F', &timeSpan, _branches);
-  utils::book(_tree, _name, "rawPt", "", 'F', &rawPt, _branches);
   utils::book(_tree, _name, "regPt", "", 'F', &regPt, _branches);
+  utils::book(_tree, _name, "smearedPt", "", 'F', &smearedPt, _branches);
   utils::book(_tree, _name, "originalPt", "", 'F', &originalPt, _branches);
   utils::book(_tree, _name, "loose", "", 'O', &loose, _branches);
   utils::book(_tree, _name, "medium", "", 'O', &medium, _branches);
@@ -726,8 +726,8 @@ panda::Photon::doInit_()
   phiWidth = 0.;
   time = 0.;
   timeSpan = 0.;
-  rawPt = 0.;
   regPt = 0.;
+  smearedPt = 0.;
   originalPt = -1.;
   loose = false;
   medium = false;
@@ -755,7 +755,8 @@ panda::Photon::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) 
     ParticleP::print(_out, _level);
     
     _out << "pfPt = " << pfPt << std::endl;
-    _out << "rawPt = " << rawPt << std::endl;
+    _out << "smearedPt = " << smearedPt << std::endl;
+    _out << "regPt = " << regPt << std::endl;
     _out << "hOverE = " << hOverE << std::endl;
     _out << "chIso = " << chIso << std::endl;
     _out << "chIsoMax = " << chIsoMax << std::endl;
@@ -798,8 +799,8 @@ panda::Photon::dump(std::ostream& _out/* = std::cout*/) const
   _out << "phiWidth = " << phiWidth << std::endl;
   _out << "time = " << time << std::endl;
   _out << "timeSpan = " << timeSpan << std::endl;
-  _out << "rawPt = " << rawPt << std::endl;
   _out << "regPt = " << regPt << std::endl;
+  _out << "smearedPt = " << smearedPt << std::endl;
   _out << "originalPt = " << originalPt << std::endl;
   _out << "loose = " << loose << std::endl;
   _out << "medium = " << medium << std::endl;

--- a/panda.def
+++ b/panda.def
@@ -199,8 +199,8 @@ sieie/F
 sipip/F
 eseed/F
 hOverE/F
-rawPt/F
 regPt/F
+smearedPt/F
 originalPt/F = -1.
 veto/O
 triggerMatch[nTriggerObjects]/O
@@ -272,8 +272,8 @@ etaWidth/F
 phiWidth/F
 time/F
 timeSpan/F
-rawPt/F
 regPt/F
+smearedPt/F
 originalPt/F = -1.
 loose/O
 medium/O


### PR DESCRIPTION
Dropping `rawPt` and replacing it with `smearedPt`. Idea is that `pt_` is used for out of the box objects, and `regPt` and `smearedPt` are to store additional regression and smearing, if the user wants them.

Part of a fix for #18 and #10 