### PR TITLE
adding unpacked versions of GenParticle and PFCand

### DIFF
--- a/Objects/interface/EventMonophoton.h
+++ b/Objects/interface/EventMonophoton.h
@@ -3,6 +3,7 @@
 #include "EventBase.h"
 #include "Constants.h"
 #include "GenReweight.h"
+#include "RecoVertex.h"
 #include "SuperCluster.h"
 #include "Electron.h"
 #include "Muon.h"
@@ -10,7 +11,8 @@
 #include "XPhoton.h"
 #include "Jet.h"
 #include "GenJet.h"
-#include "GenParticle.h"
+#include "UnpackedGenParticle.h"
+#include "Vertex.h"
 #include "Parton.h"
 #include "RecoMet.h"
 #include "Met.h"
@@ -30,6 +32,7 @@ namespace panda {
     void dump(std::ostream& = std::cout) const override;
 
     GenReweight genReweight = GenReweight("genReweight");
+    RecoVertexCollection vertices = RecoVertexCollection("vertices", 64);
     SuperClusterCollection superClusters = SuperClusterCollection("superClusters", 64);
     ElectronCollection electrons = ElectronCollection("electrons", 32);
     MuonCollection muons = MuonCollection("muons", 32);
@@ -37,7 +40,8 @@ namespace panda {
     XPhotonCollection photons = XPhotonCollection("photons", 32);
     JetCollection jets = JetCollection("jets", 64);
     GenJetCollection genJets = GenJetCollection("genJets", 64);
-    GenParticleCollection genParticles = GenParticleCollection("genParticles", 256);
+    UnpackedGenParticleCollection genParticles = UnpackedGenParticleCollection("genParticles", 256);
+    Vertex genVertex = Vertex("genVertex");
     PartonCollection partons = PartonCollection("partons", 8);
     RecoMet t1Met = RecoMet("t1Met");
     Met rawMet = Met("rawMet");
@@ -65,6 +69,7 @@ namespace panda {
   public:
     /* BEGIN CUSTOM EventMonophoton.h.classdef */
     EventMonophoton& operator=(Event const&);
+    void copyGenParticles(GenParticleCollection const&);
     /* END CUSTOM */
   };
 

--- a/Objects/interface/GenParticle.h
+++ b/Objects/interface/GenParticle.h
@@ -75,6 +75,8 @@ namespace panda {
     void print(std::ostream& = std::cout, UInt_t level = 1) const override;
     void dump(std::ostream& = std::cout) const override;
 
+    bool testFlag(StatusFlag f) const { return ((statusFlags >> f) & 1) == 1; }
+
     /* PackedParticle
     UShort_t& packedPt;
     Short_t& packedEta;

--- a/Objects/interface/UnpackedGenParticle.h
+++ b/Objects/interface/UnpackedGenParticle.h
@@ -1,0 +1,102 @@
+#ifndef PandaTree_Objects_UnpackedGenParticle_h
+#define PandaTree_Objects_UnpackedGenParticle_h
+#include "Constants.h"
+#include "ParticleM.h"
+#include "../../Framework/interface/Array.h"
+#include "../../Framework/interface/Collection.h"
+#include "../../Framework/interface/Ref.h"
+#include "../../Framework/interface/RefVector.h"
+#include "GenParticle.h"
+
+namespace panda {
+
+  class UnpackedGenParticle : public ParticleM {
+  public:
+    struct datastore : public ParticleM::datastore {
+      datastore() : ParticleM::datastore() {}
+      ~datastore() { deallocate(); }
+
+      /* ParticleP
+      Float_t* pt_{0};
+      Float_t* eta_{0};
+      Float_t* phi_{0};
+      */
+      /* ParticleM
+      Float_t* mass_{0};
+      */
+      Int_t* pdgid{0};
+      Bool_t* finalState{0};
+      UShort_t* statusFlags{0};
+      ContainerBase const* parentContainer_{0};
+      Short_t* parent_{0};
+
+      void allocate(UInt_t n) override;
+      void deallocate() override;
+      void setStatus(TTree&, TString const&, utils::BranchList const&) override;
+      utils::BranchList getStatus(TTree&, TString const&) const override;
+      utils::BranchList getBranchNames(TString const& = "") const override;
+      void setAddress(TTree&, TString const&, utils::BranchList const& = {"*"}, Bool_t setStatus = kTRUE) override;
+      void book(TTree&, TString const&, utils::BranchList const& = {"*"}, Bool_t dynamic = kTRUE) override;
+      void releaseTree(TTree&, TString const&) override;
+      void resizeVectors_(UInt_t) override;
+    };
+
+    typedef Array<UnpackedGenParticle> array_type;
+    typedef Collection<UnpackedGenParticle> collection_type;
+
+    typedef ParticleM base_type;
+
+    UnpackedGenParticle(char const* name = "");
+    UnpackedGenParticle(UnpackedGenParticle const&);
+    UnpackedGenParticle(datastore&, UInt_t idx);
+    ~UnpackedGenParticle();
+    UnpackedGenParticle& operator=(UnpackedGenParticle const&);
+
+    static char const* typeName() { return "UnpackedGenParticle"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
+
+    Int_t& pdgid;
+    Bool_t& finalState;
+    UShort_t& statusFlags;
+    Ref<UnpackedGenParticle> parent;
+
+  protected:
+    /* ParticleP
+    Float_t& pt_;
+    Float_t& eta_;
+    Float_t& phi_;
+    */
+    /* ParticleM
+    Float_t& mass_;
+    */
+
+  public:
+    /* BEGIN CUSTOM UnpackedGenParticle.h.classdef */
+    UnpackedGenParticle& operator=(GenParticle const&);
+    /* END CUSTOM */
+
+    static utils::BranchList getListOfBranches();
+
+    void destructor() override;
+
+  protected:
+    UnpackedGenParticle(ArrayBase*);
+
+    void doSetAddress_(TTree&, TString const&, utils::BranchList const& = {"*"}, Bool_t setStatus = kTRUE) override;
+    void doBook_(TTree&, TString const&, utils::BranchList const& = {"*"}) override;
+    void doInit_() override;
+  };
+
+  typedef Array<UnpackedGenParticle> UnpackedGenParticleArray;
+  typedef Collection<UnpackedGenParticle> UnpackedGenParticleCollection;
+  typedef Ref<UnpackedGenParticle> UnpackedGenParticleRef;
+  typedef RefVector<UnpackedGenParticle> UnpackedGenParticleRefVector;
+
+  /* BEGIN CUSTOM UnpackedGenParticle.h.global */
+  /* END CUSTOM */
+
+}
+
+#endif

--- a/Objects/interface/UnpackedPFCand.h
+++ b/Objects/interface/UnpackedPFCand.h
@@ -1,0 +1,130 @@
+#ifndef PandaTree_Objects_UnpackedPFCand_h
+#define PandaTree_Objects_UnpackedPFCand_h
+#include "Constants.h"
+#include "ParticleM.h"
+#include "../../Framework/interface/Array.h"
+#include "../../Framework/interface/Collection.h"
+#include "../../Framework/interface/Ref.h"
+#include "../../Framework/interface/RefVector.h"
+#include "PFCand.h"
+#include "Vertex.h"
+
+namespace panda {
+
+  class UnpackedPFCand : public ParticleM {
+  public:
+    enum PType {
+      hp,
+      hm,
+      ep,
+      em,
+      mup,
+      mum,
+      gamma,
+      h0,
+      h_HF,
+      egamma_HF,
+      Xp,
+      Xm,
+      X,
+      nPTypes
+    };
+
+    static TString PTypeName[nPTypes];
+
+    static int q_[nPTypes];
+    static int pdgId_[nPTypes];
+
+    struct datastore : public ParticleM::datastore {
+      datastore() : ParticleM::datastore() {}
+      ~datastore() { deallocate(); }
+
+      /* ParticleP
+      Float_t* pt_{0};
+      Float_t* eta_{0};
+      Float_t* phi_{0};
+      */
+      /* ParticleM
+      Float_t* mass_{0};
+      */
+      Char_t* puppiW{0};
+      Char_t* puppiWNoLep{0};
+      UChar_t* ptype{0};
+      ContainerBase const* vertexContainer_{0};
+      Short_t* vertex_{0};
+
+      void allocate(UInt_t n) override;
+      void deallocate() override;
+      void setStatus(TTree&, TString const&, utils::BranchList const&) override;
+      utils::BranchList getStatus(TTree&, TString const&) const override;
+      utils::BranchList getBranchNames(TString const& = "") const override;
+      void setAddress(TTree&, TString const&, utils::BranchList const& = {"*"}, Bool_t setStatus = kTRUE) override;
+      void book(TTree&, TString const&, utils::BranchList const& = {"*"}, Bool_t dynamic = kTRUE) override;
+      void releaseTree(TTree&, TString const&) override;
+      void resizeVectors_(UInt_t) override;
+    };
+
+    typedef Array<UnpackedPFCand> array_type;
+    typedef Collection<UnpackedPFCand> collection_type;
+
+    typedef ParticleM base_type;
+
+    UnpackedPFCand(char const* name = "");
+    UnpackedPFCand(UnpackedPFCand const&);
+    UnpackedPFCand(datastore&, UInt_t idx);
+    ~UnpackedPFCand();
+    UnpackedPFCand& operator=(UnpackedPFCand const&);
+
+    static char const* typeName() { return "UnpackedPFCand"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
+
+    TLorentzVector puppiP4() const { TLorentzVector p4; p4.SetPtEtaPhiM(pt() * puppiW, eta(), phi(), m() * puppiW); return p4; }
+    TLorentzVector puppiNoLepP4() const { TLorentzVector p4; p4.SetPtEtaPhiM(pt() * puppiWNoLep, eta(), phi(), m() * puppiWNoLep); return p4; }
+    int q() const { return q_[ptype]; }
+    int pdgId() const { return pdgId_[ptype]; }
+
+    Char_t& puppiW;
+    Char_t& puppiWNoLep;
+    UChar_t& ptype;
+    Ref<Vertex> vertex;
+
+  protected:
+    /* ParticleP
+    Float_t& pt_;
+    Float_t& eta_;
+    Float_t& phi_;
+    */
+    /* ParticleM
+    Float_t& mass_;
+    */
+
+  public:
+    /* BEGIN CUSTOM UnpackedPFCand.h.classdef */
+    UnpackedPFCand& operator=(PFCand const&);
+    /* END CUSTOM */
+
+    static utils::BranchList getListOfBranches();
+
+    void destructor() override;
+
+  protected:
+    UnpackedPFCand(ArrayBase*);
+
+    void doSetAddress_(TTree&, TString const&, utils::BranchList const& = {"*"}, Bool_t setStatus = kTRUE) override;
+    void doBook_(TTree&, TString const&, utils::BranchList const& = {"*"}) override;
+    void doInit_() override;
+  };
+
+  typedef Array<UnpackedPFCand> UnpackedPFCandArray;
+  typedef Collection<UnpackedPFCand> UnpackedPFCandCollection;
+  typedef Ref<UnpackedPFCand> UnpackedPFCandRef;
+  typedef RefVector<UnpackedPFCand> UnpackedPFCandRefVector;
+
+  /* BEGIN CUSTOM UnpackedPFCand.h.global */
+  /* END CUSTOM */
+
+}
+
+#endif

--- a/Objects/interface/XPhoton.h
+++ b/Objects/interface/XPhoton.h
@@ -72,6 +72,7 @@ namespace panda {
       Float_t* phIsoS15{0};
       Float_t* e4{0};
       Bool_t* isEB{0};
+      Int_t* matchedGenId{0};
 
       void allocate(UInt_t n) override;
       void deallocate() override;
@@ -152,6 +153,7 @@ namespace panda {
     Float_t& phIsoS15;
     Float_t& e4;
     Bool_t& isEB;
+    Int_t& matchedGenId;
 
   protected:
     /* ParticleP

--- a/Objects/src/EventMonophoton.cc
+++ b/Objects/src/EventMonophoton.cc
@@ -3,17 +3,13 @@
 panda::EventMonophoton::EventMonophoton() :
   EventBase()
 {
-  std::vector<Object*> myObjects{{&genReweight, &superClusters, &electrons, &muons, &taus, &photons, &jets, &genJets, &genParticles, &partons, &t1Met, &rawMet, &caloMet, &metMuOnlyFix, &metNoFix, &metFilters}};
+  std::vector<Object*> myObjects{{&genReweight, &vertices, &superClusters, &electrons, &muons, &taus, &photons, &jets, &genJets, &genParticles, &genVertex, &partons, &t1Met, &rawMet, &caloMet, &metMuOnlyFix, &metNoFix, &metFilters}};
   objects_.insert(objects_.end(), myObjects.begin(), myObjects.end());
-  std::vector<CollectionBase*> myCollections{{&superClusters, &electrons, &muons, &taus, &photons, &jets, &genJets, &genParticles, &partons}};
+  std::vector<CollectionBase*> myCollections{{&vertices, &superClusters, &electrons, &muons, &taus, &photons, &jets, &genJets, &genParticles, &partons}};
   collections_.insert(collections_.end(), myCollections.begin(), myCollections.end());
 
   electrons.data.superClusterContainer_ = &superClusters;
-  electrons.data.matchedGenContainer_ = &genParticles;
-  muons.data.matchedGenContainer_ = &genParticles;
-  taus.data.matchedGenContainer_ = &genParticles;
   photons.data.superClusterContainer_ = &superClusters;
-  photons.data.matchedGenContainer_ = &genParticles;
   genParticles.data.parentContainer_ = &genParticles;
   jets.data.matchedGenJetContainer_ = &genJets;
 }
@@ -21,6 +17,7 @@ panda::EventMonophoton::EventMonophoton() :
 panda::EventMonophoton::EventMonophoton(EventMonophoton const& _src) :
   EventBase(_src),
   genReweight(_src.genReweight),
+  vertices(_src.vertices),
   superClusters(_src.superClusters),
   electrons(_src.electrons),
   muons(_src.muons),
@@ -29,6 +26,7 @@ panda::EventMonophoton::EventMonophoton(EventMonophoton const& _src) :
   jets(_src.jets),
   genJets(_src.genJets),
   genParticles(_src.genParticles),
+  genVertex(_src.genVertex),
   partons(_src.partons),
   t1Met(_src.t1Met),
   rawMet(_src.rawMet),
@@ -41,18 +39,14 @@ panda::EventMonophoton::EventMonophoton(EventMonophoton const& _src) :
   rho(_src.rho),
   rhoCentralCalo(_src.rhoCentralCalo)
 {
-  std::vector<Object*> myObjects{{&genReweight, &superClusters, &electrons, &muons, &taus, &photons, &jets, &genJets, &genParticles, &partons, &t1Met, &rawMet, &caloMet, &metMuOnlyFix, &metNoFix, &metFilters}};
+  std::vector<Object*> myObjects{{&genReweight, &vertices, &superClusters, &electrons, &muons, &taus, &photons, &jets, &genJets, &genParticles, &genVertex, &partons, &t1Met, &rawMet, &caloMet, &metMuOnlyFix, &metNoFix, &metFilters}};
   objects_.insert(objects_.end(), myObjects.begin(), myObjects.end());
-  std::vector<CollectionBase*> myCollections{{&superClusters, &electrons, &muons, &taus, &photons, &jets, &genJets, &genParticles, &partons}};
+  std::vector<CollectionBase*> myCollections{{&vertices, &superClusters, &electrons, &muons, &taus, &photons, &jets, &genJets, &genParticles, &partons}};
   collections_.insert(collections_.end(), myCollections.begin(), myCollections.end());
 
 
   electrons.data.superClusterContainer_ = &superClusters;
-  electrons.data.matchedGenContainer_ = &genParticles;
-  muons.data.matchedGenContainer_ = &genParticles;
-  taus.data.matchedGenContainer_ = &genParticles;
   photons.data.superClusterContainer_ = &superClusters;
-  photons.data.matchedGenContainer_ = &genParticles;
   genParticles.data.parentContainer_ = &genParticles;
   jets.data.matchedGenJetContainer_ = &genJets;
   /* BEGIN CUSTOM EventMonophoton.cc.copy_ctor */
@@ -73,6 +67,7 @@ panda::EventMonophoton::operator=(EventMonophoton const& _src)
   rhoCentralCalo = _src.rhoCentralCalo;
 
   genReweight = _src.genReweight;
+  vertices = _src.vertices;
   superClusters = _src.superClusters;
   electrons = _src.electrons;
   muons = _src.muons;
@@ -81,6 +76,7 @@ panda::EventMonophoton::operator=(EventMonophoton const& _src)
   jets = _src.jets;
   genJets = _src.genJets;
   genParticles = _src.genParticles;
+  genVertex = _src.genVertex;
   partons = _src.partons;
   t1Met = _src.t1Met;
   rawMet = _src.rawMet;
@@ -90,11 +86,7 @@ panda::EventMonophoton::operator=(EventMonophoton const& _src)
   metFilters = _src.metFilters;
 
   electrons.data.superClusterContainer_ = &superClusters;
-  electrons.data.matchedGenContainer_ = &genParticles;
-  muons.data.matchedGenContainer_ = &genParticles;
-  taus.data.matchedGenContainer_ = &genParticles;
   photons.data.superClusterContainer_ = &superClusters;
-  photons.data.matchedGenContainer_ = &genParticles;
   genParticles.data.parentContainer_ = &genParticles;
   jets.data.matchedGenJetContainer_ = &genJets;
 
@@ -133,6 +125,7 @@ panda::EventMonophoton::dump(std::ostream& _out/* = std::cout*/) const
   _out << "rhoCentralCalo = " << rhoCentralCalo << std::endl;
 
   genReweight.dump(_out);
+  vertices.dump(_out);
   superClusters.dump(_out);
   electrons.dump(_out);
   muons.dump(_out);
@@ -141,6 +134,7 @@ panda::EventMonophoton::dump(std::ostream& _out/* = std::cout*/) const
   jets.dump(_out);
   genJets.dump(_out);
   genParticles.dump(_out);
+  genVertex.dump(_out);
   partons.dump(_out);
   t1Met.dump(_out);
   rawMet.dump(_out);
@@ -159,6 +153,7 @@ panda::EventMonophoton::getListOfBranches()
 
   blist += {"npv", "npvTrue", "rho", "rhoCentralCalo"};
   blist += GenReweight::getListOfBranches().fullNames("genReweight");
+  blist += RecoVertex::getListOfBranches().fullNames("vertices");
   blist += SuperCluster::getListOfBranches().fullNames("superClusters");
   blist += Electron::getListOfBranches().fullNames("electrons");
   blist += Muon::getListOfBranches().fullNames("muons");
@@ -166,7 +161,8 @@ panda::EventMonophoton::getListOfBranches()
   blist += XPhoton::getListOfBranches().fullNames("photons");
   blist += Jet::getListOfBranches().fullNames("jets");
   blist += GenJet::getListOfBranches().fullNames("genJets");
-  blist += GenParticle::getListOfBranches().fullNames("genParticles");
+  blist += UnpackedGenParticle::getListOfBranches().fullNames("genParticles");
+  blist += Vertex::getListOfBranches().fullNames("genVertex");
   blist += Parton::getListOfBranches().fullNames("partons");
   blist += RecoMet::getListOfBranches().fullNames("t1Met");
   blist += Met::getListOfBranches().fullNames("rawMet");
@@ -258,6 +254,8 @@ panda::EventMonophoton::doInit_()
 
 
 /* BEGIN CUSTOM EventMonophoton.cc.global */
+#include <map>
+
 panda::EventMonophoton&
 panda::EventMonophoton::operator=(Event const& _src)
 {
@@ -269,6 +267,7 @@ panda::EventMonophoton::operator=(Event const& _src)
   rhoCentralCalo = _src.rhoCentralCalo;
 
   genReweight = _src.genReweight;
+  vertices = _src.vertices;
   superClusters = _src.superClusters;
   electrons = _src.electrons;
   muons = _src.muons;
@@ -278,7 +277,6 @@ panda::EventMonophoton::operator=(Event const& _src)
     static_cast<Photon&>(photons[iP]) = _src.photons[iP];
   jets = _src.chsAK4Jets;
   genJets = _src.ak4GenJets;
-  genParticles = _src.genParticles;
   partons = _src.partons;
   t1Met = _src.pfMet;
   rawMet = _src.rawMet;
@@ -286,18 +284,70 @@ panda::EventMonophoton::operator=(Event const& _src)
   metMuOnlyFix = _src.metMuOnlyFix;
   metNoFix = _src.metNoFix;
   metFilters = _src.metFilters;
+  genVertex = _src.genVertex;
+  copyGenParticles(_src.genParticles);
 
   electrons.data.superClusterContainer_ = &superClusters;
-  electrons.data.matchedGenContainer_ = &genParticles;
-  muons.data.matchedGenContainer_ = &genParticles;
-  taus.data.matchedGenContainer_ = &genParticles;
   photons.data.superClusterContainer_ = &superClusters;
-  photons.data.matchedGenContainer_ = &genParticles;
   genParticles.data.parentContainer_ = &genParticles;
   jets.data.matchedGenJetContainer_ = &genJets;
   jets.data.constituentsContainer_ = 0;
 
   return *this;
+}
+
+void
+panda::EventMonophoton::copyGenParticles(GenParticleCollection const& _src)
+{
+  // only save leptons, prompt photons, and their ancestors
+  std::map<short, unsigned> parentMap;
+  genParticles.clear();
+  for (auto& part : _src) {
+    if (!part.finalState)
+      continue;
+
+    switch (std::abs(part.pdgid)) {
+    case 22:
+      if (!part.testFlag(GenParticle::kIsPrompt))
+        continue;
+      break;
+    case 11:
+    case 12:
+    case 13:
+    case 14:
+    case 15:
+    case 16:
+      break;
+    default:
+      continue;
+    }
+
+    auto& out(genParticles.create_back());
+    out = part;
+
+    auto* p(&out);
+    
+    short parentIdx(part.parent.idx());
+    while (parentIdx != -1) {
+      auto itr(parentMap.find(parentIdx));
+      if (itr == parentMap.end()) {
+        // parent particle not yet in genParticles
+        parentMap[parentIdx] = genParticles.size();
+
+        auto& srcParent(_src[parentIdx]);
+        auto& outParent(genParticles.create_back());
+        outParent = srcParent;
+        p->parent.setRef(&outParent);
+        p = &outParent;
+        parentIdx = srcParent.parent.idx();
+      }
+      else {
+        // already recorded particle; just set the parent ref
+        p->parent.setRef(&genParticles[itr->second]);
+        break;
+      }
+    }
+  }
 }
 
 /* END CUSTOM */

--- a/Objects/src/UnpackedGenParticle.cc
+++ b/Objects/src/UnpackedGenParticle.cc
@@ -1,0 +1,249 @@
+#include "../interface/UnpackedGenParticle.h"
+
+/*static*/
+panda::utils::BranchList
+panda::UnpackedGenParticle::getListOfBranches()
+{
+  utils::BranchList blist;
+  blist += ParticleM::getListOfBranches();
+  blist += {"pdgid", "finalState", "statusFlags", "parent_"};
+  return blist;
+}
+
+void
+panda::UnpackedGenParticle::datastore::allocate(UInt_t _nmax)
+{
+  ParticleM::datastore::allocate(_nmax);
+
+  pdgid = new Int_t[nmax_];
+  finalState = new Bool_t[nmax_];
+  statusFlags = new UShort_t[nmax_];
+  parent_ = new Short_t[nmax_];
+}
+
+void
+panda::UnpackedGenParticle::datastore::deallocate()
+{
+  ParticleM::datastore::deallocate();
+
+  delete [] pdgid;
+  pdgid = 0;
+  delete [] finalState;
+  finalState = 0;
+  delete [] statusFlags;
+  statusFlags = 0;
+  delete [] parent_;
+  parent_ = 0;
+}
+
+void
+panda::UnpackedGenParticle::datastore::setStatus(TTree& _tree, TString const& _name, utils::BranchList const& _branches)
+{
+  ParticleM::datastore::setStatus(_tree, _name, _branches);
+
+  utils::setStatus(_tree, _name, "pdgid", _branches);
+  utils::setStatus(_tree, _name, "finalState", _branches);
+  utils::setStatus(_tree, _name, "statusFlags", _branches);
+  utils::setStatus(_tree, _name, "parent_", _branches);
+}
+
+panda::utils::BranchList
+panda::UnpackedGenParticle::datastore::getStatus(TTree& _tree, TString const& _name) const
+{
+  utils::BranchList blist(ParticleM::datastore::getStatus(_tree, _name));
+
+  blist.push_back(utils::getStatus(_tree, _name, "pdgid"));
+  blist.push_back(utils::getStatus(_tree, _name, "finalState"));
+  blist.push_back(utils::getStatus(_tree, _name, "statusFlags"));
+  blist.push_back(utils::getStatus(_tree, _name, "parent_"));
+
+  return blist;
+}
+
+void
+panda::UnpackedGenParticle::datastore::setAddress(TTree& _tree, TString const& _name, utils::BranchList const& _branches/* = {"*"}*/, Bool_t _setStatus/* = kTRUE*/)
+{
+  ParticleM::datastore::setAddress(_tree, _name, _branches, _setStatus);
+
+  utils::setAddress(_tree, _name, "pdgid", pdgid, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "finalState", finalState, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "statusFlags", statusFlags, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "parent_", parent_, _branches, _setStatus);
+}
+
+void
+panda::UnpackedGenParticle::datastore::book(TTree& _tree, TString const& _name, utils::BranchList const& _branches/* = {"*"}*/, Bool_t _dynamic/* = kTRUE*/)
+{
+  ParticleM::datastore::book(_tree, _name, _branches, _dynamic);
+
+  TString size(_dynamic ? "[" + _name + ".size]" : TString::Format("[%d]", nmax_));
+
+  utils::book(_tree, _name, "pdgid", size, 'I', pdgid, _branches);
+  utils::book(_tree, _name, "finalState", size, 'O', finalState, _branches);
+  utils::book(_tree, _name, "statusFlags", size, 's', statusFlags, _branches);
+  utils::book(_tree, _name, "parent_", size, 'S', parent_, _branches);
+}
+
+void
+panda::UnpackedGenParticle::datastore::releaseTree(TTree& _tree, TString const& _name)
+{
+  ParticleM::datastore::releaseTree(_tree, _name);
+
+  utils::resetAddress(_tree, _name, "pdgid");
+  utils::resetAddress(_tree, _name, "finalState");
+  utils::resetAddress(_tree, _name, "statusFlags");
+  utils::resetAddress(_tree, _name, "parent_");
+}
+
+void
+panda::UnpackedGenParticle::datastore::resizeVectors_(UInt_t _size)
+{
+  ParticleM::datastore::resizeVectors_(_size);
+
+}
+
+
+panda::utils::BranchList
+panda::UnpackedGenParticle::datastore::getBranchNames(TString const& _name/* = ""*/) const
+{
+  return UnpackedGenParticle::getListOfBranches().fullNames(_name);
+}
+
+panda::UnpackedGenParticle::UnpackedGenParticle(char const* _name/* = ""*/) :
+  ParticleM(new UnpackedGenParticleArray(1, _name)),
+  pdgid(gStore.getData(this).pdgid[0]),
+  finalState(gStore.getData(this).finalState[0]),
+  statusFlags(gStore.getData(this).statusFlags[0]),
+  parent(gStore.getData(this).parentContainer_, gStore.getData(this).parent_[0])
+{
+}
+
+panda::UnpackedGenParticle::UnpackedGenParticle(UnpackedGenParticle const& _src) :
+  ParticleM(new UnpackedGenParticleArray(1, gStore.getName(&_src))),
+  pdgid(gStore.getData(this).pdgid[0]),
+  finalState(gStore.getData(this).finalState[0]),
+  statusFlags(gStore.getData(this).statusFlags[0]),
+  parent(gStore.getData(this).parentContainer_, gStore.getData(this).parent_[0])
+{
+  ParticleM::operator=(_src);
+
+  pdgid = _src.pdgid;
+  finalState = _src.finalState;
+  statusFlags = _src.statusFlags;
+  parent = _src.parent;
+}
+
+panda::UnpackedGenParticle::UnpackedGenParticle(datastore& _data, UInt_t _idx) :
+  ParticleM(_data, _idx),
+  pdgid(_data.pdgid[_idx]),
+  finalState(_data.finalState[_idx]),
+  statusFlags(_data.statusFlags[_idx]),
+  parent(_data.parentContainer_, _data.parent_[_idx])
+{
+}
+
+panda::UnpackedGenParticle::UnpackedGenParticle(ArrayBase* _array) :
+  ParticleM(_array),
+  pdgid(gStore.getData(this).pdgid[0]),
+  finalState(gStore.getData(this).finalState[0]),
+  statusFlags(gStore.getData(this).statusFlags[0]),
+  parent(gStore.getData(this).parentContainer_, gStore.getData(this).parent_[0])
+{
+}
+
+panda::UnpackedGenParticle::~UnpackedGenParticle()
+{
+  destructor();
+  gStore.free(this);
+}
+
+void
+panda::UnpackedGenParticle::destructor()
+{
+  /* BEGIN CUSTOM UnpackedGenParticle.cc.destructor */
+  /* END CUSTOM */
+
+  ParticleM::destructor();
+}
+
+panda::UnpackedGenParticle&
+panda::UnpackedGenParticle::operator=(UnpackedGenParticle const& _src)
+{
+  ParticleM::operator=(_src);
+
+  pdgid = _src.pdgid;
+  finalState = _src.finalState;
+  statusFlags = _src.statusFlags;
+  parent = _src.parent;
+
+  return *this;
+}
+
+void
+panda::UnpackedGenParticle::doSetAddress_(TTree& _tree, TString const& _name, utils::BranchList const& _branches/* = {"*"}*/, Bool_t _setStatus/* = kTRUE*/)
+{
+  ParticleM::doSetAddress_(_tree, _name, _branches, _setStatus);
+
+  utils::setAddress(_tree, _name, "pdgid", &pdgid, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "finalState", &finalState, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "statusFlags", &statusFlags, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "parent_", gStore.getData(this).parent_, _branches, true);
+}
+
+void
+panda::UnpackedGenParticle::doBook_(TTree& _tree, TString const& _name, utils::BranchList const& _branches/* = {"*"}*/)
+{
+  ParticleM::doBook_(_tree, _name, _branches);
+
+  utils::book(_tree, _name, "pdgid", "", 'I', &pdgid, _branches);
+  utils::book(_tree, _name, "finalState", "", 'O', &finalState, _branches);
+  utils::book(_tree, _name, "statusFlags", "", 's', &statusFlags, _branches);
+  utils::book(_tree, _name, "parent_", "", 'S', gStore.getData(this).parent_, _branches);
+}
+
+void
+panda::UnpackedGenParticle::doInit_()
+{
+  ParticleM::doInit_();
+
+  pdgid = 0;
+  finalState = false;
+  statusFlags = 0;
+  parent.init();
+
+  /* BEGIN CUSTOM UnpackedGenParticle.cc.doInit_ */
+  /* END CUSTOM */
+}
+
+void
+panda::UnpackedGenParticle::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
+{
+  /* BEGIN CUSTOM UnpackedGenParticle.cc.print */
+  dump(_out);
+  /* END CUSTOM */
+}
+
+void
+panda::UnpackedGenParticle::dump(std::ostream& _out/* = std::cout*/) const
+{
+  ParticleM::dump(_out);
+
+  _out << "pdgid = " << pdgid << std::endl;
+  _out << "finalState = " << finalState << std::endl;
+  _out << "statusFlags = " << statusFlags << std::endl;
+  _out << "parent = " << parent << std::endl;
+}
+
+/* BEGIN CUSTOM UnpackedGenParticle.cc.global */
+panda::UnpackedGenParticle&
+panda::UnpackedGenParticle::operator=(GenParticle const& _rhs)
+{
+  setPtEtaPhiM(_rhs.pt(), _rhs.eta(), _rhs.phi(), _rhs.m());
+  pdgid = _rhs.pdgid;
+  finalState = _rhs.finalState;
+  statusFlags = _rhs.statusFlags;
+
+  return *this;
+}
+
+/* END CUSTOM */

--- a/Objects/src/UnpackedPFCand.cc
+++ b/Objects/src/UnpackedPFCand.cc
@@ -1,0 +1,273 @@
+#include "../interface/UnpackedPFCand.h"
+
+TString panda::UnpackedPFCand::PTypeName[] = {
+  "hp",
+  "hm",
+  "ep",
+  "em",
+  "mup",
+  "mum",
+  "gamma",
+  "h0",
+  "h_HF",
+  "egamma_HF",
+  "Xp",
+  "Xm",
+  "X"
+};
+
+/*static*/
+int panda::UnpackedPFCand::q_[nPTypes] = {1, -1, 1, -1, 1, -1, 0, 0, 0, 0, 1, -1, 0};
+/*static*/
+int panda::UnpackedPFCand::pdgId_[nPTypes] = {211, -211, -11, 11, -13, 13, 22, 130, 1, 2, 0, 0, 0};
+
+/*static*/
+panda::utils::BranchList
+panda::UnpackedPFCand::getListOfBranches()
+{
+  utils::BranchList blist;
+  blist += ParticleM::getListOfBranches();
+  blist += {"puppiW", "puppiWNoLep", "ptype", "vertex_"};
+  return blist;
+}
+
+void
+panda::UnpackedPFCand::datastore::allocate(UInt_t _nmax)
+{
+  ParticleM::datastore::allocate(_nmax);
+
+  puppiW = new Char_t[nmax_];
+  puppiWNoLep = new Char_t[nmax_];
+  ptype = new UChar_t[nmax_];
+  vertex_ = new Short_t[nmax_];
+}
+
+void
+panda::UnpackedPFCand::datastore::deallocate()
+{
+  ParticleM::datastore::deallocate();
+
+  delete [] puppiW;
+  puppiW = 0;
+  delete [] puppiWNoLep;
+  puppiWNoLep = 0;
+  delete [] ptype;
+  ptype = 0;
+  delete [] vertex_;
+  vertex_ = 0;
+}
+
+void
+panda::UnpackedPFCand::datastore::setStatus(TTree& _tree, TString const& _name, utils::BranchList const& _branches)
+{
+  ParticleM::datastore::setStatus(_tree, _name, _branches);
+
+  utils::setStatus(_tree, _name, "puppiW", _branches);
+  utils::setStatus(_tree, _name, "puppiWNoLep", _branches);
+  utils::setStatus(_tree, _name, "ptype", _branches);
+  utils::setStatus(_tree, _name, "vertex_", _branches);
+}
+
+panda::utils::BranchList
+panda::UnpackedPFCand::datastore::getStatus(TTree& _tree, TString const& _name) const
+{
+  utils::BranchList blist(ParticleM::datastore::getStatus(_tree, _name));
+
+  blist.push_back(utils::getStatus(_tree, _name, "puppiW"));
+  blist.push_back(utils::getStatus(_tree, _name, "puppiWNoLep"));
+  blist.push_back(utils::getStatus(_tree, _name, "ptype"));
+  blist.push_back(utils::getStatus(_tree, _name, "vertex_"));
+
+  return blist;
+}
+
+void
+panda::UnpackedPFCand::datastore::setAddress(TTree& _tree, TString const& _name, utils::BranchList const& _branches/* = {"*"}*/, Bool_t _setStatus/* = kTRUE*/)
+{
+  ParticleM::datastore::setAddress(_tree, _name, _branches, _setStatus);
+
+  utils::setAddress(_tree, _name, "puppiW", puppiW, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "puppiWNoLep", puppiWNoLep, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "ptype", ptype, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "vertex_", vertex_, _branches, _setStatus);
+}
+
+void
+panda::UnpackedPFCand::datastore::book(TTree& _tree, TString const& _name, utils::BranchList const& _branches/* = {"*"}*/, Bool_t _dynamic/* = kTRUE*/)
+{
+  ParticleM::datastore::book(_tree, _name, _branches, _dynamic);
+
+  TString size(_dynamic ? "[" + _name + ".size]" : TString::Format("[%d]", nmax_));
+
+  utils::book(_tree, _name, "puppiW", size, 'B', puppiW, _branches);
+  utils::book(_tree, _name, "puppiWNoLep", size, 'B', puppiWNoLep, _branches);
+  utils::book(_tree, _name, "ptype", size, 'b', ptype, _branches);
+  utils::book(_tree, _name, "vertex_", size, 'S', vertex_, _branches);
+}
+
+void
+panda::UnpackedPFCand::datastore::releaseTree(TTree& _tree, TString const& _name)
+{
+  ParticleM::datastore::releaseTree(_tree, _name);
+
+  utils::resetAddress(_tree, _name, "puppiW");
+  utils::resetAddress(_tree, _name, "puppiWNoLep");
+  utils::resetAddress(_tree, _name, "ptype");
+  utils::resetAddress(_tree, _name, "vertex_");
+}
+
+void
+panda::UnpackedPFCand::datastore::resizeVectors_(UInt_t _size)
+{
+  ParticleM::datastore::resizeVectors_(_size);
+
+}
+
+
+panda::utils::BranchList
+panda::UnpackedPFCand::datastore::getBranchNames(TString const& _name/* = ""*/) const
+{
+  return UnpackedPFCand::getListOfBranches().fullNames(_name);
+}
+
+panda::UnpackedPFCand::UnpackedPFCand(char const* _name/* = ""*/) :
+  ParticleM(new UnpackedPFCandArray(1, _name)),
+  puppiW(gStore.getData(this).puppiW[0]),
+  puppiWNoLep(gStore.getData(this).puppiWNoLep[0]),
+  ptype(gStore.getData(this).ptype[0]),
+  vertex(gStore.getData(this).vertexContainer_, gStore.getData(this).vertex_[0])
+{
+}
+
+panda::UnpackedPFCand::UnpackedPFCand(UnpackedPFCand const& _src) :
+  ParticleM(new UnpackedPFCandArray(1, gStore.getName(&_src))),
+  puppiW(gStore.getData(this).puppiW[0]),
+  puppiWNoLep(gStore.getData(this).puppiWNoLep[0]),
+  ptype(gStore.getData(this).ptype[0]),
+  vertex(gStore.getData(this).vertexContainer_, gStore.getData(this).vertex_[0])
+{
+  ParticleM::operator=(_src);
+
+  puppiW = _src.puppiW;
+  puppiWNoLep = _src.puppiWNoLep;
+  ptype = _src.ptype;
+  vertex = _src.vertex;
+}
+
+panda::UnpackedPFCand::UnpackedPFCand(datastore& _data, UInt_t _idx) :
+  ParticleM(_data, _idx),
+  puppiW(_data.puppiW[_idx]),
+  puppiWNoLep(_data.puppiWNoLep[_idx]),
+  ptype(_data.ptype[_idx]),
+  vertex(_data.vertexContainer_, _data.vertex_[_idx])
+{
+}
+
+panda::UnpackedPFCand::UnpackedPFCand(ArrayBase* _array) :
+  ParticleM(_array),
+  puppiW(gStore.getData(this).puppiW[0]),
+  puppiWNoLep(gStore.getData(this).puppiWNoLep[0]),
+  ptype(gStore.getData(this).ptype[0]),
+  vertex(gStore.getData(this).vertexContainer_, gStore.getData(this).vertex_[0])
+{
+}
+
+panda::UnpackedPFCand::~UnpackedPFCand()
+{
+  destructor();
+  gStore.free(this);
+}
+
+void
+panda::UnpackedPFCand::destructor()
+{
+  /* BEGIN CUSTOM UnpackedPFCand.cc.destructor */
+  /* END CUSTOM */
+
+  ParticleM::destructor();
+}
+
+panda::UnpackedPFCand&
+panda::UnpackedPFCand::operator=(UnpackedPFCand const& _src)
+{
+  ParticleM::operator=(_src);
+
+  puppiW = _src.puppiW;
+  puppiWNoLep = _src.puppiWNoLep;
+  ptype = _src.ptype;
+  vertex = _src.vertex;
+
+  return *this;
+}
+
+void
+panda::UnpackedPFCand::doSetAddress_(TTree& _tree, TString const& _name, utils::BranchList const& _branches/* = {"*"}*/, Bool_t _setStatus/* = kTRUE*/)
+{
+  ParticleM::doSetAddress_(_tree, _name, _branches, _setStatus);
+
+  utils::setAddress(_tree, _name, "puppiW", &puppiW, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "puppiWNoLep", &puppiWNoLep, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "ptype", &ptype, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "vertex_", gStore.getData(this).vertex_, _branches, true);
+}
+
+void
+panda::UnpackedPFCand::doBook_(TTree& _tree, TString const& _name, utils::BranchList const& _branches/* = {"*"}*/)
+{
+  ParticleM::doBook_(_tree, _name, _branches);
+
+  utils::book(_tree, _name, "puppiW", "", 'B', &puppiW, _branches);
+  utils::book(_tree, _name, "puppiWNoLep", "", 'B', &puppiWNoLep, _branches);
+  utils::book(_tree, _name, "ptype", "", 'b', &ptype, _branches);
+  utils::book(_tree, _name, "vertex_", "", 'S', gStore.getData(this).vertex_, _branches);
+}
+
+void
+panda::UnpackedPFCand::doInit_()
+{
+  ParticleM::doInit_();
+
+  puppiW = 0;
+  puppiWNoLep = 0;
+  ptype = 0;
+  vertex.init();
+
+  /* BEGIN CUSTOM UnpackedPFCand.cc.doInit_ */
+  /* END CUSTOM */
+}
+
+void
+panda::UnpackedPFCand::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
+{
+  /* BEGIN CUSTOM UnpackedPFCand.cc.print */
+  dump(_out);
+  /* END CUSTOM */
+}
+
+void
+panda::UnpackedPFCand::dump(std::ostream& _out/* = std::cout*/) const
+{
+  ParticleM::dump(_out);
+
+  _out << "puppiW = " << puppiW << std::endl;
+  _out << "puppiWNoLep = " << puppiWNoLep << std::endl;
+  _out << "ptype = " << ptype << std::endl;
+  _out << "vertex = " << vertex << std::endl;
+}
+
+
+/* BEGIN CUSTOM UnpackedPFCand.cc.global */
+panda::UnpackedPFCand&
+panda::UnpackedPFCand::operator=(PFCand const& _rhs)
+{
+  setPtEtaPhiM(_rhs.pt(), _rhs.eta(), _rhs.phi(), _rhs.m());
+
+  puppiW = _rhs.puppiW();
+  puppiWNoLep = _rhs.puppiWNoLep();
+  ptype = _rhs.ptype;
+  vertex = _rhs.vertex;
+
+  return *this;
+}
+
+/* END CUSTOM */

--- a/Objects/src/XPhoton.cc
+++ b/Objects/src/XPhoton.cc
@@ -17,7 +17,7 @@ panda::XPhoton::getListOfBranches()
 {
   utils::BranchList blist;
   blist += Photon::getListOfBranches();
-  blist += {"scEta", "scRawPt", "chIsoS15", "nhIsoS15", "phIsoS15", "e4", "isEB"};
+  blist += {"scEta", "scRawPt", "chIsoS15", "nhIsoS15", "phIsoS15", "e4", "isEB", "matchedGenId"};
   return blist;
 }
 
@@ -33,6 +33,7 @@ panda::XPhoton::datastore::allocate(UInt_t _nmax)
   phIsoS15 = new Float_t[nmax_];
   e4 = new Float_t[nmax_];
   isEB = new Bool_t[nmax_];
+  matchedGenId = new Int_t[nmax_];
 }
 
 void
@@ -54,6 +55,8 @@ panda::XPhoton::datastore::deallocate()
   e4 = 0;
   delete [] isEB;
   isEB = 0;
+  delete [] matchedGenId;
+  matchedGenId = 0;
 }
 
 void
@@ -68,6 +71,7 @@ panda::XPhoton::datastore::setStatus(TTree& _tree, TString const& _name, utils::
   utils::setStatus(_tree, _name, "phIsoS15", _branches);
   utils::setStatus(_tree, _name, "e4", _branches);
   utils::setStatus(_tree, _name, "isEB", _branches);
+  utils::setStatus(_tree, _name, "matchedGenId", _branches);
 }
 
 panda::utils::BranchList
@@ -82,6 +86,7 @@ panda::XPhoton::datastore::getStatus(TTree& _tree, TString const& _name) const
   blist.push_back(utils::getStatus(_tree, _name, "phIsoS15"));
   blist.push_back(utils::getStatus(_tree, _name, "e4"));
   blist.push_back(utils::getStatus(_tree, _name, "isEB"));
+  blist.push_back(utils::getStatus(_tree, _name, "matchedGenId"));
 
   return blist;
 }
@@ -98,6 +103,7 @@ panda::XPhoton::datastore::setAddress(TTree& _tree, TString const& _name, utils:
   utils::setAddress(_tree, _name, "phIsoS15", phIsoS15, _branches, _setStatus);
   utils::setAddress(_tree, _name, "e4", e4, _branches, _setStatus);
   utils::setAddress(_tree, _name, "isEB", isEB, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "matchedGenId", matchedGenId, _branches, _setStatus);
 }
 
 void
@@ -114,6 +120,7 @@ panda::XPhoton::datastore::book(TTree& _tree, TString const& _name, utils::Branc
   utils::book(_tree, _name, "phIsoS15", size, 'F', phIsoS15, _branches);
   utils::book(_tree, _name, "e4", size, 'F', e4, _branches);
   utils::book(_tree, _name, "isEB", size, 'O', isEB, _branches);
+  utils::book(_tree, _name, "matchedGenId", size, 'I', matchedGenId, _branches);
 }
 
 void
@@ -128,6 +135,7 @@ panda::XPhoton::datastore::releaseTree(TTree& _tree, TString const& _name)
   utils::resetAddress(_tree, _name, "phIsoS15");
   utils::resetAddress(_tree, _name, "e4");
   utils::resetAddress(_tree, _name, "isEB");
+  utils::resetAddress(_tree, _name, "matchedGenId");
 }
 
 void
@@ -152,7 +160,8 @@ panda::XPhoton::XPhoton(char const* _name/* = ""*/) :
   nhIsoS15(gStore.getData(this).nhIsoS15[0]),
   phIsoS15(gStore.getData(this).phIsoS15[0]),
   e4(gStore.getData(this).e4[0]),
-  isEB(gStore.getData(this).isEB[0])
+  isEB(gStore.getData(this).isEB[0]),
+  matchedGenId(gStore.getData(this).matchedGenId[0])
 {
 }
 
@@ -164,7 +173,8 @@ panda::XPhoton::XPhoton(XPhoton const& _src) :
   nhIsoS15(gStore.getData(this).nhIsoS15[0]),
   phIsoS15(gStore.getData(this).phIsoS15[0]),
   e4(gStore.getData(this).e4[0]),
-  isEB(gStore.getData(this).isEB[0])
+  isEB(gStore.getData(this).isEB[0]),
+  matchedGenId(gStore.getData(this).matchedGenId[0])
 {
   Photon::operator=(_src);
 
@@ -175,6 +185,7 @@ panda::XPhoton::XPhoton(XPhoton const& _src) :
   phIsoS15 = _src.phIsoS15;
   e4 = _src.e4;
   isEB = _src.isEB;
+  matchedGenId = _src.matchedGenId;
 }
 
 panda::XPhoton::XPhoton(datastore& _data, UInt_t _idx) :
@@ -185,7 +196,8 @@ panda::XPhoton::XPhoton(datastore& _data, UInt_t _idx) :
   nhIsoS15(_data.nhIsoS15[_idx]),
   phIsoS15(_data.phIsoS15[_idx]),
   e4(_data.e4[_idx]),
-  isEB(_data.isEB[_idx])
+  isEB(_data.isEB[_idx]),
+  matchedGenId(_data.matchedGenId[_idx])
 {
 }
 
@@ -197,7 +209,8 @@ panda::XPhoton::XPhoton(ArrayBase* _array) :
   nhIsoS15(gStore.getData(this).nhIsoS15[0]),
   phIsoS15(gStore.getData(this).phIsoS15[0]),
   e4(gStore.getData(this).e4[0]),
-  isEB(gStore.getData(this).isEB[0])
+  isEB(gStore.getData(this).isEB[0]),
+  matchedGenId(gStore.getData(this).matchedGenId[0])
 {
 }
 
@@ -228,6 +241,7 @@ panda::XPhoton::operator=(XPhoton const& _src)
   phIsoS15 = _src.phIsoS15;
   e4 = _src.e4;
   isEB = _src.isEB;
+  matchedGenId = _src.matchedGenId;
 
   return *this;
 }
@@ -244,6 +258,7 @@ panda::XPhoton::doSetAddress_(TTree& _tree, TString const& _name, utils::BranchL
   utils::setAddress(_tree, _name, "phIsoS15", &phIsoS15, _branches, _setStatus);
   utils::setAddress(_tree, _name, "e4", &e4, _branches, _setStatus);
   utils::setAddress(_tree, _name, "isEB", &isEB, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "matchedGenId", &matchedGenId, _branches, _setStatus);
 }
 
 void
@@ -258,6 +273,7 @@ panda::XPhoton::doBook_(TTree& _tree, TString const& _name, utils::BranchList co
   utils::book(_tree, _name, "phIsoS15", "", 'F', &phIsoS15, _branches);
   utils::book(_tree, _name, "e4", "", 'F', &e4, _branches);
   utils::book(_tree, _name, "isEB", "", 'O', &isEB, _branches);
+  utils::book(_tree, _name, "matchedGenId", "", 'I', &matchedGenId, _branches);
 }
 
 void
@@ -272,6 +288,7 @@ panda::XPhoton::doInit_()
   phIsoS15 = 0.;
   e4 = 0.;
   isEB = false;
+  matchedGenId = 0;
 
   /* BEGIN CUSTOM XPhoton.cc.doInit_ */
   /* END CUSTOM */
@@ -312,6 +329,7 @@ panda::XPhoton::dump(std::ostream& _out/* = std::cout*/) const
   _out << "phIsoS15 = " << phIsoS15 << std::endl;
   _out << "e4 = " << e4 << std::endl;
   _out << "isEB = " << isEB << std::endl;
+  _out << "matchedGenId = " << matchedGenId << std::endl;
 }
 
 

--- a/defs/monophoton.def
+++ b/defs/monophoton.def
@@ -6,6 +6,7 @@ nhIsoS15/F
 phIsoS15/F
 e4/F
 isEB/O
+matchedGenId/I
 bool passCHIso(UInt_t wp) const { return chIso < chIsoCuts[1][isEB ? 0 : 1][wp]; }
 bool passNHIso(UInt_t wp) const { return nhIso < nhIsoCuts[1][isEB ? 0 : 1][wp]; }
 bool passPhIso(UInt_t wp) const { return phIso < phIsoCuts[1][isEB ? 0 : 1][wp]; }
@@ -20,16 +21,13 @@ static double const phIsoCuts[2][2][4]{{{0.81, 0.28, 0.08, 2.75}, {0.83, 0.39, 0
 static double const sieieCuts[2][2][4]{{{0.0102, 0.0102, 0.0100, 0.0105}, {0.0274, 0.0268, 0.0268, 0.028}}, {{0.01031, 0.01022, 0.00994, 0.0105}, {0.03013, 0.03001, 0.03000, 0.028}}};
 static double const hOverECuts[2][2][4]{{{0.05, 0.05, 0.05, 0.05}, {0.05, 0.05, 0.05, 0.05}},               {{0.0597, 0.0396, 0.0269, 0.05}, {0.0481, 0.0219, 0.0213, 0.05}}};
 
-[TPPair]
-mass/F
-mass2/F
-
 {EventMonophoton>EventBase}
 npv/s
 npvTrue/s
 rho/F
 rhoCentralCalo/F
 genReweight/GenReweight
+vertices/RecoVertexCollection(64)
 superClusters/SuperClusterCollection(64)
 electrons/ElectronCollection(32)
 muons/MuonCollection(32)
@@ -37,7 +35,8 @@ taus/TauCollection(64)
 photons/XPhotonCollection(32)
 jets/JetCollection(64)
 genJets/GenJetCollection(64)
-genParticles/GenParticleCollection(256)
+genParticles/UnpackedGenParticleCollection(256)
+genVertex/Vertex
 partons/PartonCollection(8)
 t1Met/RecoMet
 rawMet/Met
@@ -46,14 +45,14 @@ metMuOnlyFix/RecoMet
 metNoFix/RecoMet
 metFilters/MetFilters
 electrons.superCluster->superClusters
-electrons.matchedGen->genParticles
-muons.matchedGen->genParticles
-taus.matchedGen->genParticles
 photons.superCluster->superClusters
-photons.matchedGen->genParticles
 genParticles.parent->genParticles
 jets.matchedGenJet->genJets
 #include "Event.h"
+
+[TPPair]
+mass/F
+mass2/F
 
 {EventTPPhoton>EventBase}
 npv/s

--- a/obj/LinkDef.h
+++ b/obj/LinkDef.h
@@ -9,7 +9,9 @@
 #include "../Objects/interface/PFCand.h"
 #include "../Objects/interface/ParticleP.h"
 #include "../Objects/interface/ParticleM.h"
+#include "../Objects/interface/UnpackedPFCand.h"
 #include "../Objects/interface/Parton.h"
+#include "../Objects/interface/UnpackedGenParticle.h"
 #include "../Objects/interface/SuperCluster.h"
 #include "../Objects/interface/Lepton.h"
 #include "../Objects/interface/Electron.h"
@@ -57,7 +59,9 @@
 #pragma link C++ class panda::PFCand;
 #pragma link C++ class panda::ParticleP;
 #pragma link C++ class panda::ParticleM;
+#pragma link C++ class panda::UnpackedPFCand;
 #pragma link C++ class panda::Parton;
+#pragma link C++ class panda::UnpackedGenParticle;
 #pragma link C++ class panda::SuperCluster;
 #pragma link C++ class panda::Lepton;
 #pragma link C++ class panda::Electron;
@@ -92,8 +96,12 @@
 #pragma link C++ class panda::Collection<panda::ParticleP>;
 #pragma link C++ class panda::Array<panda::ParticleM>;
 #pragma link C++ class panda::Collection<panda::ParticleM>;
+#pragma link C++ class panda::Array<panda::UnpackedPFCand>;
+#pragma link C++ class panda::Collection<panda::UnpackedPFCand>;
 #pragma link C++ class panda::Array<panda::Parton>;
 #pragma link C++ class panda::Collection<panda::Parton>;
+#pragma link C++ class panda::Array<panda::UnpackedGenParticle>;
+#pragma link C++ class panda::Collection<panda::UnpackedGenParticle>;
 #pragma link C++ class panda::Array<panda::SuperCluster>;
 #pragma link C++ class panda::Collection<panda::SuperCluster>;
 #pragma link C++ class panda::Array<panda::Lepton>;
@@ -134,8 +142,12 @@
 #pragma link C++ typedef panda::ParticlePCollection;
 #pragma link C++ typedef panda::ParticleMArray;
 #pragma link C++ typedef panda::ParticleMCollection;
+#pragma link C++ typedef panda::UnpackedPFCandArray;
+#pragma link C++ typedef panda::UnpackedPFCandCollection;
 #pragma link C++ typedef panda::PartonArray;
 #pragma link C++ typedef panda::PartonCollection;
+#pragma link C++ typedef panda::UnpackedGenParticleArray;
+#pragma link C++ typedef panda::UnpackedGenParticleCollection;
 #pragma link C++ typedef panda::SuperClusterArray;
 #pragma link C++ typedef panda::SuperClusterCollection;
 #pragma link C++ typedef panda::LeptonArray;

--- a/panda.def
+++ b/panda.def
@@ -75,6 +75,7 @@ pdgid/I
 finalState/O
 statusFlags/s
 parent/GenParticleRef
+bool testFlag(StatusFlag f) const { return ((statusFlags >> f) & 1) == 1; }
 
 [PFCand>PackedParticle]
 packedPuppiW/B
@@ -147,8 +148,43 @@ void setXYZE(double px, double py, double pz, double e) override
   mass_ = std::sqrt(e * e - p * p);
 }
 
+[UnpackedPFCand>ParticleM]
+puppiW/B
+puppiWNoLep/B
+ptype/b
+vertex/VertexRef
+TLorentzVector puppiP4() const { TLorentzVector p4; p4.SetPtEtaPhiM(pt() * puppiW, eta(), phi(), m() * puppiW); return p4; }
+TLorentzVector puppiNoLepP4() const { TLorentzVector p4; p4.SetPtEtaPhiM(pt() * puppiWNoLep, eta(), phi(), m() * puppiWNoLep); return p4; }
+int q() const { return q_[ptype]; }
+int pdgId() const { return pdgId_[ptype]; }
+enum PType {
+  hp,
+  hm,
+  ep,
+  em,
+  mup,
+  mum,
+  gamma,
+  h0,
+  h_HF,
+  egamma_HF,
+  Xp,
+  Xm,
+  X
+};
+static const int q_[nPTypes] = {1, -1, 1, -1, 1, -1, 0, 0, 0, 0, 1, -1, 0};
+static const int pdgId_[nPTypes] = {211, -211, -11, 11, -13, 13, 22, 130, 1, 2, 0, 0, 0};
+#include "PFCand.h"
+
 [Parton>ParticleM]
 pdgid/I
+
+[UnpackedGenParticle>ParticleM]
+pdgid/I
+finalState/O
+statusFlags/s
+parent/UnpackedGenParticleRef
+#include "GenParticle.h"
 
 [SuperCluster]
 rawPt/F


### PR DESCRIPTION
For final slimmed & skimmed trees, packed particles are annoying because you want to use TTree::Draw and Scan. Adding unpacked versions.