### PR TITLE
EventBase bugfix - Run was not updated

### DIFF
--- a/Objects/src/EventBase.cc
+++ b/Objects/src/EventBase.cc
@@ -162,9 +162,12 @@ panda::EventBase::doGetEntry_(TTree& _tree)
       rItr = runTrees_.emplace(&_tree, std::make_pair<Int_t, TTree*>(-1, 0)).first;
     }
 
-    if (_tree.GetTreeNumber() != rItr->second.first) {
+    if (_tree.GetTreeNumber() == rItr->second.first) {
+      // We are on the same tree. Just check for run number transition (and update the trigger table if necessary)
+      run.findEntry(*rItr->second.second, runNumber);
+    }
+    else {
       // There was a file transition in the input
-
       rItr->second.first = _tree.GetTreeNumber();
 
       // First check that the runNumber branch is turned on
@@ -190,7 +193,6 @@ panda::EventBase::doGetEntry_(TTree& _tree)
         run.resetCache();
 
         // Now cue the run object to the given run number
-        // Does nothing if the run number is unchanged
         run.findEntry(*rItr->second.second, runNumber);
       }
       else {

--- a/Objects/src/Run.cc
+++ b/Objects/src/Run.cc
@@ -251,7 +251,8 @@ panda::Run::findEntry(TTree& _runTree, UInt_t _runNumber)
 {
   // Known issue: if this function is called with a new tree but with the same run number as the previous call,
   // nothing happens and the tree is not updated. This is such a rare situation that (in my opinion) does not warrant
-  // covering for.
+  // covering for. To avoid it, set runNumber to 0 before calling this function if there was a file transition.
+  // (EventBase::doGetEntry_ does that).
 
   if (_runNumber == runNumber)
     return;


### PR DESCRIPTION
Important bugfix - our trigger reading was broken. Run object belonging to the Event (which manages the trigger paths and indices) was not being updated at run transitions.