### PR TITLE
Made Collection TChain-compatible

### DIFF
--- a/Framework/interface/CollectionBase.h
+++ b/Framework/interface/CollectionBase.h
@@ -17,7 +17,7 @@ namespace panda {
   public:
     CollectionBase() = delete;
     CollectionBase(CollectionBase const& src) = delete;
-    ~CollectionBase() {}
+    ~CollectionBase();
 
     Int_t getEntry(TTree&, Long64_t entry) final;
     Int_t fill(TTree&) final;
@@ -53,10 +53,11 @@ namespace panda {
      * Since ROOT cannot automatically take care of resizing the array, we need to load the "size"
      * branch first and reallocate memory if necessary.
      *
-     * \param tree    Tree to read the entry from.
-     * \param entry   Entry number in the input tree.
+     * \param tree       Tree to read the entry from.
+     * \param entry      Entry number in the input tree.
+     * \param localEntry If >= 0, used for GetEntry from the size branch (in place of LoadTree(entry))
      */
-    void prepareGetEntry(TTree& tree, Long64_t entry);
+    void prepareGetEntry(TTree& tree, Long64_t entry, Long64_t localEntry = -1);
 
     //! Check for address change before fill.
     void prepareFill(TTree&);
@@ -78,20 +79,45 @@ namespace panda {
     //! Size information lookahead
     UInt_t sizeIn_{0};
 
+    //! Helper class that takes care of cleaning up invalid tree pointers
+    /*!
+      CollectionBase needs to store pointers to the input/output trees and their branches
+      to be able to automatically update the linked addresses when reallocation happens.
+      We need a mechanism clean up stale pointers to trees that are already deleted.
+      TTree has a UserInfo list which can store arbitrary data. All heap-based object
+      in the list are deleted at the destruction of the tree.
+     */
+    class TreePointerCleaner : public TObject {
+    public:
+      TreePointerCleaner(CollectionBase*, TTree*, bool input);
+      ~TreePointerCleaner(); //! called in TTree destructor when UserInfo list is deleted
+
+      char const* GetName() const override { return coll_->getName(); }
+      
+      CollectionBase* getColl() const { return coll_; }
+    private:
+      CollectionBase* coll_;
+      TTree* tree_;
+      bool input_;
+    };
+
+    friend class TreePointerCleaner;
+
     //! List of inputs
     /*!
      * Store a map of tree -> (size branch, in-sync flag). Size branch is for convenience
      * (don't have to GetBranch() at every call to getEntry) and the in-synch flag indicates
-     * whether the tree has the most up-to-date branch addresses. The flag is reset at each
+     * whether the tree has the most up-to-date branch addresses. If in-synch flag equals the
+     * current TreeNumber of the tree, addresses are in synch. The flag is reset to -1 at each
      * call to reallocate.
      */
-    std::map<TTree*, std::pair<TBranch*, Bool_t>> inputs_;
+    std::map<TTree*, std::pair<TBranch*, Int_t>> inputs_;
 
     //! List of outputs
     /*!
      * When resize & reallocation happens, we need to update the addresses at the output trees too.
      */
-    std::map<TTree*, Bool_t> outputs_{};
+    std::map<TTree*, Int_t> outputs_{};
   };
 
 }

--- a/Framework/src/CollectionBase.cc
+++ b/Framework/src/CollectionBase.cc
@@ -1,6 +1,32 @@
 #include "../interface/CollectionBase.h"
 #include "../interface/IOUtils.h"
 
+#include "TList.h"
+
+panda::CollectionBase::~CollectionBase()
+{
+  auto deleteFromTree([this](TTree& _tree) {
+      auto* uinfo(_tree.GetUserInfo());
+      for (TObject* obj : *uinfo) {
+        if (obj->GetName() != this->name_)
+          continue;
+
+        auto* cleaner(dynamic_cast<TreePointerCleaner*>(obj));
+        if (cleaner && cleaner->getColl() == this) {
+          uinfo->Remove(obj);
+          delete obj;
+          break;
+        }
+      }
+    });
+
+  for (auto& input : inputs_)
+    deleteFromTree(*input.first);
+
+  for (auto& output : outputs_)
+    deleteFromTree(*output.first);
+}
+
 Int_t
 panda::CollectionBase::getEntry(TTree& _tree, Long64_t _iEntry)
 {
@@ -48,9 +74,9 @@ panda::CollectionBase::resize(UInt_t _size)
 
     // signal address change
     for (auto& input : inputs_)
-      input.second.second = false;
+      input.second.second = -1;
     for (auto& output : outputs_)
-      output.second = false;
+      output.second = -1;
   }
 
   unsigned oldSize(size_);
@@ -70,39 +96,61 @@ panda::CollectionBase::reserve(UInt_t _size)
 
     // signal address change
     for (auto& input : inputs_)
-      input.second.second = false;
+      input.second.second = -1;
     for (auto& output : outputs_)
-      output.second = false;
+      output.second = -1;
   }
 }
 
 void
-panda::CollectionBase::prepareGetEntry(TTree& _tree, Long64_t _iEntry)
+panda::CollectionBase::prepareGetEntry(TTree& _tree, Long64_t _iEntry, Long64_t _localEntry/* = -1*/)
 {
+  if (inputs_.empty())
+    return;
+
   auto&& iItr(inputs_.find(&_tree));
   if (iItr == inputs_.end())
     return;
 
-  iItr->second.first->GetEntry(_iEntry);
+  if (iItr->second.second != _tree.GetTreeNumber()) {
+    auto* branch(_tree.GetBranch(name_ + ".size"));
+    if (!branch)
+      throw std::runtime_error(("Could not find branch " + name_ + ".size in input tree").Data());
+
+    branch->SetAddress(&sizeIn_);
+    iItr->second.first = branch;
+    iItr->second.second = _tree.GetTreeNumber();
+  }
+
+  if (_localEntry < 0) {
+    // LoadTree returns the entry number on the current tree.
+    _localEntry = _tree.LoadTree(_iEntry);
+  }
+
+  iItr->second.first->GetEntry(_localEntry);
   resize(sizeIn_);
 
   // in-synch flag may be reset during resize()
-  if (!iItr->second.second) {
+  if (iItr->second.second < 0) {
+    // setStatus is false -> won't set address on branches that are turned off
     doSetAddress_(_tree, {"*"}, false, true);
-    iItr->second.second = true;
+    iItr->second.second = _tree.GetTreeNumber();
   }
 }
 
 void
 panda::CollectionBase::prepareFill(TTree& _tree)
 {
+  if (outputs_.empty())
+    return;
+
   auto&& iItr(outputs_.find(&_tree));
   if (iItr == outputs_.end())
     return;
 
-  if (!iItr->second) {
+  if (iItr->second < 0) {
     doSetAddress_(_tree, {"*"}, false, false);
-    iItr->second = true;
+    iItr->second = _tree.GetTreeNumber();
   }
 }
 
@@ -142,6 +190,9 @@ panda::CollectionBase::doGetStatus_(TTree& _tree) const
 void
 panda::CollectionBase::doSetAddress_(TTree& _tree, utils::BranchList const& _branches, Bool_t _setStatus, Bool_t _asInput)
 {
+  if (!_branches.matchesAny(getBranchNames(false)))
+    return;
+
   if (_asInput) {
     auto* branch(_tree.GetBranch(name_ + ".size"));
     if (!branch)
@@ -151,7 +202,10 @@ panda::CollectionBase::doSetAddress_(TTree& _tree, utils::BranchList const& _bra
     if (sizeStatus != 1)
       return;
 
-    inputs_[&_tree] = std::make_pair(branch, true);
+    if (inputs_.count(&_tree) == 0) {
+      inputs_.emplace(&_tree, std::make_pair(branch, _tree.GetTreeNumber()));
+      _tree.GetUserInfo()->Add(new TreePointerCleaner(this, &_tree, true));
+    }
   }
   else {
     Int_t sizeStatus(utils::setAddress(_tree, name_, "size", &size_, {"size"}, _setStatus));
@@ -169,9 +223,31 @@ panda::CollectionBase::doBook_(TTree& _tree, utils::BranchList const& _branches)
   if (!_branches.matchesAny(getBranchNames(false)))
     return;
 
+  if (outputs_.count(&_tree) != 0)
+    throw std::runtime_error(("Doubly booking collection " + name_ + " on tree").Data());
+
   _tree.Branch(name_ + ".size", &size_, "size/i");
 
   getData().book(_tree, name_, _branches, true);
 
-  outputs_[&_tree] = true;
+  outputs_.emplace(&_tree, _tree.GetTreeNumber());
+
+  _tree.GetUserInfo()->Add(new TreePointerCleaner(this, &_tree, false));
+}
+
+
+panda::CollectionBase::TreePointerCleaner::TreePointerCleaner(CollectionBase* coll, TTree* tree, bool input) :
+  coll_(coll),
+  tree_(tree),
+  input_(input)
+{
+  SetBit(kIsOnHeap);
+}
+
+panda::CollectionBase::TreePointerCleaner::~TreePointerCleaner()
+{
+  if (input_)
+    coll_->inputs_.erase(tree_);
+  else
+    coll_->outputs_.erase(tree_);
 }

--- a/Framework/src/CollectionBase.cc
+++ b/Framework/src/CollectionBase.cc
@@ -112,6 +112,13 @@ panda::CollectionBase::prepareGetEntry(TTree& _tree, Long64_t _iEntry, Long64_t 
   if (iItr == inputs_.end())
     return;
 
+  if (_localEntry < 0) {
+    // LoadTree returns the entry number on the current tree.
+    _localEntry = _tree.LoadTree(_iEntry);
+  }
+  // if _localEntry is non-negative, we assume that LoadTree is already called and therefore
+  // _tree.GetTreeNumber() returns the correct tree number for the given _iEntry.
+
   if (iItr->second.second != _tree.GetTreeNumber()) {
     auto* branch(_tree.GetBranch(name_ + ".size"));
     if (!branch)
@@ -120,11 +127,6 @@ panda::CollectionBase::prepareGetEntry(TTree& _tree, Long64_t _iEntry, Long64_t 
     branch->SetAddress(&sizeIn_);
     iItr->second.first = branch;
     iItr->second.second = _tree.GetTreeNumber();
-  }
-
-  if (_localEntry < 0) {
-    // LoadTree returns the entry number on the current tree.
-    _localEntry = _tree.LoadTree(_iEntry);
   }
 
   iItr->second.first->GetEntry(_localEntry);

--- a/Framework/src/TreeEntry.cc
+++ b/Framework/src/TreeEntry.cc
@@ -68,14 +68,17 @@ panda::TreeEntry::getEntry(TTree& _tree, Long64_t _entry)
 {
   init();
 
+  Long64_t localEntry(_tree.LoadTree(_entry));
+
   for (unsigned iC(0); iC != collections_.size(); ++iC)
-    collections_[iC]->prepareGetEntry(_tree, _entry);
+    collections_[iC]->prepareGetEntry(_tree, _entry, localEntry);
 
-  Int_t retcode = _tree.GetEntry(_entry);
+  Int_t bytes(_tree.GetEntry(_entry));
 
-  doGetEntry_(_tree, _entry);
+  if (bytes > 0)
+    doGetEntry_(_tree, _entry);
 
-  return retcode;
+  return bytes;
 }
 
 Int_t

--- a/Objects/interface/Event.h
+++ b/Objects/interface/Event.h
@@ -28,7 +28,7 @@ namespace panda {
   public:
     Event();
     Event(Event const&);
-    ~Event() {}
+    ~Event();
     Event& operator=(Event const&);
 
     void print(std::ostream& = std::cout, UInt_t level = 1) const override;

--- a/Objects/interface/EventBase.h
+++ b/Objects/interface/EventBase.h
@@ -39,9 +39,6 @@ namespace panda {
   public:
     /* BEGIN CUSTOM EventBase.h.classdef */
 
-    //! Current run object.
-    Run run;
-
     //! Use to declare a trigger path to be used in the analysis. Returns a token for the path.
     /*!
      * Call this function before the event loop for each trigger you will be using. The return value
@@ -50,7 +47,7 @@ namespace panda {
      *
      * \param path   HLT path
      */
-    UInt_t registerTrigger(char const* path) { return run.registerTrigger(path); }
+    UInt_t registerTrigger(char const* path);
 
     //! Trigger decision of the event.
     /*!
@@ -59,6 +56,34 @@ namespace panda {
      * \param token   Token returned by registerTrigger()
      */
     Bool_t triggerFired(UInt_t token) const;
+
+  private:
+    
+    //! Helper class for cleaning up runTrees_
+    /*!
+      See CollectionBase for details.
+     */
+    class TreePointerCleaner : public TObject {
+    public:
+      TreePointerCleaner(EventBase*, TTree*);
+      ~TreePointerCleaner(); //! called in TTree destructor when UserInfo list is deleted
+
+      char const* GetName() const override { return coll_->getName(); }
+      
+      EventBase* getEvent() const { return event_; }
+    private:
+      EventBase* event_;
+      TTree* tree_;
+    };
+
+    //! List of run trees linked to the run object.
+    /*!
+     event tree -> tree number, run tree 
+     */
+    std::map<TTree*, std::pair<Int_t, TTree*>> runTrees_;
+
+    //! Run object to deal with trigger menu
+    Run* run_{0};
 
     /* END CUSTOM */
   };

--- a/Objects/interface/EventBase.h
+++ b/Objects/interface/EventBase.h
@@ -4,6 +4,9 @@
 #include "Constants.h"
 #include "HLTBits.h"
 #include "Run.h"
+#include "TList.h"
+#include "TFile.h"
+#include "TKey.h"
 
 namespace panda {
 
@@ -11,7 +14,7 @@ namespace panda {
   public:
     EventBase();
     EventBase(EventBase const&);
-    ~EventBase() {}
+    ~EventBase();
     EventBase& operator=(EventBase const&);
 
     void print(std::ostream& = std::cout, UInt_t level = 1) const override;
@@ -39,6 +42,9 @@ namespace panda {
   public:
     /* BEGIN CUSTOM EventBase.h.classdef */
 
+    //! Current run object.
+    Run run;
+
     //! Use to declare a trigger path to be used in the analysis. Returns a token for the path.
     /*!
      * Call this function before the event loop for each trigger you will be using. The return value
@@ -47,7 +53,7 @@ namespace panda {
      *
      * \param path   HLT path
      */
-    UInt_t registerTrigger(char const* path);
+    UInt_t registerTrigger(char const* path) { return run.registerTrigger(path); }
 
     //! Trigger decision of the event.
     /*!
@@ -58,17 +64,16 @@ namespace panda {
     Bool_t triggerFired(UInt_t token) const;
 
   private:
-    
     //! Helper class for cleaning up runTrees_
     /*!
-      See CollectionBase for details.
+      See CollectionBase for the basic idea.
      */
     class TreePointerCleaner : public TObject {
     public:
       TreePointerCleaner(EventBase*, TTree*);
       ~TreePointerCleaner(); //! called in TTree destructor when UserInfo list is deleted
 
-      char const* GetName() const override { return coll_->getName(); }
+      char const* GetName() const override { return event_->getName(); }
       
       EventBase* getEvent() const { return event_; }
     private:
@@ -76,14 +81,13 @@ namespace panda {
       TTree* tree_;
     };
 
+    friend class TreePointerCleaner;
+
     //! List of run trees linked to the run object.
     /*!
      event tree -> tree number, run tree 
      */
     std::map<TTree*, std::pair<Int_t, TTree*>> runTrees_;
-
-    //! Run object to deal with trigger menu
-    Run* run_{0};
 
     /* END CUSTOM */
   };

--- a/Objects/interface/EventMonophoton.h
+++ b/Objects/interface/EventMonophoton.h
@@ -23,7 +23,7 @@ namespace panda {
   public:
     EventMonophoton();
     EventMonophoton(EventMonophoton const&);
-    ~EventMonophoton() {}
+    ~EventMonophoton();
     EventMonophoton& operator=(EventMonophoton const&);
 
     void print(std::ostream& = std::cout, UInt_t level = 1) const override;

--- a/Objects/interface/EventMonophoton.h
+++ b/Objects/interface/EventMonophoton.h
@@ -68,7 +68,7 @@ namespace panda {
 
   public:
     /* BEGIN CUSTOM EventMonophoton.h.classdef */
-    EventMonophoton& operator=(Event const&);
+    EventMonophoton& copy(Event const&);
     void copyGenParticles(GenParticleCollection const&);
     /* END CUSTOM */
   };

--- a/Objects/interface/EventMonophoton.h
+++ b/Objects/interface/EventMonophoton.h
@@ -3,6 +3,7 @@
 #include "EventBase.h"
 #include "Constants.h"
 #include "GenReweight.h"
+#include "RecoVertex.h"
 #include "SuperCluster.h"
 #include "Electron.h"
 #include "Muon.h"
@@ -10,7 +11,8 @@
 #include "XPhoton.h"
 #include "Jet.h"
 #include "GenJet.h"
-#include "GenParticle.h"
+#include "UnpackedGenParticle.h"
+#include "Vertex.h"
 #include "Parton.h"
 #include "RecoMet.h"
 #include "Met.h"
@@ -30,6 +32,7 @@ namespace panda {
     void dump(std::ostream& = std::cout) const override;
 
     GenReweight genReweight = GenReweight("genReweight");
+    RecoVertexCollection vertices = RecoVertexCollection("vertices", 64);
     SuperClusterCollection superClusters = SuperClusterCollection("superClusters", 64);
     ElectronCollection electrons = ElectronCollection("electrons", 32);
     MuonCollection muons = MuonCollection("muons", 32);
@@ -37,7 +40,8 @@ namespace panda {
     XPhotonCollection photons = XPhotonCollection("photons", 32);
     JetCollection jets = JetCollection("jets", 64);
     GenJetCollection genJets = GenJetCollection("genJets", 64);
-    GenParticleCollection genParticles = GenParticleCollection("genParticles", 256);
+    UnpackedGenParticleCollection genParticles = UnpackedGenParticleCollection("genParticles", 256);
+    Vertex genVertex = Vertex("genVertex");
     PartonCollection partons = PartonCollection("partons", 8);
     RecoMet t1Met = RecoMet("t1Met");
     Met rawMet = Met("rawMet");
@@ -65,6 +69,7 @@ namespace panda {
   public:
     /* BEGIN CUSTOM EventMonophoton.h.classdef */
     EventMonophoton& operator=(Event const&);
+    void copyGenParticles(GenParticleCollection const&);
     /* END CUSTOM */
   };
 

--- a/Objects/interface/EventTPPhoton.h
+++ b/Objects/interface/EventTPPhoton.h
@@ -16,7 +16,7 @@ namespace panda {
   public:
     EventTPPhoton();
     EventTPPhoton(EventTPPhoton const&);
-    ~EventTPPhoton() {}
+    ~EventTPPhoton();
     EventTPPhoton& operator=(EventTPPhoton const&);
 
     void print(std::ostream& = std::cout, UInt_t level = 1) const override;

--- a/Objects/interface/EventTPPhoton.h
+++ b/Objects/interface/EventTPPhoton.h
@@ -47,8 +47,8 @@ namespace panda {
 
   public:
     /* BEGIN CUSTOM EventTPPhoton.h.classdef */
-    EventTPPhoton& operator=(Event const&);
-    EventTPPhoton& operator=(EventMonophoton const&);
+    EventTPPhoton& copy(Event const&);
+    EventTPPhoton& copy(EventMonophoton const&);
     /* END CUSTOM */
   };
 

--- a/Objects/interface/GenParticle.h
+++ b/Objects/interface/GenParticle.h
@@ -75,6 +75,8 @@ namespace panda {
     void print(std::ostream& = std::cout, UInt_t level = 1) const override;
     void dump(std::ostream& = std::cout) const override;
 
+    bool testFlag(StatusFlag f) const { return ((statusFlags >> f) & 1) == 1; }
+
     /* PackedParticle
     UShort_t& packedPt;
     Short_t& packedEta;

--- a/Objects/interface/Run.h
+++ b/Objects/interface/Run.h
@@ -61,7 +61,10 @@ namespace panda {
     UInt_t triggerSize() const { return triggerPaths().size(); }
 
     //! Check for updates
-    void update(UInt_t runNumber, TTree& eventTree);
+    void findEntry(TTree& runTree, UInt_t runNumber);
+
+    //! Update trigger information
+    void loadTriggerTable(TFile&);
 
     struct HLTTreeEntry {
       ~HLTTreeEntry() { destroy(); }
@@ -85,6 +88,9 @@ namespace panda {
   private:
     //! Switch to enable trigger loading
     Bool_t loadTrigger_{kFALSE};
+
+    //! Cached menu number to detect menu change
+    UInt_t hltMenuCache_{-1};
 
     //! List of registered paths
     std::vector<TString> registeredTriggers_{};

--- a/Objects/interface/Run.h
+++ b/Objects/interface/Run.h
@@ -40,6 +40,12 @@ namespace panda {
     //! See description on Event::registerTrigger
     UInt_t registerTrigger(char const* path);
 
+    //! Get the registered path name for the token
+    /*!
+     * Returns an empty string for an invalid token.
+     */
+    char const* getRegisteredPath(UInt_t token) const;
+
     //! Get the trigger index for the given token
     UInt_t getTriggerIndex(UInt_t token) const;
 

--- a/Objects/interface/UnpackedGenParticle.h
+++ b/Objects/interface/UnpackedGenParticle.h
@@ -1,0 +1,102 @@
+#ifndef PandaTree_Objects_UnpackedGenParticle_h
+#define PandaTree_Objects_UnpackedGenParticle_h
+#include "Constants.h"
+#include "ParticleM.h"
+#include "../../Framework/interface/Array.h"
+#include "../../Framework/interface/Collection.h"
+#include "../../Framework/interface/Ref.h"
+#include "../../Framework/interface/RefVector.h"
+#include "GenParticle.h"
+
+namespace panda {
+
+  class UnpackedGenParticle : public ParticleM {
+  public:
+    struct datastore : public ParticleM::datastore {
+      datastore() : ParticleM::datastore() {}
+      ~datastore() { deallocate(); }
+
+      /* ParticleP
+      Float_t* pt_{0};
+      Float_t* eta_{0};
+      Float_t* phi_{0};
+      */
+      /* ParticleM
+      Float_t* mass_{0};
+      */
+      Int_t* pdgid{0};
+      Bool_t* finalState{0};
+      UShort_t* statusFlags{0};
+      ContainerBase const* parentContainer_{0};
+      Short_t* parent_{0};
+
+      void allocate(UInt_t n) override;
+      void deallocate() override;
+      void setStatus(TTree&, TString const&, utils::BranchList const&) override;
+      utils::BranchList getStatus(TTree&, TString const&) const override;
+      utils::BranchList getBranchNames(TString const& = "") const override;
+      void setAddress(TTree&, TString const&, utils::BranchList const& = {"*"}, Bool_t setStatus = kTRUE) override;
+      void book(TTree&, TString const&, utils::BranchList const& = {"*"}, Bool_t dynamic = kTRUE) override;
+      void releaseTree(TTree&, TString const&) override;
+      void resizeVectors_(UInt_t) override;
+    };
+
+    typedef Array<UnpackedGenParticle> array_type;
+    typedef Collection<UnpackedGenParticle> collection_type;
+
+    typedef ParticleM base_type;
+
+    UnpackedGenParticle(char const* name = "");
+    UnpackedGenParticle(UnpackedGenParticle const&);
+    UnpackedGenParticle(datastore&, UInt_t idx);
+    ~UnpackedGenParticle();
+    UnpackedGenParticle& operator=(UnpackedGenParticle const&);
+
+    static char const* typeName() { return "UnpackedGenParticle"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
+
+    Int_t& pdgid;
+    Bool_t& finalState;
+    UShort_t& statusFlags;
+    Ref<UnpackedGenParticle> parent;
+
+  protected:
+    /* ParticleP
+    Float_t& pt_;
+    Float_t& eta_;
+    Float_t& phi_;
+    */
+    /* ParticleM
+    Float_t& mass_;
+    */
+
+  public:
+    /* BEGIN CUSTOM UnpackedGenParticle.h.classdef */
+    UnpackedGenParticle& operator=(GenParticle const&);
+    /* END CUSTOM */
+
+    static utils::BranchList getListOfBranches();
+
+    void destructor() override;
+
+  protected:
+    UnpackedGenParticle(ArrayBase*);
+
+    void doSetAddress_(TTree&, TString const&, utils::BranchList const& = {"*"}, Bool_t setStatus = kTRUE) override;
+    void doBook_(TTree&, TString const&, utils::BranchList const& = {"*"}) override;
+    void doInit_() override;
+  };
+
+  typedef Array<UnpackedGenParticle> UnpackedGenParticleArray;
+  typedef Collection<UnpackedGenParticle> UnpackedGenParticleCollection;
+  typedef Ref<UnpackedGenParticle> UnpackedGenParticleRef;
+  typedef RefVector<UnpackedGenParticle> UnpackedGenParticleRefVector;
+
+  /* BEGIN CUSTOM UnpackedGenParticle.h.global */
+  /* END CUSTOM */
+
+}
+
+#endif

--- a/Objects/interface/UnpackedPFCand.h
+++ b/Objects/interface/UnpackedPFCand.h
@@ -1,0 +1,130 @@
+#ifndef PandaTree_Objects_UnpackedPFCand_h
+#define PandaTree_Objects_UnpackedPFCand_h
+#include "Constants.h"
+#include "ParticleM.h"
+#include "../../Framework/interface/Array.h"
+#include "../../Framework/interface/Collection.h"
+#include "../../Framework/interface/Ref.h"
+#include "../../Framework/interface/RefVector.h"
+#include "PFCand.h"
+#include "Vertex.h"
+
+namespace panda {
+
+  class UnpackedPFCand : public ParticleM {
+  public:
+    enum PType {
+      hp,
+      hm,
+      ep,
+      em,
+      mup,
+      mum,
+      gamma,
+      h0,
+      h_HF,
+      egamma_HF,
+      Xp,
+      Xm,
+      X,
+      nPTypes
+    };
+
+    static TString PTypeName[nPTypes];
+
+    static int q_[nPTypes];
+    static int pdgId_[nPTypes];
+
+    struct datastore : public ParticleM::datastore {
+      datastore() : ParticleM::datastore() {}
+      ~datastore() { deallocate(); }
+
+      /* ParticleP
+      Float_t* pt_{0};
+      Float_t* eta_{0};
+      Float_t* phi_{0};
+      */
+      /* ParticleM
+      Float_t* mass_{0};
+      */
+      Char_t* puppiW{0};
+      Char_t* puppiWNoLep{0};
+      UChar_t* ptype{0};
+      ContainerBase const* vertexContainer_{0};
+      Short_t* vertex_{0};
+
+      void allocate(UInt_t n) override;
+      void deallocate() override;
+      void setStatus(TTree&, TString const&, utils::BranchList const&) override;
+      utils::BranchList getStatus(TTree&, TString const&) const override;
+      utils::BranchList getBranchNames(TString const& = "") const override;
+      void setAddress(TTree&, TString const&, utils::BranchList const& = {"*"}, Bool_t setStatus = kTRUE) override;
+      void book(TTree&, TString const&, utils::BranchList const& = {"*"}, Bool_t dynamic = kTRUE) override;
+      void releaseTree(TTree&, TString const&) override;
+      void resizeVectors_(UInt_t) override;
+    };
+
+    typedef Array<UnpackedPFCand> array_type;
+    typedef Collection<UnpackedPFCand> collection_type;
+
+    typedef ParticleM base_type;
+
+    UnpackedPFCand(char const* name = "");
+    UnpackedPFCand(UnpackedPFCand const&);
+    UnpackedPFCand(datastore&, UInt_t idx);
+    ~UnpackedPFCand();
+    UnpackedPFCand& operator=(UnpackedPFCand const&);
+
+    static char const* typeName() { return "UnpackedPFCand"; }
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
+
+    TLorentzVector puppiP4() const { TLorentzVector p4; p4.SetPtEtaPhiM(pt() * puppiW, eta(), phi(), m() * puppiW); return p4; }
+    TLorentzVector puppiNoLepP4() const { TLorentzVector p4; p4.SetPtEtaPhiM(pt() * puppiWNoLep, eta(), phi(), m() * puppiWNoLep); return p4; }
+    int q() const { return q_[ptype]; }
+    int pdgId() const { return pdgId_[ptype]; }
+
+    Char_t& puppiW;
+    Char_t& puppiWNoLep;
+    UChar_t& ptype;
+    Ref<Vertex> vertex;
+
+  protected:
+    /* ParticleP
+    Float_t& pt_;
+    Float_t& eta_;
+    Float_t& phi_;
+    */
+    /* ParticleM
+    Float_t& mass_;
+    */
+
+  public:
+    /* BEGIN CUSTOM UnpackedPFCand.h.classdef */
+    UnpackedPFCand& operator=(PFCand const&);
+    /* END CUSTOM */
+
+    static utils::BranchList getListOfBranches();
+
+    void destructor() override;
+
+  protected:
+    UnpackedPFCand(ArrayBase*);
+
+    void doSetAddress_(TTree&, TString const&, utils::BranchList const& = {"*"}, Bool_t setStatus = kTRUE) override;
+    void doBook_(TTree&, TString const&, utils::BranchList const& = {"*"}) override;
+    void doInit_() override;
+  };
+
+  typedef Array<UnpackedPFCand> UnpackedPFCandArray;
+  typedef Collection<UnpackedPFCand> UnpackedPFCandCollection;
+  typedef Ref<UnpackedPFCand> UnpackedPFCandRef;
+  typedef RefVector<UnpackedPFCand> UnpackedPFCandRefVector;
+
+  /* BEGIN CUSTOM UnpackedPFCand.h.global */
+  /* END CUSTOM */
+
+}
+
+#endif

--- a/Objects/interface/XPhoton.h
+++ b/Objects/interface/XPhoton.h
@@ -72,6 +72,7 @@ namespace panda {
       Float_t* phIsoS15{0};
       Float_t* e4{0};
       Bool_t* isEB{0};
+      Int_t* matchedGenId{0};
 
       void allocate(UInt_t n) override;
       void deallocate() override;
@@ -152,6 +153,7 @@ namespace panda {
     Float_t& phIsoS15;
     Float_t& e4;
     Bool_t& isEB;
+    Int_t& matchedGenId;
 
   protected:
     /* ParticleP

--- a/Objects/src/Event.cc
+++ b/Objects/src/Event.cc
@@ -126,6 +126,12 @@ panda::Event::Event(Event const& _src) :
   /* END CUSTOM */
 }
 
+panda::Event::~Event()
+{
+  /* BEGIN CUSTOM Event.cc.dtor */
+  /* END CUSTOM */
+}
+
 panda::Event&
 panda::Event::operator=(Event const& _src)
 {

--- a/Objects/src/EventMonophoton.cc
+++ b/Objects/src/EventMonophoton.cc
@@ -263,9 +263,15 @@ panda::EventMonophoton::doInit_()
 #include <map>
 
 panda::EventMonophoton&
-panda::EventMonophoton::operator=(Event const& _src)
+panda::EventMonophoton::copy(Event const& _src)
 {
-  EventBase::operator=(_src);
+  runNumber = _src.runNumber;
+  lumiNumber = _src.lumiNumber;
+  eventNumber = _src.eventNumber;
+  isData = _src.isData;
+  weight = _src.weight;
+
+  triggers = _src.triggers;
 
   npv = _src.npv;
   npvTrue = _src.npvTrue;

--- a/Objects/src/EventMonophoton.cc
+++ b/Objects/src/EventMonophoton.cc
@@ -59,6 +59,12 @@ panda::EventMonophoton::EventMonophoton(EventMonophoton const& _src) :
   /* END CUSTOM */
 }
 
+panda::EventMonophoton::~EventMonophoton()
+{
+  /* BEGIN CUSTOM EventMonophoton.cc.dtor */
+  /* END CUSTOM */
+}
+
 panda::EventMonophoton&
 panda::EventMonophoton::operator=(EventMonophoton const& _src)
 {

--- a/Objects/src/EventMonophoton.cc
+++ b/Objects/src/EventMonophoton.cc
@@ -3,17 +3,13 @@
 panda::EventMonophoton::EventMonophoton() :
   EventBase()
 {
-  std::vector<Object*> myObjects{{&genReweight, &superClusters, &electrons, &muons, &taus, &photons, &jets, &genJets, &genParticles, &partons, &t1Met, &rawMet, &caloMet, &metMuOnlyFix, &metNoFix, &metFilters}};
+  std::vector<Object*> myObjects{{&genReweight, &vertices, &superClusters, &electrons, &muons, &taus, &photons, &jets, &genJets, &genParticles, &genVertex, &partons, &t1Met, &rawMet, &caloMet, &metMuOnlyFix, &metNoFix, &metFilters}};
   objects_.insert(objects_.end(), myObjects.begin(), myObjects.end());
-  std::vector<CollectionBase*> myCollections{{&superClusters, &electrons, &muons, &taus, &photons, &jets, &genJets, &genParticles, &partons}};
+  std::vector<CollectionBase*> myCollections{{&vertices, &superClusters, &electrons, &muons, &taus, &photons, &jets, &genJets, &genParticles, &partons}};
   collections_.insert(collections_.end(), myCollections.begin(), myCollections.end());
 
   electrons.data.superClusterContainer_ = &superClusters;
-  electrons.data.matchedGenContainer_ = &genParticles;
-  muons.data.matchedGenContainer_ = &genParticles;
-  taus.data.matchedGenContainer_ = &genParticles;
   photons.data.superClusterContainer_ = &superClusters;
-  photons.data.matchedGenContainer_ = &genParticles;
   genParticles.data.parentContainer_ = &genParticles;
   jets.data.matchedGenJetContainer_ = &genJets;
 }
@@ -21,6 +17,7 @@ panda::EventMonophoton::EventMonophoton() :
 panda::EventMonophoton::EventMonophoton(EventMonophoton const& _src) :
   EventBase(_src),
   genReweight(_src.genReweight),
+  vertices(_src.vertices),
   superClusters(_src.superClusters),
   electrons(_src.electrons),
   muons(_src.muons),
@@ -29,6 +26,7 @@ panda::EventMonophoton::EventMonophoton(EventMonophoton const& _src) :
   jets(_src.jets),
   genJets(_src.genJets),
   genParticles(_src.genParticles),
+  genVertex(_src.genVertex),
   partons(_src.partons),
   t1Met(_src.t1Met),
   rawMet(_src.rawMet),
@@ -41,18 +39,14 @@ panda::EventMonophoton::EventMonophoton(EventMonophoton const& _src) :
   rho(_src.rho),
   rhoCentralCalo(_src.rhoCentralCalo)
 {
-  std::vector<Object*> myObjects{{&genReweight, &superClusters, &electrons, &muons, &taus, &photons, &jets, &genJets, &genParticles, &partons, &t1Met, &rawMet, &caloMet, &metMuOnlyFix, &metNoFix, &metFilters}};
+  std::vector<Object*> myObjects{{&genReweight, &vertices, &superClusters, &electrons, &muons, &taus, &photons, &jets, &genJets, &genParticles, &genVertex, &partons, &t1Met, &rawMet, &caloMet, &metMuOnlyFix, &metNoFix, &metFilters}};
   objects_.insert(objects_.end(), myObjects.begin(), myObjects.end());
-  std::vector<CollectionBase*> myCollections{{&superClusters, &electrons, &muons, &taus, &photons, &jets, &genJets, &genParticles, &partons}};
+  std::vector<CollectionBase*> myCollections{{&vertices, &superClusters, &electrons, &muons, &taus, &photons, &jets, &genJets, &genParticles, &partons}};
   collections_.insert(collections_.end(), myCollections.begin(), myCollections.end());
 
 
   electrons.data.superClusterContainer_ = &superClusters;
-  electrons.data.matchedGenContainer_ = &genParticles;
-  muons.data.matchedGenContainer_ = &genParticles;
-  taus.data.matchedGenContainer_ = &genParticles;
   photons.data.superClusterContainer_ = &superClusters;
-  photons.data.matchedGenContainer_ = &genParticles;
   genParticles.data.parentContainer_ = &genParticles;
   jets.data.matchedGenJetContainer_ = &genJets;
   /* BEGIN CUSTOM EventMonophoton.cc.copy_ctor */
@@ -73,6 +67,7 @@ panda::EventMonophoton::operator=(EventMonophoton const& _src)
   rhoCentralCalo = _src.rhoCentralCalo;
 
   genReweight = _src.genReweight;
+  vertices = _src.vertices;
   superClusters = _src.superClusters;
   electrons = _src.electrons;
   muons = _src.muons;
@@ -81,6 +76,7 @@ panda::EventMonophoton::operator=(EventMonophoton const& _src)
   jets = _src.jets;
   genJets = _src.genJets;
   genParticles = _src.genParticles;
+  genVertex = _src.genVertex;
   partons = _src.partons;
   t1Met = _src.t1Met;
   rawMet = _src.rawMet;
@@ -90,11 +86,7 @@ panda::EventMonophoton::operator=(EventMonophoton const& _src)
   metFilters = _src.metFilters;
 
   electrons.data.superClusterContainer_ = &superClusters;
-  electrons.data.matchedGenContainer_ = &genParticles;
-  muons.data.matchedGenContainer_ = &genParticles;
-  taus.data.matchedGenContainer_ = &genParticles;
   photons.data.superClusterContainer_ = &superClusters;
-  photons.data.matchedGenContainer_ = &genParticles;
   genParticles.data.parentContainer_ = &genParticles;
   jets.data.matchedGenJetContainer_ = &genJets;
 
@@ -133,6 +125,7 @@ panda::EventMonophoton::dump(std::ostream& _out/* = std::cout*/) const
   _out << "rhoCentralCalo = " << rhoCentralCalo << std::endl;
 
   genReweight.dump(_out);
+  vertices.dump(_out);
   superClusters.dump(_out);
   electrons.dump(_out);
   muons.dump(_out);
@@ -141,6 +134,7 @@ panda::EventMonophoton::dump(std::ostream& _out/* = std::cout*/) const
   jets.dump(_out);
   genJets.dump(_out);
   genParticles.dump(_out);
+  genVertex.dump(_out);
   partons.dump(_out);
   t1Met.dump(_out);
   rawMet.dump(_out);
@@ -159,6 +153,7 @@ panda::EventMonophoton::getListOfBranches()
 
   blist += {"npv", "npvTrue", "rho", "rhoCentralCalo"};
   blist += GenReweight::getListOfBranches().fullNames("genReweight");
+  blist += RecoVertex::getListOfBranches().fullNames("vertices");
   blist += SuperCluster::getListOfBranches().fullNames("superClusters");
   blist += Electron::getListOfBranches().fullNames("electrons");
   blist += Muon::getListOfBranches().fullNames("muons");
@@ -166,7 +161,8 @@ panda::EventMonophoton::getListOfBranches()
   blist += XPhoton::getListOfBranches().fullNames("photons");
   blist += Jet::getListOfBranches().fullNames("jets");
   blist += GenJet::getListOfBranches().fullNames("genJets");
-  blist += GenParticle::getListOfBranches().fullNames("genParticles");
+  blist += UnpackedGenParticle::getListOfBranches().fullNames("genParticles");
+  blist += Vertex::getListOfBranches().fullNames("genVertex");
   blist += Parton::getListOfBranches().fullNames("partons");
   blist += RecoMet::getListOfBranches().fullNames("t1Met");
   blist += Met::getListOfBranches().fullNames("rawMet");
@@ -258,6 +254,8 @@ panda::EventMonophoton::doInit_()
 
 
 /* BEGIN CUSTOM EventMonophoton.cc.global */
+#include <map>
+
 panda::EventMonophoton&
 panda::EventMonophoton::operator=(Event const& _src)
 {
@@ -269,6 +267,7 @@ panda::EventMonophoton::operator=(Event const& _src)
   rhoCentralCalo = _src.rhoCentralCalo;
 
   genReweight = _src.genReweight;
+  vertices = _src.vertices;
   superClusters = _src.superClusters;
   electrons = _src.electrons;
   muons = _src.muons;
@@ -278,7 +277,6 @@ panda::EventMonophoton::operator=(Event const& _src)
     static_cast<Photon&>(photons[iP]) = _src.photons[iP];
   jets = _src.chsAK4Jets;
   genJets = _src.ak4GenJets;
-  genParticles = _src.genParticles;
   partons = _src.partons;
   t1Met = _src.pfMet;
   rawMet = _src.rawMet;
@@ -286,18 +284,70 @@ panda::EventMonophoton::operator=(Event const& _src)
   metMuOnlyFix = _src.metMuOnlyFix;
   metNoFix = _src.metNoFix;
   metFilters = _src.metFilters;
+  genVertex = _src.genVertex;
+  copyGenParticles(_src.genParticles);
 
   electrons.data.superClusterContainer_ = &superClusters;
-  electrons.data.matchedGenContainer_ = &genParticles;
-  muons.data.matchedGenContainer_ = &genParticles;
-  taus.data.matchedGenContainer_ = &genParticles;
   photons.data.superClusterContainer_ = &superClusters;
-  photons.data.matchedGenContainer_ = &genParticles;
   genParticles.data.parentContainer_ = &genParticles;
   jets.data.matchedGenJetContainer_ = &genJets;
   jets.data.constituentsContainer_ = 0;
 
   return *this;
+}
+
+void
+panda::EventMonophoton::copyGenParticles(GenParticleCollection const& _src)
+{
+  // only save leptons, prompt photons, and their ancestors
+  std::map<short, unsigned> parentMap;
+  genParticles.clear();
+  for (auto& part : _src) {
+    if (!part.finalState)
+      continue;
+
+    switch (std::abs(part.pdgid)) {
+    case 22:
+      if (!part.testFlag(GenParticle::kIsPrompt))
+        continue;
+      break;
+    case 11:
+    case 12:
+    case 13:
+    case 14:
+    case 15:
+    case 16:
+      break;
+    default:
+      continue;
+    }
+
+    auto& out(genParticles.create_back());
+    out = part;
+
+    auto* p(&out);
+    
+    short parentIdx(part.parent.idx());
+    while (parentIdx != -1) {
+      auto itr(parentMap.find(parentIdx));
+      if (itr == parentMap.end()) {
+        // parent particle not yet in genParticles
+        parentMap[parentIdx] = genParticles.size();
+
+        auto& srcParent(_src[parentIdx]);
+        auto& outParent(genParticles.create_back());
+        outParent = srcParent;
+        p->parent.setRef(&outParent);
+        p = &outParent;
+        parentIdx = srcParent.parent.idx();
+      }
+      else {
+        // already recorded particle; just set the parent ref
+        p->parent.setRef(&genParticles[itr->second]);
+        break;
+      }
+    }
+  }
 }
 
 /* END CUSTOM */

--- a/Objects/src/EventTPPhoton.cc
+++ b/Objects/src/EventTPPhoton.cc
@@ -185,9 +185,15 @@ panda::EventTPPhoton::doInit_()
 
 /* BEGIN CUSTOM EventTPPhoton.cc.global */
 panda::EventTPPhoton&
-panda::EventTPPhoton::operator=(Event const& _src)
+panda::EventTPPhoton::copy(Event const& _src)
 {
-  EventBase::operator=(_src);
+  runNumber = _src.runNumber;
+  lumiNumber = _src.lumiNumber;
+  eventNumber = _src.eventNumber;
+  isData = _src.isData;
+  weight = _src.weight;
+
+  triggers = _src.triggers;
 
   npv = _src.npv;
   npvTrue = _src.npvTrue;
@@ -203,9 +209,15 @@ panda::EventTPPhoton::operator=(Event const& _src)
 }
 
 panda::EventTPPhoton&
-panda::EventTPPhoton::operator=(EventMonophoton const& _src)
+panda::EventTPPhoton::copy(EventMonophoton const& _src)
 {
-  EventBase::operator=(_src);
+  runNumber = _src.runNumber;
+  lumiNumber = _src.lumiNumber;
+  eventNumber = _src.eventNumber;
+  isData = _src.isData;
+  weight = _src.weight;
+
+  triggers = _src.triggers;
 
   npv = _src.npv;
   npvTrue = _src.npvTrue;

--- a/Objects/src/EventTPPhoton.cc
+++ b/Objects/src/EventTPPhoton.cc
@@ -31,6 +31,12 @@ panda::EventTPPhoton::EventTPPhoton(EventTPPhoton const& _src) :
   /* END CUSTOM */
 }
 
+panda::EventTPPhoton::~EventTPPhoton()
+{
+  /* BEGIN CUSTOM EventTPPhoton.cc.dtor */
+  /* END CUSTOM */
+}
+
 panda::EventTPPhoton&
 panda::EventTPPhoton::operator=(EventTPPhoton const& _src)
 {

--- a/Objects/src/Run.cc
+++ b/Objects/src/Run.cc
@@ -55,6 +55,9 @@ panda::Run::operator=(Run const& _src)
     hlt.paths->assign(_src.hlt.paths->begin(), _src.hlt.paths->end());
   }
 
+  if (_src.inputTree_ && _src.inputTree_ != inputTree_)
+    _src.inputTree_->GetUserInfo()->Add(new TreePointerCleaner(this, _src.inputTree_));
+
   inputTree_ = _src.inputTree_;
   inputTreeNumber_ = _src.inputTreeNumber_;
   /* END CUSTOM */
@@ -186,6 +189,17 @@ panda::Run::registerTrigger(char const* _path)
   }
   else
     return itr -registeredTriggers_.begin();
+}
+
+char const*
+panda::Run::getRegisteredPath(UInt_t _token) const
+{
+  if (_token < registeredTriggers_.size()) {
+    auto& path(registeredTriggers_[_token]);
+    return path(0, path.Length() - 2).Data();
+  }
+  else
+    return "";
 }
 
 UInt_t

--- a/Objects/src/Run.cc
+++ b/Objects/src/Run.cc
@@ -14,6 +14,7 @@ panda::Run::Run(Run const& _src) :
 
   /* BEGIN CUSTOM Run.cc.copy_ctor */
   loadTrigger_ = _src.loadTrigger_;
+  hltMenuCache_ = _src.hltMenuCache_;
   registeredTriggers_ = _src.registeredTriggers_;
   triggerIndices_ = _src.triggerIndices_;
 
@@ -22,6 +23,16 @@ panda::Run::Run(Run const& _src) :
     *hlt.menu = *_src.hlt.menu;
     hlt.paths->assign(_src.hlt.paths->begin(), _src.hlt.paths->end());
   }
+
+  inputTree_ = _src.inputTree_;
+  inputTreeNumber_ = _src.inputTreeNumber_;
+  /* END CUSTOM */
+}
+
+panda::Run::~Run()
+{
+  /* BEGIN CUSTOM Run.cc.dtor */
+  resetCache();
   /* END CUSTOM */
 }
 
@@ -32,6 +43,7 @@ panda::Run::operator=(Run const& _src)
 
   /* BEGIN CUSTOM Run.cc.operator= */
   loadTrigger_ = _src.loadTrigger_;
+  hltMenuCache_ = _src.hltMenuCache_;
   registeredTriggers_ = _src.registeredTriggers_;
   triggerIndices_ = _src.triggerIndices_;
 
@@ -42,6 +54,9 @@ panda::Run::operator=(Run const& _src)
     *hlt.menu = *_src.hlt.menu;
     hlt.paths->assign(_src.hlt.paths->begin(), _src.hlt.paths->end());
   }
+
+  inputTree_ = _src.inputTree_;
+  inputTreeNumber_ = _src.inputTreeNumber_;
   /* END CUSTOM */
 
   runNumber = _src.runNumber;
@@ -123,13 +138,8 @@ void
 panda::Run::doGetEntry_(TTree& _tree, Long64_t _entry)
 {
   /* BEGIN CUSTOM Run.cc.doGetEntry_ */
-  if (loadTrigger_ && hltMenu != hltMenuCache_) {
-    hltMenuCache_ = hltMenu;
-    
-    auto* file(_tree.GetCurrentFile());
-    if (file)
-      loadTriggerTable(*file);
-  }
+  if (loadTrigger_)
+    updateTriggerTable_(_tree);
   /* END CUSTOM */
 }
 
@@ -153,9 +163,8 @@ void
 panda::Run::setLoadTrigger(Bool_t _l/* = kTRUE*/)
 {
   loadTrigger_ = _l;
-  if (!_l) {
+  if (!_l)
     hlt.destroy();
-  }
 }
 
 UInt_t
@@ -179,6 +188,21 @@ panda::Run::registerTrigger(char const* _path)
     return itr -registeredTriggers_.begin();
 }
 
+UInt_t
+panda::Run::getTriggerIndex(UInt_t _token) const
+{
+  try {
+    return triggerIndices_.at(_token);
+  }
+  catch (std::exception& ex) {
+    std::cerr << "Trigger menu is not up to date." << std::endl;
+    std::cerr << "This happens when the runs or hlt tree is not in the input file" << std::endl;
+    std::cerr << "or runNumber branch of the events tree is not read. Please check" << std::endl;
+    std::cerr << "your input." << std::endl;
+    throw;
+  }
+}
+
 char const*
 panda::Run::triggerMenu() const
 {
@@ -200,29 +224,87 @@ panda::Run::triggerPaths() const
 void
 panda::Run::findEntry(TTree& _runTree, UInt_t _runNumber)
 {
-  if (_runNumber != runNumber) {
-    long iEntry(0);
-    while (_runTree.GetEntry(iEntry++) > 0) {
-      if (runNumber == _runNumber)
-        break;
-    }
-    if (iEntry == _runTree.GetEntries()+1) {
-      std::cerr << "Run " << _runNumber << " not found in run tree" << std::endl;
-      throw std::runtime_error("InputError");
-    }
+  // Known issue: if this function is called with a new tree but with the same run number as the previous call,
+  // nothing happens and the tree is not updated. This is such a rare situation that (in my opinion) does not warrant
+  // covering for.
 
-    doGetEntry_(_runTree, iEntry);
+  if (_runNumber == runNumber)
+    return;
+
+  long iEntry(0);
+  while (_runTree.GetEntry(iEntry++) > 0) {
+    if (runNumber == _runNumber)
+      break;
   }
+  if (iEntry == _runTree.GetEntries()+1) {
+    std::cerr << "Run " << _runNumber << " not found in run tree" << std::endl;
+    throw std::runtime_error("InputError");
+  }
+
+  doGetEntry_(_runTree, iEntry);
 }
 
 void
-panda::Run::loadTriggerTable(TFile& _inputFile)
+panda::Run::resetCache()
 {
-  auto* key(_inputFile.GetKey("hlt"));
-  if (!key) {
-    std::cerr << "File " << _inputFile.GetName() << " does not have an hlt tree" << std::endl;
+  if (inputTree_) {
+    auto* uinfo(inputTree_->GetUserInfo());
+    for (TObject* obj : *uinfo) {
+      if (obj->GetName() != this->getName())
+        continue;
+
+      auto* cleaner(dynamic_cast<TreePointerCleaner*>(obj));
+      if (cleaner && cleaner->getRun() == this) {
+        uinfo->Remove(obj);
+        delete obj;
+        break;
+      }
+    }
+
+    // inputTree_ is already set to 0 by the destructor of the TreePointerCleaner, but just to make sure
+    inputTree_ = 0;
+  }
+
+  inputTreeNumber_ = -1;
+  
+  hltMenuCache_ = -1;
+}
+    
+
+/*private*/
+void
+panda::Run::updateTriggerTable_(TTree& _tree)
+{
+  if (&_tree != inputTree_) {
+    inputTree_ = &_tree;
+    inputTreeNumber_ = -1;
+
+    // add a hook to unlink this object when the tree is deleted
+    _tree.GetUserInfo()->Add(new TreePointerCleaner(this, &_tree));
+  }
+
+  if (_tree.GetTreeNumber() != inputTreeNumber_) {
+    inputTreeNumber_ = _tree.GetTreeNumber();
+    hltMenuCache_ = -1;
+  }
+
+  if (hltMenu == hltMenuCache_)
+    return;
+
+  hltMenuCache_ = hltMenu;
+
+  auto* inputFile(inputTree_->GetCurrentFile());
+  if (!inputFile) {
+    std::cerr << "No input file associated to the run tree" << std::endl;
     throw std::runtime_error("InputError");
   }
+
+  auto* key(inputFile->GetKey("hlt"));
+  if (!key) {
+    std::cerr << "File " << inputFile->GetName() << " does not have an hlt tree" << std::endl;
+    throw std::runtime_error("InputError");
+  }
+
   auto* hltTree(static_cast<TTree*>(key->ReadObj()));
 
   if (!hlt.menu)
@@ -232,7 +314,7 @@ panda::Run::loadTriggerTable(TFile& _inputFile)
   hltTree->SetBranchAddress("paths", &hlt.paths);
 
   if (hltTree->GetEntry(hltMenu) <= 0) {
-    std::cerr << "Failed to read HLT menu " << hltMenu << " from " << _inputFile.GetName() << std::endl;
+    std::cerr << "Failed to read HLT menu " << hltMenu << " from " << inputFile->GetName() << std::endl;
     throw std::runtime_error("InputError");
   }
 
@@ -251,6 +333,21 @@ panda::Run::loadTriggerTable(TFile& _inputFile)
     if (iT == hlt.paths->size())
       triggerIndices_.push_back(-1);
   }
+}
+
+
+panda::Run::TreePointerCleaner::TreePointerCleaner(Run* run, TTree* tree) :
+  run_(run),
+  tree_(tree)
+{
+  // TTree will delete this object in UserInfo if this bit is set
+  SetBit(kIsOnHeap);
+}
+
+panda::Run::TreePointerCleaner::~TreePointerCleaner()
+{
+  if (run_->inputTree_ == tree_)
+    run_->inputTree_ = 0;
 }
 
 /* END CUSTOM */

--- a/Objects/src/UnpackedGenParticle.cc
+++ b/Objects/src/UnpackedGenParticle.cc
@@ -1,0 +1,249 @@
+#include "../interface/UnpackedGenParticle.h"
+
+/*static*/
+panda::utils::BranchList
+panda::UnpackedGenParticle::getListOfBranches()
+{
+  utils::BranchList blist;
+  blist += ParticleM::getListOfBranches();
+  blist += {"pdgid", "finalState", "statusFlags", "parent_"};
+  return blist;
+}
+
+void
+panda::UnpackedGenParticle::datastore::allocate(UInt_t _nmax)
+{
+  ParticleM::datastore::allocate(_nmax);
+
+  pdgid = new Int_t[nmax_];
+  finalState = new Bool_t[nmax_];
+  statusFlags = new UShort_t[nmax_];
+  parent_ = new Short_t[nmax_];
+}
+
+void
+panda::UnpackedGenParticle::datastore::deallocate()
+{
+  ParticleM::datastore::deallocate();
+
+  delete [] pdgid;
+  pdgid = 0;
+  delete [] finalState;
+  finalState = 0;
+  delete [] statusFlags;
+  statusFlags = 0;
+  delete [] parent_;
+  parent_ = 0;
+}
+
+void
+panda::UnpackedGenParticle::datastore::setStatus(TTree& _tree, TString const& _name, utils::BranchList const& _branches)
+{
+  ParticleM::datastore::setStatus(_tree, _name, _branches);
+
+  utils::setStatus(_tree, _name, "pdgid", _branches);
+  utils::setStatus(_tree, _name, "finalState", _branches);
+  utils::setStatus(_tree, _name, "statusFlags", _branches);
+  utils::setStatus(_tree, _name, "parent_", _branches);
+}
+
+panda::utils::BranchList
+panda::UnpackedGenParticle::datastore::getStatus(TTree& _tree, TString const& _name) const
+{
+  utils::BranchList blist(ParticleM::datastore::getStatus(_tree, _name));
+
+  blist.push_back(utils::getStatus(_tree, _name, "pdgid"));
+  blist.push_back(utils::getStatus(_tree, _name, "finalState"));
+  blist.push_back(utils::getStatus(_tree, _name, "statusFlags"));
+  blist.push_back(utils::getStatus(_tree, _name, "parent_"));
+
+  return blist;
+}
+
+void
+panda::UnpackedGenParticle::datastore::setAddress(TTree& _tree, TString const& _name, utils::BranchList const& _branches/* = {"*"}*/, Bool_t _setStatus/* = kTRUE*/)
+{
+  ParticleM::datastore::setAddress(_tree, _name, _branches, _setStatus);
+
+  utils::setAddress(_tree, _name, "pdgid", pdgid, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "finalState", finalState, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "statusFlags", statusFlags, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "parent_", parent_, _branches, _setStatus);
+}
+
+void
+panda::UnpackedGenParticle::datastore::book(TTree& _tree, TString const& _name, utils::BranchList const& _branches/* = {"*"}*/, Bool_t _dynamic/* = kTRUE*/)
+{
+  ParticleM::datastore::book(_tree, _name, _branches, _dynamic);
+
+  TString size(_dynamic ? "[" + _name + ".size]" : TString::Format("[%d]", nmax_));
+
+  utils::book(_tree, _name, "pdgid", size, 'I', pdgid, _branches);
+  utils::book(_tree, _name, "finalState", size, 'O', finalState, _branches);
+  utils::book(_tree, _name, "statusFlags", size, 's', statusFlags, _branches);
+  utils::book(_tree, _name, "parent_", size, 'S', parent_, _branches);
+}
+
+void
+panda::UnpackedGenParticle::datastore::releaseTree(TTree& _tree, TString const& _name)
+{
+  ParticleM::datastore::releaseTree(_tree, _name);
+
+  utils::resetAddress(_tree, _name, "pdgid");
+  utils::resetAddress(_tree, _name, "finalState");
+  utils::resetAddress(_tree, _name, "statusFlags");
+  utils::resetAddress(_tree, _name, "parent_");
+}
+
+void
+panda::UnpackedGenParticle::datastore::resizeVectors_(UInt_t _size)
+{
+  ParticleM::datastore::resizeVectors_(_size);
+
+}
+
+
+panda::utils::BranchList
+panda::UnpackedGenParticle::datastore::getBranchNames(TString const& _name/* = ""*/) const
+{
+  return UnpackedGenParticle::getListOfBranches().fullNames(_name);
+}
+
+panda::UnpackedGenParticle::UnpackedGenParticle(char const* _name/* = ""*/) :
+  ParticleM(new UnpackedGenParticleArray(1, _name)),
+  pdgid(gStore.getData(this).pdgid[0]),
+  finalState(gStore.getData(this).finalState[0]),
+  statusFlags(gStore.getData(this).statusFlags[0]),
+  parent(gStore.getData(this).parentContainer_, gStore.getData(this).parent_[0])
+{
+}
+
+panda::UnpackedGenParticle::UnpackedGenParticle(UnpackedGenParticle const& _src) :
+  ParticleM(new UnpackedGenParticleArray(1, gStore.getName(&_src))),
+  pdgid(gStore.getData(this).pdgid[0]),
+  finalState(gStore.getData(this).finalState[0]),
+  statusFlags(gStore.getData(this).statusFlags[0]),
+  parent(gStore.getData(this).parentContainer_, gStore.getData(this).parent_[0])
+{
+  ParticleM::operator=(_src);
+
+  pdgid = _src.pdgid;
+  finalState = _src.finalState;
+  statusFlags = _src.statusFlags;
+  parent = _src.parent;
+}
+
+panda::UnpackedGenParticle::UnpackedGenParticle(datastore& _data, UInt_t _idx) :
+  ParticleM(_data, _idx),
+  pdgid(_data.pdgid[_idx]),
+  finalState(_data.finalState[_idx]),
+  statusFlags(_data.statusFlags[_idx]),
+  parent(_data.parentContainer_, _data.parent_[_idx])
+{
+}
+
+panda::UnpackedGenParticle::UnpackedGenParticle(ArrayBase* _array) :
+  ParticleM(_array),
+  pdgid(gStore.getData(this).pdgid[0]),
+  finalState(gStore.getData(this).finalState[0]),
+  statusFlags(gStore.getData(this).statusFlags[0]),
+  parent(gStore.getData(this).parentContainer_, gStore.getData(this).parent_[0])
+{
+}
+
+panda::UnpackedGenParticle::~UnpackedGenParticle()
+{
+  destructor();
+  gStore.free(this);
+}
+
+void
+panda::UnpackedGenParticle::destructor()
+{
+  /* BEGIN CUSTOM UnpackedGenParticle.cc.destructor */
+  /* END CUSTOM */
+
+  ParticleM::destructor();
+}
+
+panda::UnpackedGenParticle&
+panda::UnpackedGenParticle::operator=(UnpackedGenParticle const& _src)
+{
+  ParticleM::operator=(_src);
+
+  pdgid = _src.pdgid;
+  finalState = _src.finalState;
+  statusFlags = _src.statusFlags;
+  parent = _src.parent;
+
+  return *this;
+}
+
+void
+panda::UnpackedGenParticle::doSetAddress_(TTree& _tree, TString const& _name, utils::BranchList const& _branches/* = {"*"}*/, Bool_t _setStatus/* = kTRUE*/)
+{
+  ParticleM::doSetAddress_(_tree, _name, _branches, _setStatus);
+
+  utils::setAddress(_tree, _name, "pdgid", &pdgid, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "finalState", &finalState, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "statusFlags", &statusFlags, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "parent_", gStore.getData(this).parent_, _branches, true);
+}
+
+void
+panda::UnpackedGenParticle::doBook_(TTree& _tree, TString const& _name, utils::BranchList const& _branches/* = {"*"}*/)
+{
+  ParticleM::doBook_(_tree, _name, _branches);
+
+  utils::book(_tree, _name, "pdgid", "", 'I', &pdgid, _branches);
+  utils::book(_tree, _name, "finalState", "", 'O', &finalState, _branches);
+  utils::book(_tree, _name, "statusFlags", "", 's', &statusFlags, _branches);
+  utils::book(_tree, _name, "parent_", "", 'S', gStore.getData(this).parent_, _branches);
+}
+
+void
+panda::UnpackedGenParticle::doInit_()
+{
+  ParticleM::doInit_();
+
+  pdgid = 0;
+  finalState = false;
+  statusFlags = 0;
+  parent.init();
+
+  /* BEGIN CUSTOM UnpackedGenParticle.cc.doInit_ */
+  /* END CUSTOM */
+}
+
+void
+panda::UnpackedGenParticle::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
+{
+  /* BEGIN CUSTOM UnpackedGenParticle.cc.print */
+  dump(_out);
+  /* END CUSTOM */
+}
+
+void
+panda::UnpackedGenParticle::dump(std::ostream& _out/* = std::cout*/) const
+{
+  ParticleM::dump(_out);
+
+  _out << "pdgid = " << pdgid << std::endl;
+  _out << "finalState = " << finalState << std::endl;
+  _out << "statusFlags = " << statusFlags << std::endl;
+  _out << "parent = " << parent << std::endl;
+}
+
+/* BEGIN CUSTOM UnpackedGenParticle.cc.global */
+panda::UnpackedGenParticle&
+panda::UnpackedGenParticle::operator=(GenParticle const& _rhs)
+{
+  setPtEtaPhiM(_rhs.pt(), _rhs.eta(), _rhs.phi(), _rhs.m());
+  pdgid = _rhs.pdgid;
+  finalState = _rhs.finalState;
+  statusFlags = _rhs.statusFlags;
+
+  return *this;
+}
+
+/* END CUSTOM */

--- a/Objects/src/UnpackedPFCand.cc
+++ b/Objects/src/UnpackedPFCand.cc
@@ -1,0 +1,273 @@
+#include "../interface/UnpackedPFCand.h"
+
+TString panda::UnpackedPFCand::PTypeName[] = {
+  "hp",
+  "hm",
+  "ep",
+  "em",
+  "mup",
+  "mum",
+  "gamma",
+  "h0",
+  "h_HF",
+  "egamma_HF",
+  "Xp",
+  "Xm",
+  "X"
+};
+
+/*static*/
+int panda::UnpackedPFCand::q_[nPTypes] = {1, -1, 1, -1, 1, -1, 0, 0, 0, 0, 1, -1, 0};
+/*static*/
+int panda::UnpackedPFCand::pdgId_[nPTypes] = {211, -211, -11, 11, -13, 13, 22, 130, 1, 2, 0, 0, 0};
+
+/*static*/
+panda::utils::BranchList
+panda::UnpackedPFCand::getListOfBranches()
+{
+  utils::BranchList blist;
+  blist += ParticleM::getListOfBranches();
+  blist += {"puppiW", "puppiWNoLep", "ptype", "vertex_"};
+  return blist;
+}
+
+void
+panda::UnpackedPFCand::datastore::allocate(UInt_t _nmax)
+{
+  ParticleM::datastore::allocate(_nmax);
+
+  puppiW = new Char_t[nmax_];
+  puppiWNoLep = new Char_t[nmax_];
+  ptype = new UChar_t[nmax_];
+  vertex_ = new Short_t[nmax_];
+}
+
+void
+panda::UnpackedPFCand::datastore::deallocate()
+{
+  ParticleM::datastore::deallocate();
+
+  delete [] puppiW;
+  puppiW = 0;
+  delete [] puppiWNoLep;
+  puppiWNoLep = 0;
+  delete [] ptype;
+  ptype = 0;
+  delete [] vertex_;
+  vertex_ = 0;
+}
+
+void
+panda::UnpackedPFCand::datastore::setStatus(TTree& _tree, TString const& _name, utils::BranchList const& _branches)
+{
+  ParticleM::datastore::setStatus(_tree, _name, _branches);
+
+  utils::setStatus(_tree, _name, "puppiW", _branches);
+  utils::setStatus(_tree, _name, "puppiWNoLep", _branches);
+  utils::setStatus(_tree, _name, "ptype", _branches);
+  utils::setStatus(_tree, _name, "vertex_", _branches);
+}
+
+panda::utils::BranchList
+panda::UnpackedPFCand::datastore::getStatus(TTree& _tree, TString const& _name) const
+{
+  utils::BranchList blist(ParticleM::datastore::getStatus(_tree, _name));
+
+  blist.push_back(utils::getStatus(_tree, _name, "puppiW"));
+  blist.push_back(utils::getStatus(_tree, _name, "puppiWNoLep"));
+  blist.push_back(utils::getStatus(_tree, _name, "ptype"));
+  blist.push_back(utils::getStatus(_tree, _name, "vertex_"));
+
+  return blist;
+}
+
+void
+panda::UnpackedPFCand::datastore::setAddress(TTree& _tree, TString const& _name, utils::BranchList const& _branches/* = {"*"}*/, Bool_t _setStatus/* = kTRUE*/)
+{
+  ParticleM::datastore::setAddress(_tree, _name, _branches, _setStatus);
+
+  utils::setAddress(_tree, _name, "puppiW", puppiW, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "puppiWNoLep", puppiWNoLep, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "ptype", ptype, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "vertex_", vertex_, _branches, _setStatus);
+}
+
+void
+panda::UnpackedPFCand::datastore::book(TTree& _tree, TString const& _name, utils::BranchList const& _branches/* = {"*"}*/, Bool_t _dynamic/* = kTRUE*/)
+{
+  ParticleM::datastore::book(_tree, _name, _branches, _dynamic);
+
+  TString size(_dynamic ? "[" + _name + ".size]" : TString::Format("[%d]", nmax_));
+
+  utils::book(_tree, _name, "puppiW", size, 'B', puppiW, _branches);
+  utils::book(_tree, _name, "puppiWNoLep", size, 'B', puppiWNoLep, _branches);
+  utils::book(_tree, _name, "ptype", size, 'b', ptype, _branches);
+  utils::book(_tree, _name, "vertex_", size, 'S', vertex_, _branches);
+}
+
+void
+panda::UnpackedPFCand::datastore::releaseTree(TTree& _tree, TString const& _name)
+{
+  ParticleM::datastore::releaseTree(_tree, _name);
+
+  utils::resetAddress(_tree, _name, "puppiW");
+  utils::resetAddress(_tree, _name, "puppiWNoLep");
+  utils::resetAddress(_tree, _name, "ptype");
+  utils::resetAddress(_tree, _name, "vertex_");
+}
+
+void
+panda::UnpackedPFCand::datastore::resizeVectors_(UInt_t _size)
+{
+  ParticleM::datastore::resizeVectors_(_size);
+
+}
+
+
+panda::utils::BranchList
+panda::UnpackedPFCand::datastore::getBranchNames(TString const& _name/* = ""*/) const
+{
+  return UnpackedPFCand::getListOfBranches().fullNames(_name);
+}
+
+panda::UnpackedPFCand::UnpackedPFCand(char const* _name/* = ""*/) :
+  ParticleM(new UnpackedPFCandArray(1, _name)),
+  puppiW(gStore.getData(this).puppiW[0]),
+  puppiWNoLep(gStore.getData(this).puppiWNoLep[0]),
+  ptype(gStore.getData(this).ptype[0]),
+  vertex(gStore.getData(this).vertexContainer_, gStore.getData(this).vertex_[0])
+{
+}
+
+panda::UnpackedPFCand::UnpackedPFCand(UnpackedPFCand const& _src) :
+  ParticleM(new UnpackedPFCandArray(1, gStore.getName(&_src))),
+  puppiW(gStore.getData(this).puppiW[0]),
+  puppiWNoLep(gStore.getData(this).puppiWNoLep[0]),
+  ptype(gStore.getData(this).ptype[0]),
+  vertex(gStore.getData(this).vertexContainer_, gStore.getData(this).vertex_[0])
+{
+  ParticleM::operator=(_src);
+
+  puppiW = _src.puppiW;
+  puppiWNoLep = _src.puppiWNoLep;
+  ptype = _src.ptype;
+  vertex = _src.vertex;
+}
+
+panda::UnpackedPFCand::UnpackedPFCand(datastore& _data, UInt_t _idx) :
+  ParticleM(_data, _idx),
+  puppiW(_data.puppiW[_idx]),
+  puppiWNoLep(_data.puppiWNoLep[_idx]),
+  ptype(_data.ptype[_idx]),
+  vertex(_data.vertexContainer_, _data.vertex_[_idx])
+{
+}
+
+panda::UnpackedPFCand::UnpackedPFCand(ArrayBase* _array) :
+  ParticleM(_array),
+  puppiW(gStore.getData(this).puppiW[0]),
+  puppiWNoLep(gStore.getData(this).puppiWNoLep[0]),
+  ptype(gStore.getData(this).ptype[0]),
+  vertex(gStore.getData(this).vertexContainer_, gStore.getData(this).vertex_[0])
+{
+}
+
+panda::UnpackedPFCand::~UnpackedPFCand()
+{
+  destructor();
+  gStore.free(this);
+}
+
+void
+panda::UnpackedPFCand::destructor()
+{
+  /* BEGIN CUSTOM UnpackedPFCand.cc.destructor */
+  /* END CUSTOM */
+
+  ParticleM::destructor();
+}
+
+panda::UnpackedPFCand&
+panda::UnpackedPFCand::operator=(UnpackedPFCand const& _src)
+{
+  ParticleM::operator=(_src);
+
+  puppiW = _src.puppiW;
+  puppiWNoLep = _src.puppiWNoLep;
+  ptype = _src.ptype;
+  vertex = _src.vertex;
+
+  return *this;
+}
+
+void
+panda::UnpackedPFCand::doSetAddress_(TTree& _tree, TString const& _name, utils::BranchList const& _branches/* = {"*"}*/, Bool_t _setStatus/* = kTRUE*/)
+{
+  ParticleM::doSetAddress_(_tree, _name, _branches, _setStatus);
+
+  utils::setAddress(_tree, _name, "puppiW", &puppiW, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "puppiWNoLep", &puppiWNoLep, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "ptype", &ptype, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "vertex_", gStore.getData(this).vertex_, _branches, true);
+}
+
+void
+panda::UnpackedPFCand::doBook_(TTree& _tree, TString const& _name, utils::BranchList const& _branches/* = {"*"}*/)
+{
+  ParticleM::doBook_(_tree, _name, _branches);
+
+  utils::book(_tree, _name, "puppiW", "", 'B', &puppiW, _branches);
+  utils::book(_tree, _name, "puppiWNoLep", "", 'B', &puppiWNoLep, _branches);
+  utils::book(_tree, _name, "ptype", "", 'b', &ptype, _branches);
+  utils::book(_tree, _name, "vertex_", "", 'S', gStore.getData(this).vertex_, _branches);
+}
+
+void
+panda::UnpackedPFCand::doInit_()
+{
+  ParticleM::doInit_();
+
+  puppiW = 0;
+  puppiWNoLep = 0;
+  ptype = 0;
+  vertex.init();
+
+  /* BEGIN CUSTOM UnpackedPFCand.cc.doInit_ */
+  /* END CUSTOM */
+}
+
+void
+panda::UnpackedPFCand::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
+{
+  /* BEGIN CUSTOM UnpackedPFCand.cc.print */
+  dump(_out);
+  /* END CUSTOM */
+}
+
+void
+panda::UnpackedPFCand::dump(std::ostream& _out/* = std::cout*/) const
+{
+  ParticleM::dump(_out);
+
+  _out << "puppiW = " << puppiW << std::endl;
+  _out << "puppiWNoLep = " << puppiWNoLep << std::endl;
+  _out << "ptype = " << ptype << std::endl;
+  _out << "vertex = " << vertex << std::endl;
+}
+
+
+/* BEGIN CUSTOM UnpackedPFCand.cc.global */
+panda::UnpackedPFCand&
+panda::UnpackedPFCand::operator=(PFCand const& _rhs)
+{
+  setPtEtaPhiM(_rhs.pt(), _rhs.eta(), _rhs.phi(), _rhs.m());
+
+  puppiW = _rhs.puppiW();
+  puppiWNoLep = _rhs.puppiWNoLep();
+  ptype = _rhs.ptype;
+  vertex = _rhs.vertex;
+
+  return *this;
+}
+
+/* END CUSTOM */

--- a/Objects/src/XPhoton.cc
+++ b/Objects/src/XPhoton.cc
@@ -17,7 +17,7 @@ panda::XPhoton::getListOfBranches()
 {
   utils::BranchList blist;
   blist += Photon::getListOfBranches();
-  blist += {"scEta", "scRawPt", "chIsoS15", "nhIsoS15", "phIsoS15", "e4", "isEB"};
+  blist += {"scEta", "scRawPt", "chIsoS15", "nhIsoS15", "phIsoS15", "e4", "isEB", "matchedGenId"};
   return blist;
 }
 
@@ -33,6 +33,7 @@ panda::XPhoton::datastore::allocate(UInt_t _nmax)
   phIsoS15 = new Float_t[nmax_];
   e4 = new Float_t[nmax_];
   isEB = new Bool_t[nmax_];
+  matchedGenId = new Int_t[nmax_];
 }
 
 void
@@ -54,6 +55,8 @@ panda::XPhoton::datastore::deallocate()
   e4 = 0;
   delete [] isEB;
   isEB = 0;
+  delete [] matchedGenId;
+  matchedGenId = 0;
 }
 
 void
@@ -68,6 +71,7 @@ panda::XPhoton::datastore::setStatus(TTree& _tree, TString const& _name, utils::
   utils::setStatus(_tree, _name, "phIsoS15", _branches);
   utils::setStatus(_tree, _name, "e4", _branches);
   utils::setStatus(_tree, _name, "isEB", _branches);
+  utils::setStatus(_tree, _name, "matchedGenId", _branches);
 }
 
 panda::utils::BranchList
@@ -82,6 +86,7 @@ panda::XPhoton::datastore::getStatus(TTree& _tree, TString const& _name) const
   blist.push_back(utils::getStatus(_tree, _name, "phIsoS15"));
   blist.push_back(utils::getStatus(_tree, _name, "e4"));
   blist.push_back(utils::getStatus(_tree, _name, "isEB"));
+  blist.push_back(utils::getStatus(_tree, _name, "matchedGenId"));
 
   return blist;
 }
@@ -98,6 +103,7 @@ panda::XPhoton::datastore::setAddress(TTree& _tree, TString const& _name, utils:
   utils::setAddress(_tree, _name, "phIsoS15", phIsoS15, _branches, _setStatus);
   utils::setAddress(_tree, _name, "e4", e4, _branches, _setStatus);
   utils::setAddress(_tree, _name, "isEB", isEB, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "matchedGenId", matchedGenId, _branches, _setStatus);
 }
 
 void
@@ -114,6 +120,7 @@ panda::XPhoton::datastore::book(TTree& _tree, TString const& _name, utils::Branc
   utils::book(_tree, _name, "phIsoS15", size, 'F', phIsoS15, _branches);
   utils::book(_tree, _name, "e4", size, 'F', e4, _branches);
   utils::book(_tree, _name, "isEB", size, 'O', isEB, _branches);
+  utils::book(_tree, _name, "matchedGenId", size, 'I', matchedGenId, _branches);
 }
 
 void
@@ -128,6 +135,7 @@ panda::XPhoton::datastore::releaseTree(TTree& _tree, TString const& _name)
   utils::resetAddress(_tree, _name, "phIsoS15");
   utils::resetAddress(_tree, _name, "e4");
   utils::resetAddress(_tree, _name, "isEB");
+  utils::resetAddress(_tree, _name, "matchedGenId");
 }
 
 void
@@ -152,7 +160,8 @@ panda::XPhoton::XPhoton(char const* _name/* = ""*/) :
   nhIsoS15(gStore.getData(this).nhIsoS15[0]),
   phIsoS15(gStore.getData(this).phIsoS15[0]),
   e4(gStore.getData(this).e4[0]),
-  isEB(gStore.getData(this).isEB[0])
+  isEB(gStore.getData(this).isEB[0]),
+  matchedGenId(gStore.getData(this).matchedGenId[0])
 {
 }
 
@@ -164,7 +173,8 @@ panda::XPhoton::XPhoton(XPhoton const& _src) :
   nhIsoS15(gStore.getData(this).nhIsoS15[0]),
   phIsoS15(gStore.getData(this).phIsoS15[0]),
   e4(gStore.getData(this).e4[0]),
-  isEB(gStore.getData(this).isEB[0])
+  isEB(gStore.getData(this).isEB[0]),
+  matchedGenId(gStore.getData(this).matchedGenId[0])
 {
   Photon::operator=(_src);
 
@@ -175,6 +185,7 @@ panda::XPhoton::XPhoton(XPhoton const& _src) :
   phIsoS15 = _src.phIsoS15;
   e4 = _src.e4;
   isEB = _src.isEB;
+  matchedGenId = _src.matchedGenId;
 }
 
 panda::XPhoton::XPhoton(datastore& _data, UInt_t _idx) :
@@ -185,7 +196,8 @@ panda::XPhoton::XPhoton(datastore& _data, UInt_t _idx) :
   nhIsoS15(_data.nhIsoS15[_idx]),
   phIsoS15(_data.phIsoS15[_idx]),
   e4(_data.e4[_idx]),
-  isEB(_data.isEB[_idx])
+  isEB(_data.isEB[_idx]),
+  matchedGenId(_data.matchedGenId[_idx])
 {
 }
 
@@ -197,7 +209,8 @@ panda::XPhoton::XPhoton(ArrayBase* _array) :
   nhIsoS15(gStore.getData(this).nhIsoS15[0]),
   phIsoS15(gStore.getData(this).phIsoS15[0]),
   e4(gStore.getData(this).e4[0]),
-  isEB(gStore.getData(this).isEB[0])
+  isEB(gStore.getData(this).isEB[0]),
+  matchedGenId(gStore.getData(this).matchedGenId[0])
 {
 }
 
@@ -228,6 +241,7 @@ panda::XPhoton::operator=(XPhoton const& _src)
   phIsoS15 = _src.phIsoS15;
   e4 = _src.e4;
   isEB = _src.isEB;
+  matchedGenId = _src.matchedGenId;
 
   return *this;
 }
@@ -244,6 +258,7 @@ panda::XPhoton::doSetAddress_(TTree& _tree, TString const& _name, utils::BranchL
   utils::setAddress(_tree, _name, "phIsoS15", &phIsoS15, _branches, _setStatus);
   utils::setAddress(_tree, _name, "e4", &e4, _branches, _setStatus);
   utils::setAddress(_tree, _name, "isEB", &isEB, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "matchedGenId", &matchedGenId, _branches, _setStatus);
 }
 
 void
@@ -258,6 +273,7 @@ panda::XPhoton::doBook_(TTree& _tree, TString const& _name, utils::BranchList co
   utils::book(_tree, _name, "phIsoS15", "", 'F', &phIsoS15, _branches);
   utils::book(_tree, _name, "e4", "", 'F', &e4, _branches);
   utils::book(_tree, _name, "isEB", "", 'O', &isEB, _branches);
+  utils::book(_tree, _name, "matchedGenId", "", 'I', &matchedGenId, _branches);
 }
 
 void
@@ -272,6 +288,7 @@ panda::XPhoton::doInit_()
   phIsoS15 = 0.;
   e4 = 0.;
   isEB = false;
+  matchedGenId = 0;
 
   /* BEGIN CUSTOM XPhoton.cc.doInit_ */
   /* END CUSTOM */
@@ -312,6 +329,7 @@ panda::XPhoton::dump(std::ostream& _out/* = std::cout*/) const
   _out << "phIsoS15 = " << phIsoS15 << std::endl;
   _out << "e4 = " << e4 << std::endl;
   _out << "isEB = " << isEB << std::endl;
+  _out << "matchedGenId = " << matchedGenId << std::endl;
 }
 
 

--- a/Utils/bin/gentree.cc
+++ b/Utils/bin/gentree.cc
@@ -55,10 +55,12 @@ main(int argc, char* argv[])
   if (matches->GetEntries() == 0)
     nEntries = TString(argv[2]).Atoi();
   else {
+    nEntries = -1;
     runNumber = TString(matches->At(1)->GetName()).Atoi();
     lumiNumber = TString(matches->At(2)->GetName()).Atoi();
     eventNumber = TString(matches->At(3)->GetName()).Atoi();
   }
+  delete matches;
 
   panda::Event event;
   event.setAddress(*tree, {"runNumber", "lumiNumber", "eventNumber", "genParticles"});
@@ -87,8 +89,10 @@ main(int argc, char* argv[])
     }
 
     std::cout << "[" << event.runNumber << ":" << event.lumiNumber << ":" << event.eventNumber << "]" << std::endl;
-    for (auto* rootNode : rootNodes)
+    for (auto* rootNode : rootNodes) {
+      rootNode->pruneDaughters();
       std::cout << rootNode->print() << std::endl;
+    }
     std::cout << std::endl << std::endl;
   }
 

--- a/defs/monophoton.def
+++ b/defs/monophoton.def
@@ -6,6 +6,7 @@ nhIsoS15/F
 phIsoS15/F
 e4/F
 isEB/O
+matchedGenId/I
 bool passCHIso(UInt_t wp) const { return chIso < chIsoCuts[1][isEB ? 0 : 1][wp]; }
 bool passNHIso(UInt_t wp) const { return nhIso < nhIsoCuts[1][isEB ? 0 : 1][wp]; }
 bool passPhIso(UInt_t wp) const { return phIso < phIsoCuts[1][isEB ? 0 : 1][wp]; }
@@ -20,16 +21,13 @@ static double const phIsoCuts[2][2][4]{{{0.81, 0.28, 0.08, 2.75}, {0.83, 0.39, 0
 static double const sieieCuts[2][2][4]{{{0.0102, 0.0102, 0.0100, 0.0105}, {0.0274, 0.0268, 0.0268, 0.028}}, {{0.01031, 0.01022, 0.00994, 0.0105}, {0.03013, 0.03001, 0.03000, 0.028}}};
 static double const hOverECuts[2][2][4]{{{0.05, 0.05, 0.05, 0.05}, {0.05, 0.05, 0.05, 0.05}},               {{0.0597, 0.0396, 0.0269, 0.05}, {0.0481, 0.0219, 0.0213, 0.05}}};
 
-[TPPair]
-mass/F
-mass2/F
-
 {EventMonophoton>EventBase}
 npv/s
 npvTrue/s
 rho/F
 rhoCentralCalo/F
 genReweight/GenReweight
+vertices/RecoVertexCollection(64)
 superClusters/SuperClusterCollection(64)
 electrons/ElectronCollection(32)
 muons/MuonCollection(32)
@@ -37,7 +35,8 @@ taus/TauCollection(64)
 photons/XPhotonCollection(32)
 jets/JetCollection(64)
 genJets/GenJetCollection(64)
-genParticles/GenParticleCollection(256)
+genParticles/UnpackedGenParticleCollection(256)
+genVertex/Vertex
 partons/PartonCollection(8)
 t1Met/RecoMet
 rawMet/Met
@@ -46,14 +45,14 @@ metMuOnlyFix/RecoMet
 metNoFix/RecoMet
 metFilters/MetFilters
 electrons.superCluster->superClusters
-electrons.matchedGen->genParticles
-muons.matchedGen->genParticles
-taus.matchedGen->genParticles
 photons.superCluster->superClusters
-photons.matchedGen->genParticles
 genParticles.parent->genParticles
 jets.matchedGenJet->genJets
 #include "Event.h"
+
+[TPPair]
+mass/F
+mass2/F
 
 {EventTPPhoton>EventBase}
 npv/s

--- a/lib/panda/tree.py
+++ b/lib/panda/tree.py
@@ -55,7 +55,7 @@ class Tree(Definition, Object):
         
         header.writeline('{name}();'.format(name = self.name)) # default constructor
         header.writeline('{name}({name} const&);'.format(name = self.name)) # copy constructor
-        header.writeline('~{name}() {{}}'.format(name = self.name)) # destructor
+        header.writeline('~{name}();'.format(name = self.name)) # destructor
         header.writeline('{name}& operator=({name} const&);'.format(name = self.name)) # assignment operator
 
         header.newline()
@@ -180,6 +180,16 @@ class Tree(Definition, Object):
                 ref.write_def(src, self.objbranches)
 
         src.write_custom_block('{name}.cc.copy_ctor'.format(name = self.name))
+
+        src.indent -= 1
+        src.writeline('}')
+        src.newline()
+
+        src.writeline('{NAMESPACE}::{name}::~{name}()'.format(NAMESPACE = NAMESPACE, name = self.name))
+        src.writeline('{')
+        src.indent += 1
+
+        src.write_custom_block('{name}.cc.dtor'.format(name = self.name))
 
         src.indent -= 1
         src.writeline('}')

--- a/obj/LinkDef.h
+++ b/obj/LinkDef.h
@@ -9,7 +9,9 @@
 #include "../Objects/interface/PFCand.h"
 #include "../Objects/interface/ParticleP.h"
 #include "../Objects/interface/ParticleM.h"
+#include "../Objects/interface/UnpackedPFCand.h"
 #include "../Objects/interface/Parton.h"
+#include "../Objects/interface/UnpackedGenParticle.h"
 #include "../Objects/interface/SuperCluster.h"
 #include "../Objects/interface/Lepton.h"
 #include "../Objects/interface/Electron.h"
@@ -57,7 +59,9 @@
 #pragma link C++ class panda::PFCand;
 #pragma link C++ class panda::ParticleP;
 #pragma link C++ class panda::ParticleM;
+#pragma link C++ class panda::UnpackedPFCand;
 #pragma link C++ class panda::Parton;
+#pragma link C++ class panda::UnpackedGenParticle;
 #pragma link C++ class panda::SuperCluster;
 #pragma link C++ class panda::Lepton;
 #pragma link C++ class panda::Electron;
@@ -92,8 +96,12 @@
 #pragma link C++ class panda::Collection<panda::ParticleP>;
 #pragma link C++ class panda::Array<panda::ParticleM>;
 #pragma link C++ class panda::Collection<panda::ParticleM>;
+#pragma link C++ class panda::Array<panda::UnpackedPFCand>;
+#pragma link C++ class panda::Collection<panda::UnpackedPFCand>;
 #pragma link C++ class panda::Array<panda::Parton>;
 #pragma link C++ class panda::Collection<panda::Parton>;
+#pragma link C++ class panda::Array<panda::UnpackedGenParticle>;
+#pragma link C++ class panda::Collection<panda::UnpackedGenParticle>;
 #pragma link C++ class panda::Array<panda::SuperCluster>;
 #pragma link C++ class panda::Collection<panda::SuperCluster>;
 #pragma link C++ class panda::Array<panda::Lepton>;
@@ -134,8 +142,12 @@
 #pragma link C++ typedef panda::ParticlePCollection;
 #pragma link C++ typedef panda::ParticleMArray;
 #pragma link C++ typedef panda::ParticleMCollection;
+#pragma link C++ typedef panda::UnpackedPFCandArray;
+#pragma link C++ typedef panda::UnpackedPFCandCollection;
 #pragma link C++ typedef panda::PartonArray;
 #pragma link C++ typedef panda::PartonCollection;
+#pragma link C++ typedef panda::UnpackedGenParticleArray;
+#pragma link C++ typedef panda::UnpackedGenParticleCollection;
 #pragma link C++ typedef panda::SuperClusterArray;
 #pragma link C++ typedef panda::SuperClusterCollection;
 #pragma link C++ typedef panda::LeptonArray;

--- a/panda.def
+++ b/panda.def
@@ -423,6 +423,9 @@ isData/O
 weight/F
 triggers/HLTBits
 #include "Run.h"
+#include "TList.h"
+#include "TFile.h"
+#include "TKey.h"
 
 {Event>EventBase}
 npv/s
@@ -503,3 +506,4 @@ puppiCA15Jets.matchedGenJet->ca15GenJets
 runNumber/i
 hltMenu/i
 hltSize/s/!
+#include "TList.h"

--- a/panda.def
+++ b/panda.def
@@ -75,6 +75,7 @@ pdgid/I
 finalState/O
 statusFlags/s
 parent/GenParticleRef
+bool testFlag(StatusFlag f) const { return ((statusFlags >> f) & 1) == 1; }
 
 [PFCand>PackedParticle]
 packedPuppiW/B
@@ -147,8 +148,43 @@ void setXYZE(double px, double py, double pz, double e) override
   mass_ = std::sqrt(e * e - p * p);
 }
 
+[UnpackedPFCand>ParticleM]
+puppiW/B
+puppiWNoLep/B
+ptype/b
+vertex/VertexRef
+TLorentzVector puppiP4() const { TLorentzVector p4; p4.SetPtEtaPhiM(pt() * puppiW, eta(), phi(), m() * puppiW); return p4; }
+TLorentzVector puppiNoLepP4() const { TLorentzVector p4; p4.SetPtEtaPhiM(pt() * puppiWNoLep, eta(), phi(), m() * puppiWNoLep); return p4; }
+int q() const { return q_[ptype]; }
+int pdgId() const { return pdgId_[ptype]; }
+enum PType {
+  hp,
+  hm,
+  ep,
+  em,
+  mup,
+  mum,
+  gamma,
+  h0,
+  h_HF,
+  egamma_HF,
+  Xp,
+  Xm,
+  X
+};
+static const int q_[nPTypes] = {1, -1, 1, -1, 1, -1, 0, 0, 0, 0, 1, -1, 0};
+static const int pdgId_[nPTypes] = {211, -211, -11, 11, -13, 13, 22, 130, 1, 2, 0, 0, 0};
+#include "PFCand.h"
+
 [Parton>ParticleM]
 pdgid/I
+
+[UnpackedGenParticle>ParticleM]
+pdgid/I
+finalState/O
+statusFlags/s
+parent/UnpackedGenParticleRef
+#include "GenParticle.h"
 
 [SuperCluster]
 rawPt/F


### PR DESCRIPTION
For #27. With this PR we can now process TChains. Made possible by remembering the tree number of the last-read event in each CollectionBase instance.

Additionally the PR includes two fixes:
- TreeEntry::getEntry would call doGetEntry_ even for nonexistent entry numbers.
  -> Added a check on the return value of Tree::GetEntry, and only if the value is non-negative, call doGetEntry_.
- CollectionBase::inputs_ and outputs_ list had no cleanup mechanisms, so they would accumulate stale tree pointers as we process multiple trees.
  -> Added a new helper class that gets embedded into the Tree objects, and does a "push notification" when the Tree object is destroyed.