### PR TITLE
adding a custom block in assignment operator

### DIFF
--- a/Objects/src/Electron.cc
+++ b/Objects/src/Electron.cc
@@ -404,6 +404,9 @@ panda::Electron::operator=(Electron const& _src)
   std::memcpy(triggerMatch, _src.triggerMatch, sizeof(Bool_t) * nTriggerObjects);
   superCluster = _src.superCluster;
 
+  /* BEGIN CUSTOM Electron.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/FatJet.cc
+++ b/Objects/src/FatJet.cc
@@ -303,6 +303,9 @@ panda::FatJet::operator=(FatJet const& _src)
   std::memcpy(ecfs, _src.ecfs, sizeof(Float_t) * 3 * 4 * 4);
   subjets = _src.subjets;
 
+  /* BEGIN CUSTOM FatJet.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/GenJet.cc
+++ b/Objects/src/GenJet.cc
@@ -134,6 +134,9 @@ panda::GenJet::operator=(GenJet const& _src)
 
   pdgid = _src.pdgid;
 
+  /* BEGIN CUSTOM GenJet.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/GenParticle.cc
+++ b/Objects/src/GenParticle.cc
@@ -194,6 +194,9 @@ panda::GenParticle::operator=(GenParticle const& _src)
   statusFlags = _src.statusFlags;
   parent = _src.parent;
 
+  /* BEGIN CUSTOM GenParticle.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/GenReweight.cc
+++ b/Objects/src/GenReweight.cc
@@ -50,6 +50,9 @@ panda::GenReweight::operator=(GenReweight const& _src)
   pdfDW = _src.pdfDW;
   std::memcpy(genParam, _src.genParam, sizeof(Float_t) * 1024);
 
+  /* BEGIN CUSTOM GenReweight.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/HLTBits.cc
+++ b/Objects/src/HLTBits.cc
@@ -29,6 +29,9 @@ panda::HLTBits::operator=(HLTBits const& _src)
 {
   std::memcpy(words, _src.words, sizeof(UInt_t) * 32);
 
+  /* BEGIN CUSTOM HLTBits.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/Jet.cc
+++ b/Objects/src/Jet.cc
@@ -331,6 +331,9 @@ panda::Jet::operator=(Jet const& _src)
   matchedGenJet = _src.matchedGenJet;
   constituents = _src.constituents;
 
+  /* BEGIN CUSTOM Jet.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/Lepton.cc
+++ b/Objects/src/Lepton.cc
@@ -288,6 +288,9 @@ panda::Lepton::operator=(Lepton const& _src)
   matchedGen = _src.matchedGen;
   vertex = _src.vertex;
 
+  /* BEGIN CUSTOM Lepton.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/Met.cc
+++ b/Objects/src/Met.cc
@@ -33,6 +33,9 @@ panda::Met::operator=(Met const& _src)
   pt = _src.pt;
   phi = _src.phi;
 
+  /* BEGIN CUSTOM Met.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/MetFilters.cc
+++ b/Objects/src/MetFilters.cc
@@ -63,6 +63,9 @@ panda::MetFilters::operator=(MetFilters const& _src)
   badPFMuons = _src.badPFMuons;
   badChargedHadrons = _src.badChargedHadrons;
 
+  /* BEGIN CUSTOM MetFilters.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/MicroJet.cc
+++ b/Objects/src/MicroJet.cc
@@ -148,6 +148,9 @@ panda::MicroJet::operator=(MicroJet const& _src)
   csv = _src.csv;
   qgl = _src.qgl;
 
+  /* BEGIN CUSTOM MicroJet.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/Muon.cc
+++ b/Objects/src/Muon.cc
@@ -157,6 +157,9 @@ panda::Muon::operator=(Muon const& _src)
   mediumBtoF = _src.mediumBtoF;
   std::memcpy(triggerMatch, _src.triggerMatch, sizeof(Bool_t) * nTriggerObjects);
 
+  /* BEGIN CUSTOM Muon.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/PFCand.cc
+++ b/Objects/src/PFCand.cc
@@ -201,6 +201,9 @@ panda::PFCand::operator=(PFCand const& _src)
   vertex = _src.vertex;
   track = _src.track;
 
+  /* BEGIN CUSTOM PFCand.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/PackedParticle.cc
+++ b/Objects/src/PackedParticle.cc
@@ -176,6 +176,14 @@ panda::PackedParticle::operator=(PackedParticle const& _src)
   packedPhi = _src.packedPhi;
   packedM = _src.packedM;
 
+  /* BEGIN CUSTOM PackedParticle.cc.operator= */
+  pt_ = _src.pt_;
+  eta_ = _src.eta_;
+  phi_ = _src.phi_;
+  mass_ = _src.mass_;
+  unpacked_ = _src.unpacked_;
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/PackedTrack.cc
+++ b/Objects/src/PackedTrack.cc
@@ -170,6 +170,14 @@ panda::PackedTrack::operator=(PackedTrack const& _src)
   packedDz = _src.packedDz;
   packedDPhi = _src.packedDPhi;
 
+  /* BEGIN CUSTOM PackedTrack.cc.operator= */
+  ptError_ = _src.ptError_;
+  dxy_ = _src.dxy_;
+  dz_ = _src.dz_;
+  dPhi_ = _src.dPhi_;
+  unpacked_ = _src.unpacked_;
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/Particle.cc
+++ b/Objects/src/Particle.cc
@@ -101,6 +101,9 @@ panda::Particle&
 panda::Particle::operator=(Particle const& _src)
 {
 
+  /* BEGIN CUSTOM Particle.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/ParticleM.cc
+++ b/Objects/src/ParticleM.cc
@@ -134,6 +134,9 @@ panda::ParticleM::operator=(ParticleM const& _src)
 
   mass_ = _src.mass_;
 
+  /* BEGIN CUSTOM ParticleM.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/ParticleP.cc
+++ b/Objects/src/ParticleP.cc
@@ -162,6 +162,9 @@ panda::ParticleP::operator=(ParticleP const& _src)
   eta_ = _src.eta_;
   phi_ = _src.phi_;
 
+  /* BEGIN CUSTOM ParticleP.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/Parton.cc
+++ b/Objects/src/Parton.cc
@@ -134,6 +134,9 @@ panda::Parton::operator=(Parton const& _src)
 
   pdgid = _src.pdgid;
 
+  /* BEGIN CUSTOM Parton.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/Photon.cc
+++ b/Objects/src/Photon.cc
@@ -615,6 +615,9 @@ panda::Photon::operator=(Photon const& _src)
   matchedPF = _src.matchedPF;
   matchedGen = _src.matchedGen;
 
+  /* BEGIN CUSTOM Photon.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/RecoMet.cc
+++ b/Objects/src/RecoMet.cc
@@ -57,6 +57,9 @@ panda::RecoMet::operator=(RecoMet const& _src)
   ptUnclDown = _src.ptUnclDown;
   phiUnclDown = _src.phiUnclDown;
 
+  /* BEGIN CUSTOM RecoMet.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/RecoVertex.cc
+++ b/Objects/src/RecoVertex.cc
@@ -190,6 +190,9 @@ panda::RecoVertex::operator=(RecoVertex const& _src)
   chi2 = _src.chi2;
   pfRangeMax = _src.pfRangeMax;
 
+  /* BEGIN CUSTOM RecoVertex.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/Recoil.cc
+++ b/Objects/src/Recoil.cc
@@ -57,6 +57,9 @@ panda::Recoil::operator=(Recoil const& _src)
   gamma = _src.gamma;
   max = _src.max;
 
+  /* BEGIN CUSTOM Recoil.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/SuperCluster.cc
+++ b/Objects/src/SuperCluster.cc
@@ -156,6 +156,9 @@ panda::SuperCluster::operator=(SuperCluster const& _src)
   eta = _src.eta;
   phi = _src.phi;
 
+  /* BEGIN CUSTOM SuperCluster.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/TPPair.cc
+++ b/Objects/src/TPPair.cc
@@ -142,6 +142,9 @@ panda::TPPair::operator=(TPPair const& _src)
   mass = _src.mass;
   mass2 = _src.mass2;
 
+  /* BEGIN CUSTOM TPPair.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/Tau.cc
+++ b/Objects/src/Tau.cc
@@ -246,6 +246,9 @@ panda::Tau::operator=(Tau const& _src)
   vertex = _src.vertex;
   matchedGen = _src.matchedGen;
 
+  /* BEGIN CUSTOM Tau.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/UnpackedGenParticle.cc
+++ b/Objects/src/UnpackedGenParticle.cc
@@ -176,6 +176,9 @@ panda::UnpackedGenParticle::operator=(UnpackedGenParticle const& _src)
   statusFlags = _src.statusFlags;
   parent = _src.parent;
 
+  /* BEGIN CUSTOM UnpackedGenParticle.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/UnpackedPFCand.cc
+++ b/Objects/src/UnpackedPFCand.cc
@@ -197,6 +197,9 @@ panda::UnpackedPFCand::operator=(UnpackedPFCand const& _src)
   ptype = _src.ptype;
   vertex = _src.vertex;
 
+  /* BEGIN CUSTOM UnpackedPFCand.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/Vertex.cc
+++ b/Objects/src/Vertex.cc
@@ -156,6 +156,9 @@ panda::Vertex::operator=(Vertex const& _src)
   y = _src.y;
   z = _src.z;
 
+  /* BEGIN CUSTOM Vertex.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/Objects/src/XPhoton.cc
+++ b/Objects/src/XPhoton.cc
@@ -243,6 +243,9 @@ panda::XPhoton::operator=(XPhoton const& _src)
   isEB = _src.isEB;
   matchedGenId = _src.matchedGenId;
 
+  /* BEGIN CUSTOM XPhoton.cc.operator= */
+  /* END CUSTOM */
+
   return *this;
 }
 

--- a/lib/panda/physics.py
+++ b/lib/panda/physics.py
@@ -474,7 +474,7 @@ class PhysicsObject(Definition, Object):
 
             for method in methods:
                 src.newline()
-                self._write_method(src, 'Singlet', method, custom_block = (method[0] in ['doInit_']))
+                self._write_method(src, 'Singlet', method, custom_block = (method[0] in ['operator=', 'doInit_']))
 
             src.newline()
             src.writeline('panda::utils::BranchList')
@@ -612,7 +612,7 @@ class PhysicsObject(Definition, Object):
 
             for method in methods:
                 src.newline()
-                self._write_method(src, 'Element', method, custom_block = (method[0] in ['doInit_']))
+                self._write_method(src, 'Element', method, custom_block = (method[0] in ['operator=', 'doInit_']))
 
         src.newline()
         src.writeline('void')


### PR DESCRIPTION
Bug: PFCand unpacked_ flag was not reset after assignment:
```
PFCand a;
a.pt();
PFCand b;
a = b;
```
`a.pt()` would not return the pt value of `b` because `a` is already unpacked and the flag value was not changed after `a = b`.
There were multiple ways to solve the problem, but I figured allowing a custom block in the assignment operator is the cleanest. We already have a custom block in `init()`, so in fact it was somewhat inconsistent to not have one in `operator=`.