### PR TITLE
Element tweak

### DIFF
--- a/Framework/interface/Array.h
+++ b/Framework/interface/Array.h
@@ -93,7 +93,7 @@ namespace panda {
       // Call the destructor of the array elements
       auto* p(addr_());
       for (UInt_t iP(0); iP != data.nmax(); ++iP, ++p)
-        p->destructor();
+        p->destructor(true);
 
       std::allocator<value_type>().deallocate(addr_(), data.nmax());
       data.deallocate();

--- a/Framework/interface/Collection.h
+++ b/Framework/interface/Collection.h
@@ -292,7 +292,7 @@ namespace panda {
     // Call the destructor of the array elements
     value_type* p(_addr);
     for (UInt_t iP(0); iP != _data.nmax(); ++iP, ++p)
-      p->destructor();
+      p->destructor(true);
 
     std::allocator<value_type>().deallocate(_addr, _data.nmax());
     _data.deallocate();

--- a/Framework/interface/Element.h
+++ b/Framework/interface/Element.h
@@ -15,13 +15,19 @@ namespace panda {
   //! Base class for elements of containers.
   /*!
    * Element is the base class of objects that are elements of containers (Array = fixed size and Collection = dynamic size).
-   * All deriving class of Element must have a subclass named datastore (which derives from Element::datastore) where
+   * All deriving class of Element must have a member class named datastore (which derives from Element::datastore) where
    * arrays of plain-old-data types and vectors of objects are held. This big chunk of memory is in turn owned by a Container, which
    * also holds an array of Elements. Individual "data members" of a Element-derived class are references to the
    * elements of their associated datastore, linked by the Container.
    * By construction, the standard usage of the Element object is therefore to define a container first and to fetch from it
    * as an element. However, it is also possible to use a Element class as a singlet. This operation is rather expensive as
    * every singlet instantiation of a Element will create a one-element Array in memory in the back end.
+   *
+   * Note on destructors:
+   * The actual destructor of the is called only if the Element is instantiated as a singlet.
+   * In the Container environment, the memory allocated for this object is directly deallocated without
+   * calling ~(Object). If subclasses need to make some calls at the destruction time of the object, they
+   * must be implemented in the destructor() function.
    */
   class Element : public Object {
   public:
@@ -73,7 +79,7 @@ namespace panda {
      * Copy construction is similar to default construction, and involves a creation of a one-element Array.
      */
     Element(Element const& src) : Object(src) {}
-    ~Element() {}
+    ~Element();
     Element& operator=(Element const&) { return *this; }
 
     static char const* typeName() { return "Element"; }
@@ -87,15 +93,6 @@ namespace panda {
     char const* getName() const final;
     void setName(char const*) final;
 
-    //! Destructor implementation
-    /*!
-     * The actual destructor of the object should be called only if the Element is constructed as a singlet.
-     * In the Container environment, the memory allocated for this object is directly deallocated without
-     * calling ~(Object). If subclasses need to make some calls at the destruction time of the object, they
-     * must be implemented in this function.
-     */
-    virtual void destructor() {}
-
   protected:
     //! Ctor for singlet instantiation
     /*!
@@ -108,9 +105,6 @@ namespace panda {
     virtual void doSetAddress_(TTree&, TString const&, utils::BranchList const&, Bool_t setStatus) = 0;
     virtual void doBook_(TTree&, TString const&, utils::BranchList const&) = 0;
     virtual void doInit_() = 0;
-  };
-
-  namespace utils {
 
     //! Singleton class for bookkeeping of Elements constructed as singlets.
     /*!
@@ -119,28 +113,22 @@ namespace panda {
      * referenced by singlet Elements. When a singlet Element is destructed, the slots in StoraManager
      * it referred to are freed and is recycled for the next instantiation of an Element object.
      */
-    class StoreManager {
+    class StoreManager : public std::map<Element const*, ArrayBase*> {
     public:
-      void add(Element const* obj, ArrayBase* array) { store_.emplace(obj, array); }
-      ArrayBase& getArray(Element const* obj) const { return *store_.at(obj); }
+      ArrayBase& getArray(Element const*) const;
       template<class O> typename O::datastore& getData(O const*) const;
       char const* getName(Element const*) const;
-      void free(Element const*);
-
-    private:
-      std::map<Element const*, ArrayBase*> store_{};
     };
 
-    template<class O>
-    typename O::datastore&
-    StoreManager::getData(O const* _obj) const
-    {
-      return static_cast<typename O::datastore&>(store_.at(_obj)->getData());
-    }
-    
-  }
+    static StoreManager gStore;
+  };
 
-  extern utils::StoreManager gStore;
+  template<class O>
+  typename O::datastore&
+  Element::StoreManager::getData(O const* _obj) const
+  {
+    return static_cast<typename O::datastore&>(getArray(_obj).getData());
+  }
 }
 
 #endif

--- a/Framework/src/Element.cc
+++ b/Framework/src/Element.cc
@@ -1,20 +1,29 @@
 #include "../interface/Element.h"
 #include "../interface/ArrayBase.h"
 
-namespace panda {
-  panda::utils::StoreManager gStore;
-}
+panda::Element::StoreManager panda::Element::gStore;
 
 /*protected*/
 panda::Element::Element(ArrayBase* _array)
 {
-  gStore.add(this, _array);
+  gStore.emplace(this, _array);
+}
+
+panda::Element::~Element()
+{
+  delete &gStore.getArray(this);
+  gStore.erase(this);
 }
 
 char const*
 panda::Element::getName() const
 {
-  return gStore.getName(this);
+  // Must return an empty string when called for a non-singlet instance (i.e. a member of a Container)
+  auto oItr(gStore.find(this));
+  if (oItr == gStore.end())
+    return "";
+  else
+    return oItr->second->getName();
 }
 
 void
@@ -26,22 +35,25 @@ panda::Element::setName(char const* _name)
 void
 panda::Element::setStatus(TTree& _tree, utils::BranchList const& _branches)
 {
-  gStore.getData(this).setStatus(_tree, gStore.getName(this), _branches);
+  auto& array(gStore.getArray(this));
+  array.getData().setStatus(_tree, array.getName(), _branches);
 }
 
 panda::utils::BranchList
 panda::Element::getStatus(TTree& _tree) const
 {
-  return gStore.getData(this).getStatus(_tree, gStore.getName(this));
+  auto& array(gStore.getArray(this));
+  return array.getData().getStatus(_tree, array.getName());
 }
 
 panda::utils::BranchList
 panda::Element::getBranchNames(Bool_t _fullName/* = kTRUE*/) const
 {
+  auto& array(gStore.getArray(this));
   if (_fullName)
-    return gStore.getData(this).getBranchNames(gStore.getName(this));
+    return array.getData().getBranchNames(array.getName());
   else
-    return gStore.getData(this).getBranchNames();
+    return array.getData().getBranchNames();
 }
 
 void
@@ -57,22 +69,23 @@ panda::Element::book(TTree& _tree, utils::BranchList const& _branches/* = {"*"}*
   doBook_(_tree, gStore.getName(this), _branches);
 }
 
-char const*
-panda::utils::StoreManager::getName(Element const* _obj) const
+panda::ArrayBase&
+panda::Element::StoreManager::getArray(Element const* _obj) const
 {
-  return store_.at(_obj)->getName();
+  try {
+    return *at(_obj);
+  }
+  catch (std::out_of_range&) {
+    std::cerr << "!!! EXCEPTION !!!" << std::endl;
+    std::cerr << "Data was requested for a non-singlet " << _obj->typeName() << " instance." << std::endl;
+    std::cerr << "This should not happen under normal circumstances and indicates a bug in" << std::endl;
+    std::cerr << "the framework. Contact a Panda expert to fix the issue." << std::endl;
+    throw;
+  }
 }
 
-void
-panda::utils::StoreManager::free(Element const* _obj)
+char const*
+panda::Element::StoreManager::getName(Element const* _obj) const
 {
-  // Since virtual destructors are called recursively, destruction of one derived object
-  // will result in multiple calls of free(). Not very efficient, but the alternative
-  // is to add some "freed" flag to the objects.
-  auto itr(store_.find(_obj));
-  if (itr == store_.end())
-    return;
-
-  delete itr->second;
-  store_.erase(itr);
+  return getArray(_obj).getName();
 }

--- a/Objects/interface/Electron.h
+++ b/Objects/interface/Electron.h
@@ -157,7 +157,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     Electron(ArrayBase*);

--- a/Objects/interface/FatJet.h
+++ b/Objects/interface/FatJet.h
@@ -143,7 +143,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     FatJet(ArrayBase*);

--- a/Objects/interface/GenJet.h
+++ b/Objects/interface/GenJet.h
@@ -70,7 +70,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     GenJet(ArrayBase*);

--- a/Objects/interface/GenParticle.h
+++ b/Objects/interface/GenParticle.h
@@ -93,7 +93,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     GenParticle(ArrayBase*);

--- a/Objects/interface/Jet.h
+++ b/Objects/interface/Jet.h
@@ -110,7 +110,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     Jet(ArrayBase*);

--- a/Objects/interface/Lepton.h
+++ b/Objects/interface/Lepton.h
@@ -94,7 +94,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     Lepton(ArrayBase*);

--- a/Objects/interface/MicroJet.h
+++ b/Objects/interface/MicroJet.h
@@ -72,7 +72,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     MicroJet(ArrayBase*);

--- a/Objects/interface/Muon.h
+++ b/Objects/interface/Muon.h
@@ -112,7 +112,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     Muon(ArrayBase*);

--- a/Objects/interface/PFCand.h
+++ b/Objects/interface/PFCand.h
@@ -116,7 +116,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     PFCand(ArrayBase*);

--- a/Objects/interface/PackedParticle.h
+++ b/Objects/interface/PackedParticle.h
@@ -77,7 +77,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     PackedParticle(ArrayBase*);

--- a/Objects/interface/PackedTrack.h
+++ b/Objects/interface/PackedTrack.h
@@ -75,7 +75,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     PackedTrack(ArrayBase*);

--- a/Objects/interface/Particle.h
+++ b/Objects/interface/Particle.h
@@ -70,7 +70,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     Particle(ArrayBase*);

--- a/Objects/interface/ParticleM.h
+++ b/Objects/interface/ParticleM.h
@@ -67,7 +67,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     ParticleM(ArrayBase*);

--- a/Objects/interface/ParticleP.h
+++ b/Objects/interface/ParticleP.h
@@ -64,7 +64,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     ParticleP(ArrayBase*);

--- a/Objects/interface/Parton.h
+++ b/Objects/interface/Parton.h
@@ -70,7 +70,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     Parton(ArrayBase*);

--- a/Objects/interface/Photon.h
+++ b/Objects/interface/Photon.h
@@ -158,7 +158,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     Photon(ArrayBase*);

--- a/Objects/interface/RecoVertex.h
+++ b/Objects/interface/RecoVertex.h
@@ -71,7 +71,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     RecoVertex(ArrayBase*);

--- a/Objects/interface/SuperCluster.h
+++ b/Objects/interface/SuperCluster.h
@@ -55,7 +55,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     SuperCluster(ArrayBase*);

--- a/Objects/interface/TPPair.h
+++ b/Objects/interface/TPPair.h
@@ -53,7 +53,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     TPPair(ArrayBase*);

--- a/Objects/interface/Tau.h
+++ b/Objects/interface/Tau.h
@@ -90,7 +90,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     Tau(ArrayBase*);

--- a/Objects/interface/UnpackedGenParticle.h
+++ b/Objects/interface/UnpackedGenParticle.h
@@ -79,7 +79,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     UnpackedGenParticle(ArrayBase*);

--- a/Objects/interface/UnpackedPFCand.h
+++ b/Objects/interface/UnpackedPFCand.h
@@ -107,7 +107,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     UnpackedPFCand(ArrayBase*);

--- a/Objects/interface/Vertex.h
+++ b/Objects/interface/Vertex.h
@@ -57,7 +57,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     Vertex(ArrayBase*);

--- a/Objects/interface/XPhoton.h
+++ b/Objects/interface/XPhoton.h
@@ -168,7 +168,7 @@ namespace panda {
 
     static utils::BranchList getListOfBranches();
 
-    void destructor() override;
+    void destructor(Bool_t recursive = kFALSE);
 
   protected:
     XPhoton(ArrayBase*);

--- a/Objects/src/Electron.cc
+++ b/Objects/src/Electron.cc
@@ -272,7 +272,7 @@ panda::Electron::Electron(char const* _name/* = ""*/) :
 }
 
 panda::Electron::Electron(Electron const& _src) :
-  Lepton(new ElectronArray(1, gStore.getName(&_src))),
+  Lepton(new ElectronArray(1, _src.getName())),
   hltsafe(gStore.getData(this).hltsafe[0]),
   chIsoPh(gStore.getData(this).chIsoPh[0]),
   nhIsoPh(gStore.getData(this).nhIsoPh[0]),
@@ -367,16 +367,16 @@ panda::Electron::Electron(ArrayBase* _array) :
 panda::Electron::~Electron()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::Electron::destructor()
+panda::Electron::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM Electron.cc.destructor */
   /* END CUSTOM */
 
-  Lepton::destructor();
+  if (_recursive)
+    Lepton::destructor(kTRUE);
 }
 
 panda::Electron&

--- a/Objects/src/FatJet.cc
+++ b/Objects/src/FatJet.cc
@@ -201,7 +201,7 @@ panda::FatJet::FatJet(char const* _name/* = ""*/) :
 }
 
 panda::FatJet::FatJet(FatJet const& _src) :
-  Jet(new FatJetArray(1, gStore.getName(&_src))),
+  Jet(new FatJetArray(1, _src.getName())),
   tau1(gStore.getData(this).tau1[0]),
   tau2(gStore.getData(this).tau2[0]),
   tau3(gStore.getData(this).tau3[0]),
@@ -272,16 +272,16 @@ panda::FatJet::FatJet(ArrayBase* _array) :
 panda::FatJet::~FatJet()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::FatJet::destructor()
+panda::FatJet::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM FatJet.cc.destructor */
   /* END CUSTOM */
 
-  Jet::destructor();
+  if (_recursive)
+    Jet::destructor(kTRUE);
 }
 
 panda::FatJet&

--- a/Objects/src/GenJet.cc
+++ b/Objects/src/GenJet.cc
@@ -92,7 +92,7 @@ panda::GenJet::GenJet(char const* _name/* = ""*/) :
 }
 
 panda::GenJet::GenJet(GenJet const& _src) :
-  ParticleM(new GenJetArray(1, gStore.getName(&_src))),
+  ParticleM(new GenJetArray(1, _src.getName())),
   pdgid(gStore.getData(this).pdgid[0])
 {
   ParticleM::operator=(_src);
@@ -115,16 +115,16 @@ panda::GenJet::GenJet(ArrayBase* _array) :
 panda::GenJet::~GenJet()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::GenJet::destructor()
+panda::GenJet::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM GenJet.cc.destructor */
   /* END CUSTOM */
 
-  ParticleM::destructor();
+  if (_recursive)
+    ParticleM::destructor(kTRUE);
 }
 
 panda::GenJet&

--- a/Objects/src/GenParticle.cc
+++ b/Objects/src/GenParticle.cc
@@ -137,7 +137,7 @@ panda::GenParticle::GenParticle(char const* _name/* = ""*/) :
 }
 
 panda::GenParticle::GenParticle(GenParticle const& _src) :
-  PackedParticle(new GenParticleArray(1, gStore.getName(&_src))),
+  PackedParticle(new GenParticleArray(1, _src.getName())),
   pdgid(gStore.getData(this).pdgid[0]),
   finalState(gStore.getData(this).finalState[0]),
   statusFlags(gStore.getData(this).statusFlags[0]),
@@ -172,16 +172,16 @@ panda::GenParticle::GenParticle(ArrayBase* _array) :
 panda::GenParticle::~GenParticle()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::GenParticle::destructor()
+panda::GenParticle::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM GenParticle.cc.destructor */
   /* END CUSTOM */
 
-  PackedParticle::destructor();
+  if (_recursive)
+    PackedParticle::destructor(kTRUE);
 }
 
 panda::GenParticle&

--- a/Objects/src/Jet.cc
+++ b/Objects/src/Jet.cc
@@ -219,7 +219,7 @@ panda::Jet::Jet(char const* _name/* = ""*/) :
 }
 
 panda::Jet::Jet(Jet const& _src) :
-  MicroJet(new JetArray(1, gStore.getName(&_src))),
+  MicroJet(new JetArray(1, _src.getName())),
   rawPt(gStore.getData(this).rawPt[0]),
   ptCorrUp(gStore.getData(this).ptCorrUp[0]),
   ptCorrDown(gStore.getData(this).ptCorrDown[0]),
@@ -298,16 +298,16 @@ panda::Jet::Jet(ArrayBase* _array) :
 panda::Jet::~Jet()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::Jet::destructor()
+panda::Jet::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM Jet.cc.destructor */
   /* END CUSTOM */
 
-  MicroJet::destructor();
+  if (_recursive)
+    MicroJet::destructor(kTRUE);
 }
 
 panda::Jet&

--- a/Objects/src/Lepton.cc
+++ b/Objects/src/Lepton.cc
@@ -191,7 +191,7 @@ panda::Lepton::Lepton(char const* _name/* = ""*/) :
 }
 
 panda::Lepton::Lepton(Lepton const& _src) :
-  ParticleP(new LeptonArray(1, gStore.getName(&_src))),
+  ParticleP(new LeptonArray(1, _src.getName())),
   pfPt(gStore.getData(this).pfPt[0]),
   charge(gStore.getData(this).charge[0]),
   loose(gStore.getData(this).loose[0]),
@@ -258,16 +258,16 @@ panda::Lepton::Lepton(ArrayBase* _array) :
 panda::Lepton::~Lepton()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::Lepton::destructor()
+panda::Lepton::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM Lepton.cc.destructor */
   /* END CUSTOM */
 
-  ParticleP::destructor();
+  if (_recursive)
+    ParticleP::destructor(kTRUE);
 }
 
 panda::Lepton&

--- a/Objects/src/MicroJet.cc
+++ b/Objects/src/MicroJet.cc
@@ -101,7 +101,7 @@ panda::MicroJet::MicroJet(char const* _name/* = ""*/) :
 }
 
 panda::MicroJet::MicroJet(MicroJet const& _src) :
-  ParticleM(new MicroJetArray(1, gStore.getName(&_src))),
+  ParticleM(new MicroJetArray(1, _src.getName())),
   csv(gStore.getData(this).csv[0]),
   qgl(gStore.getData(this).qgl[0])
 {
@@ -128,16 +128,16 @@ panda::MicroJet::MicroJet(ArrayBase* _array) :
 panda::MicroJet::~MicroJet()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::MicroJet::destructor()
+panda::MicroJet::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM MicroJet.cc.destructor */
   /* END CUSTOM */
 
-  ParticleM::destructor();
+  if (_recursive)
+    ParticleM::destructor(kTRUE);
 }
 
 panda::MicroJet&

--- a/Objects/src/Muon.cc
+++ b/Objects/src/Muon.cc
@@ -110,7 +110,7 @@ panda::Muon::Muon(char const* _name/* = ""*/) :
 }
 
 panda::Muon::Muon(Muon const& _src) :
-  Lepton(new MuonArray(1, gStore.getName(&_src))),
+  Lepton(new MuonArray(1, _src.getName())),
   mediumBtoF(gStore.getData(this).mediumBtoF[0]),
   triggerMatch(gStore.getData(this).triggerMatch[0])
 {
@@ -137,16 +137,16 @@ panda::Muon::Muon(ArrayBase* _array) :
 panda::Muon::~Muon()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::Muon::destructor()
+panda::Muon::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM Muon.cc.destructor */
   /* END CUSTOM */
 
-  Lepton::destructor();
+  if (_recursive)
+    Lepton::destructor(kTRUE);
 }
 
 panda::Muon&

--- a/Objects/src/PFCand.cc
+++ b/Objects/src/PFCand.cc
@@ -139,7 +139,7 @@ panda::PFCand::PFCand(char const* _name/* = ""*/) :
 }
 
 panda::PFCand::PFCand(PFCand const& _src) :
-  PackedParticle(new PFCandArray(1, gStore.getName(&_src))),
+  PackedParticle(new PFCandArray(1, _src.getName())),
   packedPuppiW(gStore.getData(this).packedPuppiW[0]),
   packedPuppiWNoLepDiff(gStore.getData(this).packedPuppiWNoLepDiff[0]),
   ptype(gStore.getData(this).ptype[0]),
@@ -178,16 +178,16 @@ panda::PFCand::PFCand(ArrayBase* _array) :
 panda::PFCand::~PFCand()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::PFCand::destructor()
+panda::PFCand::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM PFCand.cc.destructor */
   /* END CUSTOM */
 
-  PackedParticle::destructor();
+  if (_recursive)
+    PackedParticle::destructor(kTRUE);
 }
 
 panda::PFCand&

--- a/Objects/src/PackedParticle.cc
+++ b/Objects/src/PackedParticle.cc
@@ -119,7 +119,7 @@ panda::PackedParticle::PackedParticle(char const* _name/* = ""*/) :
 }
 
 panda::PackedParticle::PackedParticle(PackedParticle const& _src) :
-  Particle(new PackedParticleArray(1, gStore.getName(&_src))),
+  Particle(new PackedParticleArray(1, _src.getName())),
   packedPt(gStore.getData(this).packedPt[0]),
   packedEta(gStore.getData(this).packedEta[0]),
   packedPhi(gStore.getData(this).packedPhi[0]),
@@ -154,16 +154,16 @@ panda::PackedParticle::PackedParticle(ArrayBase* _array) :
 panda::PackedParticle::~PackedParticle()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::PackedParticle::destructor()
+panda::PackedParticle::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM PackedParticle.cc.destructor */
   /* END CUSTOM */
 
-  Particle::destructor();
+  if (_recursive)
+    Particle::destructor(kTRUE);
 }
 
 panda::PackedParticle&

--- a/Objects/src/PackedTrack.cc
+++ b/Objects/src/PackedTrack.cc
@@ -118,7 +118,7 @@ panda::PackedTrack::PackedTrack(char const* _name/* = ""*/) :
 }
 
 panda::PackedTrack::PackedTrack(PackedTrack const& _src) :
-  Element(new PackedTrackArray(1, gStore.getName(&_src))),
+  Element(new PackedTrackArray(1, _src.getName())),
   packedPtError(gStore.getData(this).packedPtError[0]),
   packedDxy(gStore.getData(this).packedDxy[0]),
   packedDz(gStore.getData(this).packedDz[0]),
@@ -153,16 +153,13 @@ panda::PackedTrack::PackedTrack(ArrayBase* _array) :
 panda::PackedTrack::~PackedTrack()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::PackedTrack::destructor()
+panda::PackedTrack::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM PackedTrack.cc.destructor */
   /* END CUSTOM */
-
-  Element::destructor();
 }
 
 panda::PackedTrack&

--- a/Objects/src/Particle.cc
+++ b/Objects/src/Particle.cc
@@ -88,16 +88,13 @@ panda::Particle::Particle(ArrayBase* _array) :
 panda::Particle::~Particle()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::Particle::destructor()
+panda::Particle::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM Particle.cc.destructor */
   /* END CUSTOM */
-
-  Element::destructor();
 }
 
 panda::Particle&

--- a/Objects/src/ParticleM.cc
+++ b/Objects/src/ParticleM.cc
@@ -92,7 +92,7 @@ panda::ParticleM::ParticleM(char const* _name/* = ""*/) :
 }
 
 panda::ParticleM::ParticleM(ParticleM const& _src) :
-  ParticleP(new ParticleMArray(1, gStore.getName(&_src))),
+  ParticleP(new ParticleMArray(1, _src.getName())),
   mass_(gStore.getData(this).mass_[0])
 {
   ParticleP::operator=(_src);
@@ -115,16 +115,16 @@ panda::ParticleM::ParticleM(ArrayBase* _array) :
 panda::ParticleM::~ParticleM()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::ParticleM::destructor()
+panda::ParticleM::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM ParticleM.cc.destructor */
   /* END CUSTOM */
 
-  ParticleP::destructor();
+  if (_recursive)
+    ParticleP::destructor(kTRUE);
 }
 
 panda::ParticleM&

--- a/Objects/src/ParticleP.cc
+++ b/Objects/src/ParticleP.cc
@@ -110,7 +110,7 @@ panda::ParticleP::ParticleP(char const* _name/* = ""*/) :
 }
 
 panda::ParticleP::ParticleP(ParticleP const& _src) :
-  Particle(new ParticlePArray(1, gStore.getName(&_src))),
+  Particle(new ParticlePArray(1, _src.getName())),
   pt_(gStore.getData(this).pt_[0]),
   eta_(gStore.getData(this).eta_[0]),
   phi_(gStore.getData(this).phi_[0])
@@ -141,16 +141,16 @@ panda::ParticleP::ParticleP(ArrayBase* _array) :
 panda::ParticleP::~ParticleP()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::ParticleP::destructor()
+panda::ParticleP::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM ParticleP.cc.destructor */
   /* END CUSTOM */
 
-  Particle::destructor();
+  if (_recursive)
+    Particle::destructor(kTRUE);
 }
 
 panda::ParticleP&

--- a/Objects/src/Parton.cc
+++ b/Objects/src/Parton.cc
@@ -92,7 +92,7 @@ panda::Parton::Parton(char const* _name/* = ""*/) :
 }
 
 panda::Parton::Parton(Parton const& _src) :
-  ParticleM(new PartonArray(1, gStore.getName(&_src))),
+  ParticleM(new PartonArray(1, _src.getName())),
   pdgid(gStore.getData(this).pdgid[0])
 {
   ParticleM::operator=(_src);
@@ -115,16 +115,16 @@ panda::Parton::Parton(ArrayBase* _array) :
 panda::Parton::~Parton()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::Parton::destructor()
+panda::Parton::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM Parton.cc.destructor */
   /* END CUSTOM */
 
-  ParticleM::destructor();
+  if (_recursive)
+    ParticleM::destructor(kTRUE);
 }
 
 panda::Parton&

--- a/Objects/src/Photon.cc
+++ b/Objects/src/Photon.cc
@@ -408,7 +408,7 @@ panda::Photon::Photon(char const* _name/* = ""*/) :
 }
 
 panda::Photon::Photon(Photon const& _src) :
-  ParticleP(new PhotonArray(1, gStore.getName(&_src))),
+  ParticleP(new PhotonArray(1, _src.getName())),
   pfPt(gStore.getData(this).pfPt[0]),
   chIso(gStore.getData(this).chIso[0]),
   chIsoMax(gStore.getData(this).chIsoMax[0]),
@@ -563,16 +563,16 @@ panda::Photon::Photon(ArrayBase* _array) :
 panda::Photon::~Photon()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::Photon::destructor()
+panda::Photon::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM Photon.cc.destructor */
   /* END CUSTOM */
 
-  ParticleP::destructor();
+  if (_recursive)
+    ParticleP::destructor(kTRUE);
 }
 
 panda::Photon&

--- a/Objects/src/RecoVertex.cc
+++ b/Objects/src/RecoVertex.cc
@@ -128,7 +128,7 @@ panda::RecoVertex::RecoVertex(char const* _name/* = ""*/) :
 }
 
 panda::RecoVertex::RecoVertex(RecoVertex const& _src) :
-  Vertex(new RecoVertexArray(1, gStore.getName(&_src))),
+  Vertex(new RecoVertexArray(1, _src.getName())),
   score(gStore.getData(this).score[0]),
   ntrk(gStore.getData(this).ntrk[0]),
   ndof(gStore.getData(this).ndof[0]),
@@ -167,16 +167,16 @@ panda::RecoVertex::RecoVertex(ArrayBase* _array) :
 panda::RecoVertex::~RecoVertex()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::RecoVertex::destructor()
+panda::RecoVertex::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM RecoVertex.cc.destructor */
   /* END CUSTOM */
 
-  Vertex::destructor();
+  if (_recursive)
+    Vertex::destructor(kTRUE);
 }
 
 panda::RecoVertex&

--- a/Objects/src/SuperCluster.cc
+++ b/Objects/src/SuperCluster.cc
@@ -109,7 +109,7 @@ panda::SuperCluster::SuperCluster(char const* _name/* = ""*/) :
 }
 
 panda::SuperCluster::SuperCluster(SuperCluster const& _src) :
-  Element(new SuperClusterArray(1, gStore.getName(&_src))),
+  Element(new SuperClusterArray(1, _src.getName())),
   rawPt(gStore.getData(this).rawPt[0]),
   eta(gStore.getData(this).eta[0]),
   phi(gStore.getData(this).phi[0])
@@ -140,16 +140,13 @@ panda::SuperCluster::SuperCluster(ArrayBase* _array) :
 panda::SuperCluster::~SuperCluster()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::SuperCluster::destructor()
+panda::SuperCluster::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM SuperCluster.cc.destructor */
   /* END CUSTOM */
-
-  Element::destructor();
 }
 
 panda::SuperCluster&

--- a/Objects/src/TPPair.cc
+++ b/Objects/src/TPPair.cc
@@ -100,7 +100,7 @@ panda::TPPair::TPPair(char const* _name/* = ""*/) :
 }
 
 panda::TPPair::TPPair(TPPair const& _src) :
-  Element(new TPPairArray(1, gStore.getName(&_src))),
+  Element(new TPPairArray(1, _src.getName())),
   mass(gStore.getData(this).mass[0]),
   mass2(gStore.getData(this).mass2[0])
 {
@@ -127,16 +127,13 @@ panda::TPPair::TPPair(ArrayBase* _array) :
 panda::TPPair::~TPPair()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::TPPair::destructor()
+panda::TPPair::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM TPPair.cc.destructor */
   /* END CUSTOM */
-
-  Element::destructor();
 }
 
 panda::TPPair&

--- a/Objects/src/Tau.cc
+++ b/Objects/src/Tau.cc
@@ -164,7 +164,7 @@ panda::Tau::Tau(char const* _name/* = ""*/) :
 }
 
 panda::Tau::Tau(Tau const& _src) :
-  ParticleM(new TauArray(1, gStore.getName(&_src))),
+  ParticleM(new TauArray(1, _src.getName())),
   charge(gStore.getData(this).charge[0]),
   decayMode(gStore.getData(this).decayMode[0]),
   decayModeNew(gStore.getData(this).decayModeNew[0]),
@@ -219,16 +219,16 @@ panda::Tau::Tau(ArrayBase* _array) :
 panda::Tau::~Tau()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::Tau::destructor()
+panda::Tau::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM Tau.cc.destructor */
   /* END CUSTOM */
 
-  ParticleM::destructor();
+  if (_recursive)
+    ParticleM::destructor(kTRUE);
 }
 
 panda::Tau&

--- a/Objects/src/UnpackedGenParticle.cc
+++ b/Objects/src/UnpackedGenParticle.cc
@@ -119,7 +119,7 @@ panda::UnpackedGenParticle::UnpackedGenParticle(char const* _name/* = ""*/) :
 }
 
 panda::UnpackedGenParticle::UnpackedGenParticle(UnpackedGenParticle const& _src) :
-  ParticleM(new UnpackedGenParticleArray(1, gStore.getName(&_src))),
+  ParticleM(new UnpackedGenParticleArray(1, _src.getName())),
   pdgid(gStore.getData(this).pdgid[0]),
   finalState(gStore.getData(this).finalState[0]),
   statusFlags(gStore.getData(this).statusFlags[0]),
@@ -154,16 +154,16 @@ panda::UnpackedGenParticle::UnpackedGenParticle(ArrayBase* _array) :
 panda::UnpackedGenParticle::~UnpackedGenParticle()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::UnpackedGenParticle::destructor()
+panda::UnpackedGenParticle::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM UnpackedGenParticle.cc.destructor */
   /* END CUSTOM */
 
-  ParticleM::destructor();
+  if (_recursive)
+    ParticleM::destructor(kTRUE);
 }
 
 panda::UnpackedGenParticle&

--- a/Objects/src/UnpackedPFCand.cc
+++ b/Objects/src/UnpackedPFCand.cc
@@ -140,7 +140,7 @@ panda::UnpackedPFCand::UnpackedPFCand(char const* _name/* = ""*/) :
 }
 
 panda::UnpackedPFCand::UnpackedPFCand(UnpackedPFCand const& _src) :
-  ParticleM(new UnpackedPFCandArray(1, gStore.getName(&_src))),
+  ParticleM(new UnpackedPFCandArray(1, _src.getName())),
   puppiW(gStore.getData(this).puppiW[0]),
   puppiWNoLep(gStore.getData(this).puppiWNoLep[0]),
   ptype(gStore.getData(this).ptype[0]),
@@ -175,16 +175,16 @@ panda::UnpackedPFCand::UnpackedPFCand(ArrayBase* _array) :
 panda::UnpackedPFCand::~UnpackedPFCand()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::UnpackedPFCand::destructor()
+panda::UnpackedPFCand::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM UnpackedPFCand.cc.destructor */
   /* END CUSTOM */
 
-  ParticleM::destructor();
+  if (_recursive)
+    ParticleM::destructor(kTRUE);
 }
 
 panda::UnpackedPFCand&

--- a/Objects/src/Vertex.cc
+++ b/Objects/src/Vertex.cc
@@ -109,7 +109,7 @@ panda::Vertex::Vertex(char const* _name/* = ""*/) :
 }
 
 panda::Vertex::Vertex(Vertex const& _src) :
-  Element(new VertexArray(1, gStore.getName(&_src))),
+  Element(new VertexArray(1, _src.getName())),
   x(gStore.getData(this).x[0]),
   y(gStore.getData(this).y[0]),
   z(gStore.getData(this).z[0])
@@ -140,16 +140,13 @@ panda::Vertex::Vertex(ArrayBase* _array) :
 panda::Vertex::~Vertex()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::Vertex::destructor()
+panda::Vertex::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM Vertex.cc.destructor */
   /* END CUSTOM */
-
-  Element::destructor();
 }
 
 panda::Vertex&

--- a/Objects/src/XPhoton.cc
+++ b/Objects/src/XPhoton.cc
@@ -166,7 +166,7 @@ panda::XPhoton::XPhoton(char const* _name/* = ""*/) :
 }
 
 panda::XPhoton::XPhoton(XPhoton const& _src) :
-  Photon(new XPhotonArray(1, gStore.getName(&_src))),
+  Photon(new XPhotonArray(1, _src.getName())),
   scEta(gStore.getData(this).scEta[0]),
   scRawPt(gStore.getData(this).scRawPt[0]),
   chIsoS15(gStore.getData(this).chIsoS15[0]),
@@ -217,16 +217,16 @@ panda::XPhoton::XPhoton(ArrayBase* _array) :
 panda::XPhoton::~XPhoton()
 {
   destructor();
-  gStore.free(this);
 }
 
 void
-panda::XPhoton::destructor()
+panda::XPhoton::destructor(Bool_t _recursive/* = kFALSE*/)
 {
   /* BEGIN CUSTOM XPhoton.cc.destructor */
   /* END CUSTOM */
 
-  Photon::destructor();
+  if (_recursive)
+    Photon::destructor(kTRUE);
 }
 
 panda::XPhoton&


### PR DESCRIPTION
- Copy construction of Element subclasses used gStore.getName(src), assuming that src is instantiated as a singlet. This is not necessarily the case; one can copy-construct an Element from a member of a Container. Now using src.getName() which will return an empty string if the src is not found in gStore.
- General implementation around gStore is improved.
- Element destructor is made non-virtual. Each object will call its destructor() in ~Object.
