### PR TITLE
fixed bug that surfaces when using Collection/Array::end() virtually

### DIFF
--- a/Framework/interface/Collection.h
+++ b/Framework/interface/Collection.h
@@ -39,25 +39,25 @@ namespace panda {
     //! Element accessor with range check
     const_reference at(UInt_t idx) const;
     //! Element accessor with no range check
-    reference operator[](UInt_t);
+    reference operator[](UInt_t idx) { return *addr_(idx); }
     //! Element accessor with no range check
-    const_reference operator[](UInt_t) const;
+    const_reference operator[](UInt_t idx) const { return *const_addr_(idx); }
     //! Return an iterator pointing to the first element
     iterator begin() { return iterator(addr_(), ContainerBase::unitSize_); }
     //! Return an iterator pointing to the first element
     const_iterator begin() const { return const_iterator(const_addr_(), ContainerBase::unitSize_); }
     //! Return an iterator pointing to the end of the array (invalid address)
-    iterator end() { return iterator(addr_() + CollectionBase::size(), ContainerBase::unitSize_); }
+    iterator end() { return iterator(addr_(CollectionBase::size()), ContainerBase::unitSize_); }
     //! Return an iterator pointing to the end of the array (invalid address)
-    const_iterator end() const { return const_iterator(const_addr_() + CollectionBase::size(), ContainerBase::unitSize_); }
+    const_iterator end() const { return const_iterator(const_addr_(CollectionBase::size()), ContainerBase::unitSize_); }
     //! Reference to the first element
-    reference front() { return operator[](0); }
+    reference front() { return *addr_(); }
     //! Reference to the first element
-    const_reference front() const { return operator[](0); }
+    const_reference front() const { return *const_addr_(); }
     //! Reference to the last element
-    reference back() { return operator[](CollectionBase::size() - 1); }
+    reference back() { return *addr_(CollectionBase::size() - 1); }
     //! Reference to the last element
-    const_reference back() const { return operator[](CollectionBase::size() - 1); }
+    const_reference back() const { return *const_addr_(CollectionBase::size() - 1); }
     //! Copy the array contents.
     /*!
      * If the new size is greater than nmax, data will be reallocated, making all references invalid.
@@ -94,8 +94,8 @@ namespace panda {
     void reallocate_(UInt_t) override;
 
   private:
-    value_type* addr_() const { return reinterpret_cast<value_type*>(ContainerBase::array_); }
-    value_type const* const_addr_() const { return reinterpret_cast<value_type const*>(ContainerBase::array_); }
+    value_type* addr_(unsigned idx = 0);
+    value_type const* const_addr_(unsigned idx = 0) const;
 
     template<class T = E>
     typename std::enable_if<std::is_constructible<T>::value>::type allocate_(UInt_t);
@@ -128,12 +128,7 @@ namespace panda {
     if (_idx >= CollectionBase::size())
       throw std::out_of_range((ContainerBase::name_ + "::at").Data());
 
-    // Here we may be calling from a base class (when E0 <- E1, (Collection<E0>*)(&t1_array)->at(i) should properly point to the second *E1*, not E0),
-    // which means we must shift by _idx * unitSize_ instead of _idx * sizeof(value_type).
-    Char_t* p(ContainerBase::array_);
-    p += _idx * ContainerBase::unitSize_;
-
-    return *reinterpret_cast<value_type*>(p);
+    return *addr_(_idx);
   }
 
   template<class E>
@@ -143,36 +138,7 @@ namespace panda {
     if (_idx >= CollectionBase::size())
       throw std::out_of_range((ContainerBase::name_ + "::at").Data());
   
-    // Here we may be calling from a base class (when E0 <- E1, (Collection<E0>*)(&t1_array)->at(i) should properly point to the second *E1*, not E0),
-    // which means we must shift by _idx * unitSize_ instead of _idx * sizeof(value_type).
-    Char_t* p(ContainerBase::array_);
-    p += _idx * ContainerBase::unitSize_;
-
-    return *reinterpret_cast<value_type const*>(p);
-  }
-
-  template<class E>
-  typename Collection<E>::reference
-  Collection<E>::operator[](UInt_t _idx)
-  {
-    // Here we may be calling from a base class (when E0 <- E1, (Array<E0>*)(&t1_array)->at(i) should properly point to the second *E1*, not E0),
-    // which means we must shift by _idx * unitSize_ instead of _idx * sizeof(value_type).
-    Char_t* p(ContainerBase::array_);
-    p += _idx * ContainerBase::unitSize_;
-
-    return *reinterpret_cast<value_type*>(p);
-  }
-
-  template<class E>
-  typename Collection<E>::const_reference
-  Collection<E>::operator[](UInt_t _idx) const
-  {
-    // Here we may be calling from a base class (when E0 <- E1, (Array<E0>*)(&t1_array)->at(i) should properly point to the second *E1*, not E0),
-    // which means we must shift by _idx * unitSize_ instead of _idx * sizeof(value_type).
-    Char_t* p(ContainerBase::array_);
-    p += _idx * ContainerBase::unitSize_;
-
-    return *reinterpret_cast<value_type const*>(p);
+    return *const_addr_(_idx);
   }
 
   template<class E>
@@ -269,6 +235,28 @@ namespace panda {
 
     // deallocate old space
     deallocate_(tmpArray, tmpStore);
+  }
+
+  /*private*/
+  template<class E>
+  typename Collection<E>::value_type*
+  Collection<E>::addr_(unsigned _idx/* = 0*/)
+  {
+    // Here we may be calling from a base class (when E0 <- E1, (Collection<E0>*)(&t1_array)->addr_(i) should properly point to the second *E1*, not E0),
+    // which means we must shift by _idx * unitSize_ instead of _idx * sizeof(value_type).
+
+    return reinterpret_cast<value_type*>(ContainerBase::array_ + _idx * ContainerBase::unitSize_);
+  }
+
+  /*private*/
+  template<class E>
+  typename Collection<E>::value_type const*
+  Collection<E>::const_addr_(unsigned _idx/* = 0*/) const
+  {
+    // Here we may be calling from a base class (when E0 <- E1, (Collection<E0>*)(&t1_array)->addr_(i) should properly point to the second *E1*, not E0),
+    // which means we must shift by _idx * unitSize_ instead of _idx * sizeof(value_type).
+
+    return reinterpret_cast<value_type const*>(ContainerBase::array_ + _idx * ContainerBase::unitSize_);
   }
 
   /*private*/


### PR DESCRIPTION
There was a bug in Collection and Array ::end() function.
It matters for e.g.
`
Collection<B>* ptr = &collection;
ptr->end();
`
where `collection` is a Collection of class D which derives from B. We need `ptr->end()` to point to the address of one-past-last element of `collection`. The bug was that the address was instead of one-past-last element of a Collection<B> with the same size.

Fixed and also slightly simplified the code.
