### PR TITLE
Important bugfix of copy Ctors and assignments

### DIFF
--- a/Framework/interface/ArrayBase.h
+++ b/Framework/interface/ArrayBase.h
@@ -14,8 +14,10 @@ namespace panda {
     friend class Element;
 
   public:
-    ArrayBase(ArrayBase const& src) : ContainerBase(src) {}
+    ArrayBase() = delete;
+    ArrayBase(ArrayBase const& src) = delete;
     ~ArrayBase() {}
+    ArrayBase& operator=(ArrayBase const&) = delete;
 
     void init() final;
     UInt_t size() const final { return getData().nmax(); }

--- a/Framework/interface/CollectionBase.h
+++ b/Framework/interface/CollectionBase.h
@@ -15,7 +15,8 @@ namespace panda {
    */
   class CollectionBase : public ContainerBase {
   public:
-    CollectionBase(CollectionBase const& src) : ContainerBase(src), size_(src.size_) {}
+    CollectionBase() = delete;
+    CollectionBase(CollectionBase const& src) = delete;
     ~CollectionBase() {}
 
     Int_t getEntry(TTree&, Long64_t entry) final;

--- a/Framework/interface/ContainerBase.h
+++ b/Framework/interface/ContainerBase.h
@@ -17,9 +17,10 @@ namespace panda {
    */
   class ContainerBase : public Object {
   public:
-    ContainerBase() {}
-    ContainerBase(ContainerBase const& src) : Object(), name_(src.name_), unitSize_(src.unitSize_) {}
+    ContainerBase() = delete;
+    ContainerBase(ContainerBase const&) = delete;
     virtual ~ContainerBase() {}
+    ContainerBase& operator=(ContainerBase const&) = delete;
 
     void setStatus(TTree&, utils::BranchList const& blist) final;
     utils::BranchList getStatus(TTree&) const final;

--- a/Framework/interface/Element.h
+++ b/Framework/interface/Element.h
@@ -64,6 +64,8 @@ namespace panda {
     typedef ArrayBase array_type;
     typedef CollectionBase collection_type;
 
+    //! Disabled default constructor.
+    Element() = delete;
     //! Standard constructor.
     Element(datastore&, UInt_t) {}
     //! Copy constructor.
@@ -106,10 +108,6 @@ namespace panda {
     virtual void doSetAddress_(TTree&, TString const&, utils::BranchList const&, Bool_t setStatus) = 0;
     virtual void doBook_(TTree&, TString const&, utils::BranchList const&) = 0;
     virtual void doInit_() = 0;
-
-  private:
-    //! Hidden default constructor.
-    Element() {}
   };
 
   namespace utils {

--- a/Framework/interface/TreeEntry.h
+++ b/Framework/interface/TreeEntry.h
@@ -18,8 +18,11 @@ namespace panda {
    */
   class TreeEntry : public Object {
   public:
-    TreeEntry() {}
+    TreeEntry() : Object() {}
+    TreeEntry(TreeEntry const& src) : Object (src) {}
     virtual ~TreeEntry() {}
+    // Important to have this implemented - otherwise the TreeEntries will start copying the objects_ vectors!
+    TreeEntry& operator=(TreeEntry const&) { return *this; }
 
     void setStatus(TTree&, utils::BranchList const& blist) final;
     utils::BranchList getStatus(TTree&) const final;


### PR DESCRIPTION
Some classes (TreeEntry in particular) was using an compiler-generated copy Ctor and assignment operator, leading to unexpected behavior.

Bug: With
`event1 = event2;`,
`objects_` vector of `event1` is replaced with that of `event2`, so `event1.init()` will now suddenly start initializing `event2` collections.

Fixed by explicitly defining / disabling various Ctors.