### PR TITLE
Allowing multiline-definition of constexpr

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -60,7 +60,7 @@ for fname in args.configs:
             pass
 
         try:
-            constants.append(Constant(line))
+            constants.append(Constant(line, configFile))
             continue
         except Definition.NoMatch:
             pass

--- a/lib/panda/_obj.py
+++ b/lib/panda/_obj.py
@@ -45,7 +45,7 @@ def __init__(self, name, source):
             pass
 
         try:
-            self.constants.append(Constant(line))
+            self.constants.append(Constant(line, source))
             continue
         except Definition.NoMatch:
             pass


### PR DESCRIPTION
Example is defs/monophoton.def.