### PR TITLE
Using ULong64_t for eventNumber

### DIFF
--- a/Objects/interface/EventBase.h
+++ b/Objects/interface/EventBase.h
@@ -25,7 +25,7 @@ namespace panda {
 
     UInt_t runNumber{};
     UInt_t lumiNumber{};
-    UInt_t eventNumber{};
+    ULong64_t eventNumber{};
     Bool_t isData{};
     Float_t weight{};
 

--- a/Objects/src/EventBase.cc
+++ b/Objects/src/EventBase.cc
@@ -152,7 +152,7 @@ panda::EventBase::doBook_(TTree& _tree, utils::BranchList const& _branches)
 {
   utils::book(_tree, "", "runNumber", "", 'i', &runNumber, _branches);
   utils::book(_tree, "", "lumiNumber", "", 'i', &lumiNumber, _branches);
-  utils::book(_tree, "", "eventNumber", "", 'i', &eventNumber, _branches);
+  utils::book(_tree, "", "eventNumber", "", 'l', &eventNumber, _branches);
   utils::book(_tree, "", "isData", "", 'O', &isData, _branches);
   utils::book(_tree, "", "weight", "", 'F', &weight, _branches);
 }

--- a/defs/panda.def
+++ b/defs/panda.def
@@ -479,7 +479,7 @@ bool any() const { return met || monoMu || monoE || diMu || diE || gamma; }
 {EventBase}
 runNumber/i
 lumiNumber/i
-eventNumber/i
+eventNumber/l
 isData/O
 weight/F
 triggers/HLTBits


### PR DESCRIPTION
CMSSW gives us event numbers greater than the maximum of 32-bit unsigned integer.
This update will make reading the eventNumber branch backward-incompatible.