### PR TITLE
Cleaning namespace, Jenkins, more colorful webpage, and format comments for doxygen

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,127 @@
+pipeline {
+  agent any
+
+  environment {
+    SCRAM_ARCH = 'slc6_amd64_gcc530'
+    DOSRC = 'source /cvmfs/cms.cern.ch/cmsset_default.sh'
+    CMSSW_VERSION = 'CMSSW_8_0_29'
+    PANDA_PROD_URL = 'https://github.com/dabercro/PandaProd.git'
+    PANDA_PROD_BRANCH = 'jenkins'
+    TEST_FILES_DIR = '/home/dabercro/cms/cmssw/CMSSW_8_0_29/src/PandaProd/Producer/cfg'
+  }
+
+  stages {
+    stage('Report Start') {
+      steps {
+        withCredentials([usernameColonPassword(credentialsId: 'mitsidekick', variable: 'USERPASS')]) {
+          sh '''
+             set +x
+             if [ ! -z $CHANGE_URL ]
+             then
+                 # Craft the URL for the github comments API from the PR
+                 COMMENT_URL=$(echo $CHANGE_URL | perl -a -F/ -ne 'chomp @F[-1]; print "https://api.github.com/repos/@F[-4]/@F[-3]/issues/@F[-1]/comments"')
+                 curl -u $USERPASS -X POST -d '{"body": "Starting tests"}' $COMMENT_URL
+             fi
+             '''
+        }
+      }
+    }
+
+    stage('Build') {
+      steps {
+
+        sh 'ls'
+
+        // Get CMSSW if needed
+        sh '''
+           if [ ! -d $CMSSW_VERSION ]
+           then
+               $DOSRC
+               scramv1 project CMSSW $CMSSW_VERSION
+           fi
+           '''    
+
+        sh 'ls $CMSSW_VERSION/src'
+
+        // Make PandaTree directory for us to recursively copy files into
+        sh '''
+           if [ ! -d $CMSSW_VERSION/src/PandaTree ]
+           then
+               mkdir $CMSSW_VERSION/src/PandaTree
+           fi
+           '''
+
+        // Copy all of the files, and the HEAD where we will get the git tag from
+        sh 'cp --parents $(git ls-files) $CMSSW_VERSION/src/PandaTree'
+        sh 'cp --parents .git/HEAD  $CMSSW_VERSION/src/PandaTree'
+
+        // Install PandaProd and compile
+        dir ("${env.CMSSW_VERSION}/src") {
+
+            // Install PandaProd, from scratch
+            sh '''
+               if [ -d PandaProd ]
+               then
+                   rm -rf PandaProd
+               fi
+               git clone -b $PANDA_PROD_BRANCH $PANDA_PROD_URL
+               '''
+
+            // Check if we should reinstall everything else
+            // If we don't use what's already there, compiling takes much longer
+            sh '''
+               if [ ! -d PhysicsTools ]
+               then
+                   $DOSRC
+                   eval `scramv1 runtime -sh`
+                   PandaProd/Producer/cfg/setuprel.sh
+               fi
+               '''
+
+            // Compile
+            sh '$DOSRC; eval `scramv1 runtime -sh`; scram b -j4'
+        }
+      }
+    }
+
+    stage('Test') {
+      steps {
+        dir ("${env.CMSSW_VERSION}/src") {
+            sh '$DOSRC;  eval `scramv1 runtime -sh`; testpanda $TEST_FILES_DIR/mc.root ${BUILD_TAG}_mc'
+            sh '$DOSRC;  eval `scramv1 runtime -sh`; testpanda $TEST_FILES_DIR/data.root ${BUILD_TAG}_data'
+        }
+      }
+    }
+  }
+
+  post {
+    success {
+      withCredentials([usernameColonPassword(credentialsId: 'mitsidekick', variable: 'USERPASS')]) {
+        sh '''
+           set +x
+           if [ ! -z $CHANGE_URL ]
+           then
+               # Craft the URL for the github comments API from the PR
+               COMMENT_URL=$(echo $CHANGE_URL | perl -a -F/ -ne 'chomp @F[-1]; print "https://api.github.com/repos/@F[-4]/@F[-3]/issues/@F[-1]/comments"')
+               # Lots of escape strings because Jenkins uses this sh string to generate a .sh file...
+               curl -u $USERPASS -X POST --data-binary \"{\\\"body\\\": \\\"Tests passed! Plots here:\\n\\n- http://t3serv001.mit.edu/~${USER}/relval/?d=${BUILD_TAG}_data\\n- http://t3serv001.mit.edu/~${USER}/relval/?d=${BUILD_TAG}_mc\\\"}\" $COMMENT_URL
+           fi
+           '''
+      }
+    }
+
+    failure {
+      withCredentials([usernameColonPassword(credentialsId: 'mitsidekick', variable: 'USERPASS')]) {
+        sh '''
+           set +x
+           if [ ! -z $CHANGE_URL ]
+           then
+               # Craft the URL for the github comments API from the PR
+               COMMENT_URL=$(echo $CHANGE_URL | perl -a -F/ -ne 'chomp @F[-1]; print "https://api.github.com/repos/@F[-4]/@F[-3]/issues/@F[-1]/comments"')
+               curl -u $USERPASS -X POST -d '{"body": "Tests failed..."}' $COMMENT_URL
+           fi
+           '''
+      }
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,28 +5,11 @@ pipeline {
     SCRAM_ARCH = 'slc6_amd64_gcc530'
     DOSRC = 'source /cvmfs/cms.cern.ch/cmsset_default.sh'
     CMSSW_VERSION = 'CMSSW_8_0_29'
-    PANDA_PROD_URL = 'https://github.com/dabercro/PandaProd.git'
-    PANDA_PROD_BRANCH = 'jenkins'
-    TEST_FILES_DIR = '/home/dabercro/cms/cmssw/CMSSW_8_0_29/src/PandaProd/Producer/cfg'
+    PANDA_PROD_USER = 'dabercro'
+    PANDA_PROD_BRANCH = 'jenkins-clean'
   }
 
   stages {
-    stage('Report Start') {
-      steps {
-        withCredentials([usernameColonPassword(credentialsId: 'mitsidekick', variable: 'USERPASS')]) {
-          sh '''
-             set +x
-             if [ ! -z $CHANGE_URL ]
-             then
-                 # Craft the URL for the github comments API from the PR
-                 COMMENT_URL=$(echo $CHANGE_URL | perl -a -F/ -ne 'chomp @F[-1]; print "https://api.github.com/repos/@F[-4]/@F[-3]/issues/@F[-1]/comments"')
-                 curl -u $USERPASS -X POST -d '{"body": "Starting tests"}' $COMMENT_URL
-             fi
-             '''
-        }
-      }
-    }
-
     stage('Build') {
       steps {
 
@@ -54,41 +37,21 @@ pipeline {
         // Copy all of the files, and the HEAD where we will get the git tag from
         sh 'cp --parents $(git ls-files) $CMSSW_VERSION/src/PandaTree'
         sh 'cp --parents .git/HEAD  $CMSSW_VERSION/src/PandaTree'
-
-        // Install PandaProd and compile
-        dir ("${env.CMSSW_VERSION}/src") {
-
-            // Install PandaProd, from scratch
-            sh '''
-               if [ -d PandaProd ]
-               then
-                   rm -rf PandaProd
-               fi
-               git clone -b $PANDA_PROD_BRANCH $PANDA_PROD_URL
-               '''
-
-            // Check if we should reinstall everything else
-            // If we don't use what's already there, compiling takes much longer
-            sh '''
-               if [ ! -d PhysicsTools ]
-               then
-                   $DOSRC
-                   eval `scramv1 runtime -sh`
-                   PandaProd/Producer/cfg/setuprel.sh
-               fi
-               '''
-
-            // Compile
-            sh '$DOSRC; eval `scramv1 runtime -sh`; scram b -j4'
-        }
       }
     }
 
     stage('Test') {
       steps {
         dir ("${env.CMSSW_VERSION}/src") {
-            sh '$DOSRC;  eval `scramv1 runtime -sh`; testpanda $TEST_FILES_DIR/mc.root ${BUILD_TAG}_mc'
-            sh '$DOSRC;  eval `scramv1 runtime -sh`; testpanda $TEST_FILES_DIR/data.root ${BUILD_TAG}_data'
+            sh '''
+               $DOSRC
+               eval `scramv1 runtime -sh`
+               for f in /mnt/hadoop/scratch/jenkins/panda/$PANDA_PROD_USER/PandaProd/$PANDA_PROD_BRANCH/*
+               do
+                   BASE=$(echo $f | perl -e '/\/([\w-]+)\.root/ && print "$1"')
+                   testpanda $f ${JOB_NAME}/${BUILD_NUMBER}/$(tail -n1 $HOME/miniaod/$BASE.txt)
+               done
+               '''
         }
       }
     }
@@ -104,7 +67,7 @@ pipeline {
                # Craft the URL for the github comments API from the PR
                COMMENT_URL=$(echo $CHANGE_URL | perl -a -F/ -ne 'chomp @F[-1]; print "https://api.github.com/repos/@F[-4]/@F[-3]/issues/@F[-1]/comments"')
                # Lots of escape strings because Jenkins uses this sh string to generate a .sh file...
-               curl -u $USERPASS -X POST --data-binary \"{\\\"body\\\": \\\"Tests passed! Plots here:\\n\\n- http://t3serv001.mit.edu/~${USER}/relval/?d=${BUILD_TAG}_data\\n- http://t3serv001.mit.edu/~${USER}/relval/?d=${BUILD_TAG}_mc\\\"}\" $COMMENT_URL
+               curl -u $USERPASS -X POST --data-binary \"{\\\"body\\\": \\\"Tests passed! Plots here:\\n\\n- http://t3serv001.mit.edu/~${USER}/relval/?d=${JOB_NAME}/${BUILD_NUMBER}\\\"}\" $COMMENT_URL
            fi
            '''
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,8 +38,10 @@ pipeline {
         sh 'cp --parents $(git ls-files) $CMSSW_VERSION/src/PandaTree'
         sh 'cp --parents .git/HEAD  $CMSSW_VERSION/src/PandaTree'
 
-        // Compile
-        sh '$DOSRC; eval `scramv1 runtime -sh`; scram b -j4'
+        dir ("${env.CMSSW_VERSION}/src") {
+          // Compile
+          sh '$DOSRC; eval `scramv1 runtime -sh`; scram b -j4'
+        }
       }
     }
 
@@ -51,7 +53,7 @@ pipeline {
                eval `scramv1 runtime -sh`
                for f in /mnt/hadoop/scratch/jenkins/panda/$PANDA_PROD_USER/PandaProd/$PANDA_PROD_BRANCH/*
                do
-                   BASE=$(echo $f | perl -e '/\\/([\\w-]+)\\.root/ && print "$1"')
+                   BASE=$(echo $f | perl -ne '/\\/([\\w-]+)\\.root/ && print "$1"')
                    testpanda $f ${JOB_NAME}/${BUILD_NUMBER}/$(tail -n1 $HOME/miniaod/$BASE.txt)
                done
                '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,9 @@ pipeline {
         // Copy all of the files, and the HEAD where we will get the git tag from
         sh 'cp --parents $(git ls-files) $CMSSW_VERSION/src/PandaTree'
         sh 'cp --parents .git/HEAD  $CMSSW_VERSION/src/PandaTree'
+
+        // Compile
+        sh '$DOSRC; eval `scramv1 runtime -sh`; scram b -j4'
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ pipeline {
                eval `scramv1 runtime -sh`
                for f in /mnt/hadoop/scratch/jenkins/panda/$PANDA_PROD_USER/PandaProd/$PANDA_PROD_BRANCH/*
                do
-                   BASE=$(echo $f | perl -e '/\/([\w-]+)\.root/ && print "$1"')
+                   BASE=$(echo $f | perl -e '/\\/([\w-]+)\\.root/ && print "$1"')
                    testpanda $f ${JOB_NAME}/${BUILD_NUMBER}/$(tail -n1 $HOME/miniaod/$BASE.txt)
                done
                '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ pipeline {
                eval `scramv1 runtime -sh`
                for f in /mnt/hadoop/scratch/jenkins/panda/$PANDA_PROD_USER/PandaProd/$PANDA_PROD_BRANCH/*
                do
-                   BASE=$(echo $f | perl -e '/\\/([\w-]+)\\.root/ && print "$1"')
+                   BASE=$(echo $f | perl -e '/\\/([\\w-]+)\\.root/ && print "$1"')
                    testpanda $f ${JOB_NAME}/${BUILD_NUMBER}/$(tail -n1 $HOME/miniaod/$BASE.txt)
                done
                '''

--- a/Objects/interface/Electron.h
+++ b/Objects/interface/Electron.h
@@ -114,7 +114,7 @@ namespace panda {
     double combIso() const override { return chIso + std::max(nhIso + phIso - isoPUOffset, Float_t(0.)); }
 
     /* Lepton
-    Float_t& pfPt; //< for E: Pt of the dR-closest PF candidate; for Mu: pfP4().pt()
+    Float_t& pfPt; ///< for E: Pt of the dR-closest PF candidate; for Mu: pfP4().pt()
     Char_t& charge;
     Bool_t& loose;
     Bool_t& medium;

--- a/Objects/interface/Electron.h
+++ b/Objects/interface/Electron.h
@@ -114,7 +114,7 @@ namespace panda {
     double combIso() const override { return chIso + std::max(nhIso + phIso - isoPUOffset, Float_t(0.)); }
 
     /* Lepton
-    Float_t& pfPt; // for E: Pt of the dR-closest PF candidate; for Mu: pfP4().pt()
+    Float_t& pfPt; //< for E: Pt of the dR-closest PF candidate; for Mu: pfP4().pt()
     Char_t& charge;
     Bool_t& loose;
     Bool_t& medium;

--- a/Objects/interface/GenJet.h
+++ b/Objects/interface/GenJet.h
@@ -55,7 +55,7 @@ namespace panda {
     void print(std::ostream& = std::cout, UInt_t level = 1) const override;
     void dump(std::ostream& = std::cout) const override;
 
-    Short_t& pdgid;
+    Short_t& pdgid; //< Filled with hadron flavor
     Short_t& partonFlavor;
     Short_t& numB;
     Short_t& numC;

--- a/Objects/interface/GenJet.h
+++ b/Objects/interface/GenJet.h
@@ -55,7 +55,7 @@ namespace panda {
     void print(std::ostream& = std::cout, UInt_t level = 1) const override;
     void dump(std::ostream& = std::cout) const override;
 
-    Short_t& pdgid; //< Filled with hadron flavor
+    Short_t& pdgid; ///< Filled with hadron flavor
     Short_t& partonFlavor;
     Short_t& numB;
     Short_t& numC;

--- a/Objects/interface/Lepton.h
+++ b/Objects/interface/Lepton.h
@@ -71,7 +71,7 @@ namespace panda {
 
     virtual double combIso() const { return 0.; }
 
-    Float_t& pfPt; //< for E: Pt of the dR-closest PF candidate; for Mu: pfP4().pt()
+    Float_t& pfPt; ///< for E: Pt of the dR-closest PF candidate; for Mu: pfP4().pt()
     Char_t& charge;
     Bool_t& loose;
     Bool_t& medium;

--- a/Objects/interface/Lepton.h
+++ b/Objects/interface/Lepton.h
@@ -71,7 +71,7 @@ namespace panda {
 
     virtual double combIso() const { return 0.; }
 
-    Float_t& pfPt; // for E: Pt of the dR-closest PF candidate; for Mu: pfP4().pt()
+    Float_t& pfPt; //< for E: Pt of the dR-closest PF candidate; for Mu: pfP4().pt()
     Char_t& charge;
     Bool_t& loose;
     Bool_t& medium;

--- a/Objects/interface/Muon.h
+++ b/Objects/interface/Muon.h
@@ -104,7 +104,7 @@ namespace panda {
     double combIso() const override { return chIso + std::max(nhIso + phIso - 0.5 * puIso, 0.); }
 
     /* Lepton
-    Float_t& pfPt; // for E: Pt of the dR-closest PF candidate; for Mu: pfP4().pt()
+    Float_t& pfPt; //< for E: Pt of the dR-closest PF candidate; for Mu: pfP4().pt()
     Char_t& charge;
     Bool_t& loose;
     Bool_t& medium;

--- a/Objects/interface/Muon.h
+++ b/Objects/interface/Muon.h
@@ -104,7 +104,7 @@ namespace panda {
     double combIso() const override { return chIso + std::max(nhIso + phIso - 0.5 * puIso, 0.); }
 
     /* Lepton
-    Float_t& pfPt; //< for E: Pt of the dR-closest PF candidate; for Mu: pfP4().pt()
+    Float_t& pfPt; ///< for E: Pt of the dR-closest PF candidate; for Mu: pfP4().pt()
     Char_t& charge;
     Bool_t& loose;
     Bool_t& medium;

--- a/Objects/interface/PFCand.h
+++ b/Objects/interface/PFCand.h
@@ -49,9 +49,9 @@ namespace panda {
       Char_t* packedPuppiWNoLepDiff{0};
       UChar_t* ptype{0};
       ContainerBase const* vertexContainer_{0};
-      Short_t* vertex_{0}; //< transient
+      Short_t* vertex_{0}; ///< transient
       ContainerBase const* trackContainer_{0};
-      Short_t* track_{0}; //< transient
+      Short_t* track_{0}; ///< transient
       Float_t* hCalFrac{0};
 
       void allocate(UInt_t n) override;

--- a/Objects/interface/PFCand.h
+++ b/Objects/interface/PFCand.h
@@ -49,9 +49,9 @@ namespace panda {
       Char_t* packedPuppiWNoLepDiff{0};
       UChar_t* ptype{0};
       ContainerBase const* vertexContainer_{0};
-      Short_t* vertex_{0}; // transient
+      Short_t* vertex_{0}; //< transient
       ContainerBase const* trackContainer_{0};
-      Short_t* track_{0}; // transient
+      Short_t* track_{0}; //< transient
       Float_t* hCalFrac{0};
 
       void allocate(UInt_t n) override;

--- a/Objects/interface/Photon.h
+++ b/Objects/interface/Photon.h
@@ -106,7 +106,7 @@ namespace panda {
     void print(std::ostream& = std::cout, UInt_t level = 1) const override;
     void dump(std::ostream& = std::cout) const override;
 
-    Float_t& pfPt; // Pt of the dR-closest PF candidate
+    Float_t& pfPt; //< Pt of the dR-closest PF candidate
     Float_t& chIso;
     Float_t& chIsoMax;
     Float_t& nhIso;

--- a/Objects/interface/Photon.h
+++ b/Objects/interface/Photon.h
@@ -106,7 +106,7 @@ namespace panda {
     void print(std::ostream& = std::cout, UInt_t level = 1) const override;
     void dump(std::ostream& = std::cout) const override;
 
-    Float_t& pfPt; //< Pt of the dR-closest PF candidate
+    Float_t& pfPt; ///< Pt of the dR-closest PF candidate
     Float_t& chIso;
     Float_t& chIsoMax;
     Float_t& nhIso;

--- a/Objects/interface/Run.h
+++ b/Objects/interface/Run.h
@@ -18,7 +18,7 @@ namespace panda {
 
     UInt_t runNumber{};
     UInt_t hltMenu{};
-    UShort_t hltSize{}; //< transient
+    UShort_t hltSize{}; ///< transient
 
     static utils::BranchList getListOfBranches(Bool_t direct = kFALSE);
 

--- a/Objects/interface/Run.h
+++ b/Objects/interface/Run.h
@@ -18,7 +18,7 @@ namespace panda {
 
     UInt_t runNumber{};
     UInt_t hltMenu{};
-    UShort_t hltSize{}; // transient
+    UShort_t hltSize{}; //< transient
 
     static utils::BranchList getListOfBranches(Bool_t direct = kFALSE);
 

--- a/Objects/interface/XPhoton.h
+++ b/Objects/interface/XPhoton.h
@@ -122,7 +122,7 @@ namespace panda {
     bool passHOverE(UInt_t wp, UInt_t t) const { return hOverE < hOverECuts[t][isEB ? 0 : 1][wp]; }
 
     /* Photon
-    Float_t& pfPt; //< Pt of the dR-closest PF candidate
+    Float_t& pfPt; ///< Pt of the dR-closest PF candidate
     Float_t& chIso;
     Float_t& chIsoMax;
     Float_t& nhIso;

--- a/Objects/interface/XPhoton.h
+++ b/Objects/interface/XPhoton.h
@@ -122,7 +122,7 @@ namespace panda {
     bool passHOverE(UInt_t wp, UInt_t t) const { return hOverE < hOverECuts[t][isEB ? 0 : 1][wp]; }
 
     /* Photon
-    Float_t& pfPt; // Pt of the dR-closest PF candidate
+    Float_t& pfPt; //< Pt of the dR-closest PF candidate
     Float_t& chIso;
     Float_t& chIsoMax;
     Float_t& nhIso;

--- a/RelVal/bin/testpanda.cpp
+++ b/RelVal/bin/testpanda.cpp
@@ -27,6 +27,7 @@
 #include "PandaTree/RelVal/interface/EnumerateBranches.h"
 #include "PandaTree/RelVal/interface/TemplateMagic.h"
 
+using namespace testpanda;
 
 bool exists(const char* path) {
   struct stat buffer;

--- a/RelVal/bin/testpanda.cpp
+++ b/RelVal/bin/testpanda.cpp
@@ -370,6 +370,14 @@ int main(int argc, char** argv) {
         canvas->SaveAs((output_dir + "/" + branch_name + "_log" + ext).data());
         canvas->SetLogy(false);
       }
+
+      // Check if only a single value was filled, and flag as potential bad filling.
+      if (maximums[index].first == minimums[index].first) {
+        std::ofstream flag_file((output_dir + "/" + branch_name + "_FLAG.txt"));
+        flag_file << maximums[index].first;
+        flag_file.close();
+      }
+
     }
   };
 

--- a/RelVal/bin/testpanda.cpp
+++ b/RelVal/bin/testpanda.cpp
@@ -83,12 +83,19 @@ std::string get_git_tag(std::string repo) {
     head_file >> head >> head;
     head_file.close();
 
-    std::string tag;
-    std::ifstream tag_file((git_dir + "/" + head).data());
-    tag_file >> tag;
-    tag_file.close();
+    auto tag_location = git_dir + "/" + head;
 
-    return tag;
+    if (exists(tag_location.data())) {
+        std::string tag;
+        std::ifstream tag_file(tag_location.data());
+        tag_file >> tag;
+        tag_file.close();
+
+        return tag;
+      }
+
+      // Checkout in Jenkins just saves the commit in HEAD
+      return head;
   }
   std::cout << "No git dir" << std::endl;
   return "";
@@ -145,13 +152,17 @@ int main(int argc, char** argv) {
   // I'll do the stat by hand here so that I can keep the stat info
   struct stat input_stat;
 
-  if (argc != 2 || stat(argv[1], &input_stat) != 0) {
+  // We can accept argc == 2 | argc == 3
+  if (argc >> 1 != 1 || stat(argv[1], &input_stat) != 0) {
     // Print the usage information
     std::cout << std::endl
-              << "Usage: " << argv[0] << " INPUT" << std::endl
+              << "Usage: " << argv[0] << " INPUT [OUTPUT]" << std::endl
               << std::endl
               << "Takes a panda file and creates plots in your personal web directory." << std::endl
               << "A little webpage is included to make the output directory nice to look at." << std::endl
+              << std::endl
+              << "OUTPUT is the name of the final directory to put in your ~/public_html/relval" << std::endl
+              << "If left blank or already filled, a directory will be made based on a timestamp." << std::endl
               << std::endl;
 
     return 1;
@@ -322,9 +333,14 @@ int main(int argc, char** argv) {
   time_t end_time;
   time(&end_time);
 
-  char timestamp_str[32];
-  strftime(timestamp_str, sizeof(timestamp_str) - 1, "%y%m%d_%H%M%S", localtime(&end_time));
-  auto output_dir = base_dir + "/" + timestamp_str;
+  auto output_dir = base_dir + "/";
+  if (argc == 2 || exists((output_dir + argv[2]).data())) {
+    char timestamp_str[32];
+    strftime(timestamp_str, sizeof(timestamp_str) - 1, "%y%m%d_%H%M%S", localtime(&end_time));
+    output_dir += timestamp_str;
+  }
+  else
+    output_dir += argv[2];
 
   // We will actually make the directory when the first plots come in
 
@@ -372,9 +388,11 @@ int main(int argc, char** argv) {
   if (!debug) {
     std::ofstream metadata_file(output_dir + "/metadata.txt");
 
+    std::string in_file_name = argv[1][0] == '/' ? argv[1] : std::string(getenv("PWD")) + '/' + argv[1];
+
     metadata_file << "Report generated: " << report_time_str << std::endl
                   << std::endl
-                  << "File name:  " << getenv("PWD") << '/' << argv[1] << std::endl
+                  << "File name:  " << in_file_name << std::endl
                   << "File size:  " << input_stat.st_size << std::endl
                   << "File mtime: " << mtime_str << std::endl
                   << std::endl

--- a/RelVal/interface/EnumerateBranches.h
+++ b/RelVal/interface/EnumerateBranches.h
@@ -186,11 +186,9 @@ namespace testpanda {
   struct plotter <17> {
     constexpr static const char* name = "pfCandidates/vertex_isValid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.pfCandidates)
-      output.push_back(i.vertex.isValid());
-
+      std::vector<float> output;
+      for (auto& i : event.pfCandidates)
+        output.push_back(i.vertex.isValid());
       return output;
     }
   };
@@ -200,11 +198,9 @@ namespace testpanda {
   struct plotter <18> {
     constexpr static const char* name = "pfCandidates/track_isValid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.pfCandidates)
-      output.push_back(i.track.isValid());
-
+      std::vector<float> output;
+      for (auto& i : event.pfCandidates)
+        output.push_back(i.track.isValid());
       return output;
     }
   };
@@ -214,11 +210,9 @@ namespace testpanda {
   struct plotter <19> {
     constexpr static const char* name = "pfCandidates/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.pfCandidates)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.pfCandidates)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -228,11 +222,9 @@ namespace testpanda {
   struct plotter <20> {
     constexpr static const char* name = "pfCandidates/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.pfCandidates)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.pfCandidates)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -242,11 +234,9 @@ namespace testpanda {
   struct plotter <21> {
     constexpr static const char* name = "pfCandidates/puppiWNoLep";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.pfCandidates)
-      output.push_back(i.puppiWNoLep());
-
+      std::vector<float> output;
+      for (auto& i : event.pfCandidates)
+        output.push_back(i.puppiWNoLep());
       return output;
     }
   };
@@ -256,11 +246,9 @@ namespace testpanda {
   struct plotter <22> {
     constexpr static const char* name = "pfCandidates/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.pfCandidates)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.pfCandidates)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -270,11 +258,9 @@ namespace testpanda {
   struct plotter <23> {
     constexpr static const char* name = "pfCandidates/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.pfCandidates)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.pfCandidates)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -284,11 +270,9 @@ namespace testpanda {
   struct plotter <24> {
     constexpr static const char* name = "pfCandidates/pdgId";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.pfCandidates)
-      output.push_back(i.pdgId());
-
+      std::vector<float> output;
+      for (auto& i : event.pfCandidates)
+        output.push_back(i.pdgId());
       return output;
     }
   };
@@ -298,11 +282,9 @@ namespace testpanda {
   struct plotter <25> {
     constexpr static const char* name = "pfCandidates/hCalFrac";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.pfCandidates)
-      output.push_back(i.hCalFrac);
-
+      std::vector<float> output;
+      for (auto& i : event.pfCandidates)
+        output.push_back(i.hCalFrac);
       return output;
     }
   };
@@ -312,11 +294,9 @@ namespace testpanda {
   struct plotter <26> {
     constexpr static const char* name = "pfCandidates/ptype";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.pfCandidates)
-      output.push_back(i.ptype);
-
+      std::vector<float> output;
+      for (auto& i : event.pfCandidates)
+        output.push_back(i.ptype);
       return output;
     }
   };
@@ -326,11 +306,9 @@ namespace testpanda {
   struct plotter <27> {
     constexpr static const char* name = "pfCandidates/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.pfCandidates)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.pfCandidates)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -340,11 +318,9 @@ namespace testpanda {
   struct plotter <28> {
     constexpr static const char* name = "pfCandidates/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.pfCandidates)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.pfCandidates)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -354,11 +330,9 @@ namespace testpanda {
   struct plotter <29> {
     constexpr static const char* name = "pfCandidates/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.pfCandidates)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.pfCandidates)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -368,11 +342,9 @@ namespace testpanda {
   struct plotter <30> {
     constexpr static const char* name = "pfCandidates/q";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.pfCandidates)
-      output.push_back(i.q());
-
+      std::vector<float> output;
+      for (auto& i : event.pfCandidates)
+        output.push_back(i.q());
       return output;
     }
   };
@@ -382,11 +354,9 @@ namespace testpanda {
   struct plotter <31> {
     constexpr static const char* name = "pfCandidates/puppiW";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.pfCandidates)
-      output.push_back(i.puppiW());
-
+      std::vector<float> output;
+      for (auto& i : event.pfCandidates)
+        output.push_back(i.puppiW());
       return output;
     }
   };
@@ -396,11 +366,9 @@ namespace testpanda {
   struct plotter <32> {
     constexpr static const char* name = "pfCandidates/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.pfCandidates)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.pfCandidates)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -410,11 +378,9 @@ namespace testpanda {
   struct plotter <33> {
     constexpr static const char* name = "pfCandidates/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.pfCandidates)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.pfCandidates)
+        output.push_back(i.e());
       return output;
     }
   };
@@ -434,11 +400,9 @@ namespace testpanda {
   struct plotter <35> {
     constexpr static const char* name = "vertices/chi2";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.vertices)
-      output.push_back(i.chi2);
-
+      std::vector<float> output;
+      for (auto& i : event.vertices)
+        output.push_back(i.chi2);
       return output;
     }
   };
@@ -448,11 +412,9 @@ namespace testpanda {
   struct plotter <36> {
     constexpr static const char* name = "vertices/ntrk";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.vertices)
-      output.push_back(i.ntrk);
-
+      std::vector<float> output;
+      for (auto& i : event.vertices)
+        output.push_back(i.ntrk);
       return output;
     }
   };
@@ -462,11 +424,9 @@ namespace testpanda {
   struct plotter <37> {
     constexpr static const char* name = "vertices/ndof";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.vertices)
-      output.push_back(i.ndof);
-
+      std::vector<float> output;
+      for (auto& i : event.vertices)
+        output.push_back(i.ndof);
       return output;
     }
   };
@@ -476,11 +436,9 @@ namespace testpanda {
   struct plotter <38> {
     constexpr static const char* name = "vertices/score";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.vertices)
-      output.push_back(i.score);
-
+      std::vector<float> output;
+      for (auto& i : event.vertices)
+        output.push_back(i.score);
       return output;
     }
   };
@@ -490,11 +448,9 @@ namespace testpanda {
   struct plotter <39> {
     constexpr static const char* name = "vertices/normChi2";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.vertices)
-      output.push_back(i.normChi2());
-
+      std::vector<float> output;
+      for (auto& i : event.vertices)
+        output.push_back(i.normChi2());
       return output;
     }
   };
@@ -504,11 +460,9 @@ namespace testpanda {
   struct plotter <40> {
     constexpr static const char* name = "vertices/pfRangeMax";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.vertices)
-      output.push_back(i.pfRangeMax);
-
+      std::vector<float> output;
+      for (auto& i : event.vertices)
+        output.push_back(i.pfRangeMax);
       return output;
     }
   };
@@ -518,11 +472,9 @@ namespace testpanda {
   struct plotter <41> {
     constexpr static const char* name = "vertices/y";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.vertices)
-      output.push_back(i.y);
-
+      std::vector<float> output;
+      for (auto& i : event.vertices)
+        output.push_back(i.y);
       return output;
     }
   };
@@ -532,11 +484,9 @@ namespace testpanda {
   struct plotter <42> {
     constexpr static const char* name = "vertices/x";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.vertices)
-      output.push_back(i.x);
-
+      std::vector<float> output;
+      for (auto& i : event.vertices)
+        output.push_back(i.x);
       return output;
     }
   };
@@ -546,11 +496,9 @@ namespace testpanda {
   struct plotter <43> {
     constexpr static const char* name = "vertices/z";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.vertices)
-      output.push_back(i.z);
-
+      std::vector<float> output;
+      for (auto& i : event.vertices)
+        output.push_back(i.z);
       return output;
     }
   };
@@ -570,11 +518,9 @@ namespace testpanda {
   struct plotter <45> {
     constexpr static const char* name = "secondaryVertices/daughters_size";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.secondaryVertices)
-      output.push_back(i.daughters.size());
-
+      std::vector<float> output;
+      for (auto& i : event.secondaryVertices)
+        output.push_back(i.daughters.size());
       return output;
     }
   };
@@ -584,11 +530,9 @@ namespace testpanda {
   struct plotter <46> {
     constexpr static const char* name = "secondaryVertices/vtx3DVal";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.secondaryVertices)
-      output.push_back(i.vtx3DVal);
-
+      std::vector<float> output;
+      for (auto& i : event.secondaryVertices)
+        output.push_back(i.vtx3DVal);
       return output;
     }
   };
@@ -598,11 +542,9 @@ namespace testpanda {
   struct plotter <47> {
     constexpr static const char* name = "secondaryVertices/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.secondaryVertices)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.secondaryVertices)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -612,11 +554,9 @@ namespace testpanda {
   struct plotter <48> {
     constexpr static const char* name = "secondaryVertices/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.secondaryVertices)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.secondaryVertices)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -626,11 +566,9 @@ namespace testpanda {
   struct plotter <49> {
     constexpr static const char* name = "secondaryVertices/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.secondaryVertices)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.secondaryVertices)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -640,11 +578,9 @@ namespace testpanda {
   struct plotter <50> {
     constexpr static const char* name = "secondaryVertices/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.secondaryVertices)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.secondaryVertices)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -654,11 +590,9 @@ namespace testpanda {
   struct plotter <51> {
     constexpr static const char* name = "secondaryVertices/chi2";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.secondaryVertices)
-      output.push_back(i.chi2);
-
+      std::vector<float> output;
+      for (auto& i : event.secondaryVertices)
+        output.push_back(i.chi2);
       return output;
     }
   };
@@ -668,11 +602,9 @@ namespace testpanda {
   struct plotter <52> {
     constexpr static const char* name = "secondaryVertices/significance";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.secondaryVertices)
-      output.push_back(i.significance);
-
+      std::vector<float> output;
+      for (auto& i : event.secondaryVertices)
+        output.push_back(i.significance);
       return output;
     }
   };
@@ -682,11 +614,9 @@ namespace testpanda {
   struct plotter <53> {
     constexpr static const char* name = "secondaryVertices/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.secondaryVertices)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.secondaryVertices)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -696,11 +626,9 @@ namespace testpanda {
   struct plotter <54> {
     constexpr static const char* name = "secondaryVertices/ndof";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.secondaryVertices)
-      output.push_back(i.ndof);
-
+      std::vector<float> output;
+      for (auto& i : event.secondaryVertices)
+        output.push_back(i.ndof);
       return output;
     }
   };
@@ -710,11 +638,9 @@ namespace testpanda {
   struct plotter <55> {
     constexpr static const char* name = "secondaryVertices/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.secondaryVertices)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.secondaryVertices)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -724,11 +650,9 @@ namespace testpanda {
   struct plotter <56> {
     constexpr static const char* name = "secondaryVertices/vtx3DeVal";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.secondaryVertices)
-      output.push_back(i.vtx3DeVal);
-
+      std::vector<float> output;
+      for (auto& i : event.secondaryVertices)
+        output.push_back(i.vtx3DeVal);
       return output;
     }
   };
@@ -738,11 +662,9 @@ namespace testpanda {
   struct plotter <57> {
     constexpr static const char* name = "secondaryVertices/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.secondaryVertices)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.secondaryVertices)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -752,11 +674,9 @@ namespace testpanda {
   struct plotter <58> {
     constexpr static const char* name = "secondaryVertices/normChi2";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.secondaryVertices)
-      output.push_back(i.normChi2());
-
+      std::vector<float> output;
+      for (auto& i : event.secondaryVertices)
+        output.push_back(i.normChi2());
       return output;
     }
   };
@@ -766,11 +686,9 @@ namespace testpanda {
   struct plotter <59> {
     constexpr static const char* name = "secondaryVertices/ntrk";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.secondaryVertices)
-      output.push_back(i.ntrk);
-
+      std::vector<float> output;
+      for (auto& i : event.secondaryVertices)
+        output.push_back(i.ntrk);
       return output;
     }
   };
@@ -780,11 +698,9 @@ namespace testpanda {
   struct plotter <60> {
     constexpr static const char* name = "secondaryVertices/y";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.secondaryVertices)
-      output.push_back(i.y);
-
+      std::vector<float> output;
+      for (auto& i : event.secondaryVertices)
+        output.push_back(i.y);
       return output;
     }
   };
@@ -794,11 +710,9 @@ namespace testpanda {
   struct plotter <61> {
     constexpr static const char* name = "secondaryVertices/x";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.secondaryVertices)
-      output.push_back(i.x);
-
+      std::vector<float> output;
+      for (auto& i : event.secondaryVertices)
+        output.push_back(i.x);
       return output;
     }
   };
@@ -808,11 +722,9 @@ namespace testpanda {
   struct plotter <62> {
     constexpr static const char* name = "secondaryVertices/z";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.secondaryVertices)
-      output.push_back(i.z);
-
+      std::vector<float> output;
+      for (auto& i : event.secondaryVertices)
+        output.push_back(i.z);
       return output;
     }
   };
@@ -822,11 +734,9 @@ namespace testpanda {
   struct plotter <63> {
     constexpr static const char* name = "secondaryVertices/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.secondaryVertices)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.secondaryVertices)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -836,11 +746,9 @@ namespace testpanda {
   struct plotter <64> {
     constexpr static const char* name = "secondaryVertices/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.secondaryVertices)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.secondaryVertices)
+        output.push_back(i.e());
       return output;
     }
   };
@@ -860,11 +768,9 @@ namespace testpanda {
   struct plotter <66> {
     constexpr static const char* name = "tracks/dxy";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.tracks)
-      output.push_back(i.dxy());
-
+      std::vector<float> output;
+      for (auto& i : event.tracks)
+        output.push_back(i.dxy());
       return output;
     }
   };
@@ -874,11 +780,9 @@ namespace testpanda {
   struct plotter <67> {
     constexpr static const char* name = "tracks/dPhi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.tracks)
-      output.push_back(i.dPhi());
-
+      std::vector<float> output;
+      for (auto& i : event.tracks)
+        output.push_back(i.dPhi());
       return output;
     }
   };
@@ -888,11 +792,9 @@ namespace testpanda {
   struct plotter <68> {
     constexpr static const char* name = "tracks/dz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.tracks)
-      output.push_back(i.dz());
-
+      std::vector<float> output;
+      for (auto& i : event.tracks)
+        output.push_back(i.dz());
       return output;
     }
   };
@@ -902,11 +804,9 @@ namespace testpanda {
   struct plotter <69> {
     constexpr static const char* name = "tracks/ptError";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.tracks)
-      output.push_back(i.ptError());
-
+      std::vector<float> output;
+      for (auto& i : event.tracks)
+        output.push_back(i.ptError());
       return output;
     }
   };
@@ -926,11 +826,9 @@ namespace testpanda {
   struct plotter <71> {
     constexpr static const char* name = "superClusters/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.superClusters)
-      output.push_back(i.phi);
-
+      std::vector<float> output;
+      for (auto& i : event.superClusters)
+        output.push_back(i.phi);
       return output;
     }
   };
@@ -940,11 +838,9 @@ namespace testpanda {
   struct plotter <72> {
     constexpr static const char* name = "superClusters/rawPt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.superClusters)
-      output.push_back(i.rawPt);
-
+      std::vector<float> output;
+      for (auto& i : event.superClusters)
+        output.push_back(i.rawPt);
       return output;
     }
   };
@@ -954,11 +850,9 @@ namespace testpanda {
   struct plotter <73> {
     constexpr static const char* name = "superClusters/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.superClusters)
-      output.push_back(i.eta);
-
+      std::vector<float> output;
+      for (auto& i : event.superClusters)
+        output.push_back(i.eta);
       return output;
     }
   };
@@ -978,11 +872,9 @@ namespace testpanda {
   struct plotter <75> {
     constexpr static const char* name = "electrons/superCluster_isValid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.superCluster.isValid());
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.superCluster.isValid());
       return output;
     }
   };
@@ -992,11 +884,9 @@ namespace testpanda {
   struct plotter <76> {
     constexpr static const char* name = "electrons/dxy";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.dxy);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.dxy);
       return output;
     }
   };
@@ -1006,11 +896,9 @@ namespace testpanda {
   struct plotter <77> {
     constexpr static const char* name = "electrons/chIso";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.chIso);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.chIso);
       return output;
     }
   };
@@ -1020,11 +908,9 @@ namespace testpanda {
   struct plotter <78> {
     constexpr static const char* name = "electrons/phIsoPh";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.phIsoPh);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.phIsoPh);
       return output;
     }
   };
@@ -1034,11 +920,9 @@ namespace testpanda {
   struct plotter <79> {
     constexpr static const char* name = "electrons/trackIso";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.trackIso);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.trackIso);
       return output;
     }
   };
@@ -1048,11 +932,9 @@ namespace testpanda {
   struct plotter <80> {
     constexpr static const char* name = "electrons/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -1062,11 +944,9 @@ namespace testpanda {
   struct plotter <81> {
     constexpr static const char* name = "electrons/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -1076,11 +956,9 @@ namespace testpanda {
   struct plotter <82> {
     constexpr static const char* name = "electrons/ecalIso";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.ecalIso);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.ecalIso);
       return output;
     }
   };
@@ -1090,11 +968,9 @@ namespace testpanda {
   struct plotter <83> {
     constexpr static const char* name = "electrons/medium";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.medium);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.medium);
       return output;
     }
   };
@@ -1104,11 +980,9 @@ namespace testpanda {
   struct plotter <84> {
     constexpr static const char* name = "electrons/isoPUOffset";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.isoPUOffset);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.isoPUOffset);
       return output;
     }
   };
@@ -1118,11 +992,9 @@ namespace testpanda {
   struct plotter <85> {
     constexpr static const char* name = "electrons/pfPt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.pfPt);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.pfPt);
       return output;
     }
   };
@@ -1132,11 +1004,9 @@ namespace testpanda {
   struct plotter <86> {
     constexpr static const char* name = "electrons/trackP";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.trackP);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.trackP);
       return output;
     }
   };
@@ -1146,11 +1016,9 @@ namespace testpanda {
   struct plotter <87> {
     constexpr static const char* name = "electrons/ecalE";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.ecalE);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.ecalE);
       return output;
     }
   };
@@ -1160,11 +1028,9 @@ namespace testpanda {
   struct plotter <88> {
     constexpr static const char* name = "electrons/sipip";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.sipip);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.sipip);
       return output;
     }
   };
@@ -1174,11 +1040,9 @@ namespace testpanda {
   struct plotter <89> {
     constexpr static const char* name = "electrons/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -1188,11 +1052,9 @@ namespace testpanda {
   struct plotter <90> {
     constexpr static const char* name = "electrons/hltsafe";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.hltsafe);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.hltsafe);
       return output;
     }
   };
@@ -1202,11 +1064,9 @@ namespace testpanda {
   struct plotter <91> {
     constexpr static const char* name = "electrons/tripleCharge";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.tripleCharge);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.tripleCharge);
       return output;
     }
   };
@@ -1216,11 +1076,9 @@ namespace testpanda {
   struct plotter <92> {
     constexpr static const char* name = "electrons/charge";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.charge);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.charge);
       return output;
     }
   };
@@ -1230,11 +1088,9 @@ namespace testpanda {
   struct plotter <93> {
     constexpr static const char* name = "electrons/dEtaInSeed";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.dEtaInSeed);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.dEtaInSeed);
       return output;
     }
   };
@@ -1244,11 +1100,9 @@ namespace testpanda {
   struct plotter <94> {
     constexpr static const char* name = "electrons/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.e());
       return output;
     }
   };
@@ -1258,11 +1112,9 @@ namespace testpanda {
   struct plotter <95> {
     constexpr static const char* name = "electrons/tight";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.tight);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.tight);
       return output;
     }
   };
@@ -1272,11 +1124,9 @@ namespace testpanda {
   struct plotter <96> {
     constexpr static const char* name = "electrons/sieie";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.sieie);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.sieie);
       return output;
     }
   };
@@ -1286,11 +1136,9 @@ namespace testpanda {
   struct plotter <97> {
     constexpr static const char* name = "electrons/eseed";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.eseed);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.eseed);
       return output;
     }
   };
@@ -1300,11 +1148,9 @@ namespace testpanda {
   struct plotter <98> {
     constexpr static const char* name = "electrons/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -1314,11 +1160,9 @@ namespace testpanda {
   struct plotter <99> {
     constexpr static const char* name = "electrons/veto";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.veto);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.veto);
       return output;
     }
   };
@@ -1328,11 +1172,9 @@ namespace testpanda {
   struct plotter <100> {
     constexpr static const char* name = "electrons/conversionVeto";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.conversionVeto);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.conversionVeto);
       return output;
     }
   };
@@ -1342,11 +1184,9 @@ namespace testpanda {
   struct plotter <101> {
     constexpr static const char* name = "electrons/loose";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.loose);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.loose);
       return output;
     }
   };
@@ -1356,11 +1196,9 @@ namespace testpanda {
   struct plotter <102> {
     constexpr static const char* name = "electrons/regPt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.regPt);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.regPt);
       return output;
     }
   };
@@ -1370,11 +1208,9 @@ namespace testpanda {
   struct plotter <103> {
     constexpr static const char* name = "electrons/nhIso";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.nhIso);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.nhIso);
       return output;
     }
   };
@@ -1384,11 +1220,9 @@ namespace testpanda {
   struct plotter <104> {
     constexpr static const char* name = "electrons/dPhiIn";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.dPhiIn);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.dPhiIn);
       return output;
     }
   };
@@ -1398,11 +1232,9 @@ namespace testpanda {
   struct plotter <105> {
     constexpr static const char* name = "electrons/dz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.dz);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.dz);
       return output;
     }
   };
@@ -1412,11 +1244,9 @@ namespace testpanda {
   struct plotter <106> {
     constexpr static const char* name = "electrons/chIsoPh";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.chIsoPh);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.chIsoPh);
       return output;
     }
   };
@@ -1426,11 +1256,9 @@ namespace testpanda {
   struct plotter <107> {
     constexpr static const char* name = "electrons/phIso";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.phIso);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.phIso);
       return output;
     }
   };
@@ -1440,11 +1268,9 @@ namespace testpanda {
   struct plotter <108> {
     constexpr static const char* name = "electrons/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -1454,11 +1280,9 @@ namespace testpanda {
   struct plotter <109> {
     constexpr static const char* name = "electrons/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -1468,11 +1292,9 @@ namespace testpanda {
   struct plotter <110> {
     constexpr static const char* name = "electrons/nhIsoPh";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.nhIsoPh);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.nhIsoPh);
       return output;
     }
   };
@@ -1482,11 +1304,9 @@ namespace testpanda {
   struct plotter <111> {
     constexpr static const char* name = "electrons/hcalIso";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.hcalIso);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.hcalIso);
       return output;
     }
   };
@@ -1496,11 +1316,9 @@ namespace testpanda {
   struct plotter <112> {
     constexpr static const char* name = "electrons/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -1510,11 +1328,9 @@ namespace testpanda {
   struct plotter <113> {
     constexpr static const char* name = "electrons/puIso";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.puIso);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.puIso);
       return output;
     }
   };
@@ -1524,11 +1340,9 @@ namespace testpanda {
   struct plotter <114> {
     constexpr static const char* name = "electrons/combIso";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.combIso());
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.combIso());
       return output;
     }
   };
@@ -1538,11 +1352,9 @@ namespace testpanda {
   struct plotter <115> {
     constexpr static const char* name = "electrons/r9";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.r9);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.r9);
       return output;
     }
   };
@@ -1552,11 +1364,9 @@ namespace testpanda {
   struct plotter <116> {
     constexpr static const char* name = "electrons/nMissingHits";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.nMissingHits);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.nMissingHits);
       return output;
     }
   };
@@ -1566,11 +1376,9 @@ namespace testpanda {
   struct plotter <117> {
     constexpr static const char* name = "electrons/hOverE";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.hOverE);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.hOverE);
       return output;
     }
   };
@@ -1580,11 +1388,9 @@ namespace testpanda {
   struct plotter <118> {
     constexpr static const char* name = "electrons/smearedPt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.smearedPt);
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.smearedPt);
       return output;
     }
   };
@@ -1594,11 +1400,9 @@ namespace testpanda {
   struct plotter <119> {
     constexpr static const char* name = "electrons/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.electrons)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.electrons)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -1618,11 +1422,9 @@ namespace testpanda {
   struct plotter <121> {
     constexpr static const char* name = "muons/dxy";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.dxy);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.dxy);
       return output;
     }
   };
@@ -1632,11 +1434,9 @@ namespace testpanda {
   struct plotter <122> {
     constexpr static const char* name = "muons/global";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.global);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.global);
       return output;
     }
   };
@@ -1646,11 +1446,9 @@ namespace testpanda {
   struct plotter <123> {
     constexpr static const char* name = "muons/chIso";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.chIso);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.chIso);
       return output;
     }
   };
@@ -1660,11 +1458,9 @@ namespace testpanda {
   struct plotter <124> {
     constexpr static const char* name = "muons/normChi2";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.normChi2);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.normChi2);
       return output;
     }
   };
@@ -1674,11 +1470,9 @@ namespace testpanda {
   struct plotter <125> {
     constexpr static const char* name = "muons/trkLayersWithMmt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.trkLayersWithMmt);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.trkLayersWithMmt);
       return output;
     }
   };
@@ -1688,11 +1482,9 @@ namespace testpanda {
   struct plotter <126> {
     constexpr static const char* name = "muons/pfPt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.pfPt);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.pfPt);
       return output;
     }
   };
@@ -1702,11 +1494,9 @@ namespace testpanda {
   struct plotter <127> {
     constexpr static const char* name = "muons/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -1716,11 +1506,9 @@ namespace testpanda {
   struct plotter <128> {
     constexpr static const char* name = "muons/hltsafe";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.hltsafe);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.hltsafe);
       return output;
     }
   };
@@ -1730,11 +1518,9 @@ namespace testpanda {
   struct plotter <129> {
     constexpr static const char* name = "muons/tight";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.tight);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.tight);
       return output;
     }
   };
@@ -1744,11 +1530,9 @@ namespace testpanda {
   struct plotter <130> {
     constexpr static const char* name = "muons/charge";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.charge);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.charge);
       return output;
     }
   };
@@ -1758,11 +1542,9 @@ namespace testpanda {
   struct plotter <131> {
     constexpr static const char* name = "muons/tracker";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.tracker);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.tracker);
       return output;
     }
   };
@@ -1772,11 +1554,9 @@ namespace testpanda {
   struct plotter <132> {
     constexpr static const char* name = "muons/pf";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.pf);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.pf);
       return output;
     }
   };
@@ -1786,11 +1566,9 @@ namespace testpanda {
   struct plotter <133> {
     constexpr static const char* name = "muons/segmentCompatibility";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.segmentCompatibility);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.segmentCompatibility);
       return output;
     }
   };
@@ -1800,11 +1578,9 @@ namespace testpanda {
   struct plotter <134> {
     constexpr static const char* name = "muons/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.e());
       return output;
     }
   };
@@ -1814,11 +1590,9 @@ namespace testpanda {
   struct plotter <135> {
     constexpr static const char* name = "muons/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -1828,11 +1602,9 @@ namespace testpanda {
   struct plotter <136> {
     constexpr static const char* name = "muons/medium";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.medium);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.medium);
       return output;
     }
   };
@@ -1842,11 +1614,9 @@ namespace testpanda {
   struct plotter <137> {
     constexpr static const char* name = "muons/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -1856,11 +1626,9 @@ namespace testpanda {
   struct plotter <138> {
     constexpr static const char* name = "muons/validFraction";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.validFraction);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.validFraction);
       return output;
     }
   };
@@ -1870,11 +1638,9 @@ namespace testpanda {
   struct plotter <139> {
     constexpr static const char* name = "muons/nMatched";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.nMatched);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.nMatched);
       return output;
     }
   };
@@ -1884,11 +1650,9 @@ namespace testpanda {
   struct plotter <140> {
     constexpr static const char* name = "muons/loose";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.loose);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.loose);
       return output;
     }
   };
@@ -1898,11 +1662,9 @@ namespace testpanda {
   struct plotter <141> {
     constexpr static const char* name = "muons/mediumBtoF";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.mediumBtoF);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.mediumBtoF);
       return output;
     }
   };
@@ -1912,11 +1674,9 @@ namespace testpanda {
   struct plotter <142> {
     constexpr static const char* name = "muons/nValidPixel";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.nValidPixel);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.nValidPixel);
       return output;
     }
   };
@@ -1926,11 +1686,9 @@ namespace testpanda {
   struct plotter <143> {
     constexpr static const char* name = "muons/nhIso";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.nhIso);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.nhIso);
       return output;
     }
   };
@@ -1940,11 +1698,9 @@ namespace testpanda {
   struct plotter <144> {
     constexpr static const char* name = "muons/nValidMuon";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.nValidMuon);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.nValidMuon);
       return output;
     }
   };
@@ -1954,11 +1710,9 @@ namespace testpanda {
   struct plotter <145> {
     constexpr static const char* name = "muons/dz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.dz);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.dz);
       return output;
     }
   };
@@ -1968,11 +1722,9 @@ namespace testpanda {
   struct plotter <146> {
     constexpr static const char* name = "muons/chi2LocalPosition";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.chi2LocalPosition);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.chi2LocalPosition);
       return output;
     }
   };
@@ -1982,11 +1734,9 @@ namespace testpanda {
   struct plotter <147> {
     constexpr static const char* name = "muons/pixLayersWithMmt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.pixLayersWithMmt);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.pixLayersWithMmt);
       return output;
     }
   };
@@ -1996,11 +1746,9 @@ namespace testpanda {
   struct plotter <148> {
     constexpr static const char* name = "muons/phIso";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.phIso);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.phIso);
       return output;
     }
   };
@@ -2010,11 +1758,9 @@ namespace testpanda {
   struct plotter <149> {
     constexpr static const char* name = "muons/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -2024,11 +1770,9 @@ namespace testpanda {
   struct plotter <150> {
     constexpr static const char* name = "muons/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -2038,11 +1782,9 @@ namespace testpanda {
   struct plotter <151> {
     constexpr static const char* name = "muons/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -2052,11 +1794,9 @@ namespace testpanda {
   struct plotter <152> {
     constexpr static const char* name = "muons/puIso";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.puIso);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.puIso);
       return output;
     }
   };
@@ -2066,11 +1806,9 @@ namespace testpanda {
   struct plotter <153> {
     constexpr static const char* name = "muons/combIso";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.combIso());
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.combIso());
       return output;
     }
   };
@@ -2080,11 +1818,9 @@ namespace testpanda {
   struct plotter <154> {
     constexpr static const char* name = "muons/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -2094,11 +1830,9 @@ namespace testpanda {
   struct plotter <155> {
     constexpr static const char* name = "muons/r03Iso";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.r03Iso);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.r03Iso);
       return output;
     }
   };
@@ -2108,11 +1842,9 @@ namespace testpanda {
   struct plotter <156> {
     constexpr static const char* name = "muons/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -2122,11 +1854,9 @@ namespace testpanda {
   struct plotter <157> {
     constexpr static const char* name = "muons/trkKink";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.trkKink);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.trkKink);
       return output;
     }
   };
@@ -2136,11 +1866,9 @@ namespace testpanda {
   struct plotter <158> {
     constexpr static const char* name = "muons/soft";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.muons)
-      output.push_back(i.soft);
-
+      std::vector<float> output;
+      for (auto& i : event.muons)
+        output.push_back(i.soft);
       return output;
     }
   };
@@ -2160,11 +1888,9 @@ namespace testpanda {
   struct plotter <160> {
     constexpr static const char* name = "taus/vertex_isValid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.taus)
-      output.push_back(i.vertex.isValid());
-
+      std::vector<float> output;
+      for (auto& i : event.taus)
+        output.push_back(i.vertex.isValid());
       return output;
     }
   };
@@ -2174,11 +1900,9 @@ namespace testpanda {
   struct plotter <161> {
     constexpr static const char* name = "taus/matchedGen_isValid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.taus)
-      output.push_back(i.matchedGen.isValid());
-
+      std::vector<float> output;
+      for (auto& i : event.taus)
+        output.push_back(i.matchedGen.isValid());
       return output;
     }
   };
@@ -2188,11 +1912,9 @@ namespace testpanda {
   struct plotter <162> {
     constexpr static const char* name = "taus/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.taus)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.taus)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -2202,11 +1924,9 @@ namespace testpanda {
   struct plotter <163> {
     constexpr static const char* name = "taus/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.taus)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.taus)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -2216,11 +1936,9 @@ namespace testpanda {
   struct plotter <164> {
     constexpr static const char* name = "taus/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.taus)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.taus)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -2230,11 +1948,9 @@ namespace testpanda {
   struct plotter <165> {
     constexpr static const char* name = "taus/decayMode";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.taus)
-      output.push_back(i.decayMode);
-
+      std::vector<float> output;
+      for (auto& i : event.taus)
+        output.push_back(i.decayMode);
       return output;
     }
   };
@@ -2244,11 +1960,9 @@ namespace testpanda {
   struct plotter <166> {
     constexpr static const char* name = "taus/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.taus)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.taus)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -2258,11 +1972,9 @@ namespace testpanda {
   struct plotter <167> {
     constexpr static const char* name = "taus/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.taus)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.taus)
+        output.push_back(i.e());
       return output;
     }
   };
@@ -2272,11 +1984,9 @@ namespace testpanda {
   struct plotter <168> {
     constexpr static const char* name = "taus/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.taus)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.taus)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -2286,11 +1996,9 @@ namespace testpanda {
   struct plotter <169> {
     constexpr static const char* name = "taus/isoDeltaBetaCorr";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.taus)
-      output.push_back(i.isoDeltaBetaCorr);
-
+      std::vector<float> output;
+      for (auto& i : event.taus)
+        output.push_back(i.isoDeltaBetaCorr);
       return output;
     }
   };
@@ -2300,11 +2008,9 @@ namespace testpanda {
   struct plotter <170> {
     constexpr static const char* name = "taus/charge";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.taus)
-      output.push_back(i.charge);
-
+      std::vector<float> output;
+      for (auto& i : event.taus)
+        output.push_back(i.charge);
       return output;
     }
   };
@@ -2314,11 +2020,9 @@ namespace testpanda {
   struct plotter <171> {
     constexpr static const char* name = "taus/iso";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.taus)
-      output.push_back(i.iso);
-
+      std::vector<float> output;
+      for (auto& i : event.taus)
+        output.push_back(i.iso);
       return output;
     }
   };
@@ -2328,11 +2032,9 @@ namespace testpanda {
   struct plotter <172> {
     constexpr static const char* name = "taus/looseIsoMVA";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.taus)
-      output.push_back(i.looseIsoMVA);
-
+      std::vector<float> output;
+      for (auto& i : event.taus)
+        output.push_back(i.looseIsoMVA);
       return output;
     }
   };
@@ -2342,11 +2044,9 @@ namespace testpanda {
   struct plotter <173> {
     constexpr static const char* name = "taus/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.taus)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.taus)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -2356,11 +2056,9 @@ namespace testpanda {
   struct plotter <174> {
     constexpr static const char* name = "taus/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.taus)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.taus)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -2370,11 +2068,9 @@ namespace testpanda {
   struct plotter <175> {
     constexpr static const char* name = "taus/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.taus)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.taus)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -2384,11 +2080,9 @@ namespace testpanda {
   struct plotter <176> {
     constexpr static const char* name = "taus/looseIsoMVAOld";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.taus)
-      output.push_back(i.looseIsoMVAOld);
-
+      std::vector<float> output;
+      for (auto& i : event.taus)
+        output.push_back(i.looseIsoMVAOld);
       return output;
     }
   };
@@ -2398,11 +2092,9 @@ namespace testpanda {
   struct plotter <177> {
     constexpr static const char* name = "taus/decayModeNew";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.taus)
-      output.push_back(i.decayModeNew);
-
+      std::vector<float> output;
+      for (auto& i : event.taus)
+        output.push_back(i.decayModeNew);
       return output;
     }
   };
@@ -2422,11 +2114,9 @@ namespace testpanda {
   struct plotter <179> {
     constexpr static const char* name = "photons/superCluster_isValid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.superCluster.isValid());
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.superCluster.isValid());
       return output;
     }
   };
@@ -2436,11 +2126,9 @@ namespace testpanda {
   struct plotter <180> {
     constexpr static const char* name = "photons/matchedPF_isValid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.matchedPF.isValid());
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.matchedPF.isValid());
       return output;
     }
   };
@@ -2450,11 +2138,9 @@ namespace testpanda {
   struct plotter <181> {
     constexpr static const char* name = "photons/matchedGen_isValid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.matchedGen.isValid());
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.matchedGen.isValid());
       return output;
     }
   };
@@ -2464,11 +2150,9 @@ namespace testpanda {
   struct plotter <182> {
     constexpr static const char* name = "photons/emax";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.emax);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.emax);
       return output;
     }
   };
@@ -2478,11 +2162,9 @@ namespace testpanda {
   struct plotter <183> {
     constexpr static const char* name = "photons/chIsoMax";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.chIsoMax);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.chIsoMax);
       return output;
     }
   };
@@ -2492,11 +2174,9 @@ namespace testpanda {
   struct plotter <184> {
     constexpr static const char* name = "photons/e2nd";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.e2nd);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.e2nd);
       return output;
     }
   };
@@ -2506,11 +2186,9 @@ namespace testpanda {
   struct plotter <185> {
     constexpr static const char* name = "photons/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -2520,11 +2198,9 @@ namespace testpanda {
   struct plotter <186> {
     constexpr static const char* name = "photons/etop";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.etop);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.etop);
       return output;
     }
   };
@@ -2534,11 +2210,9 @@ namespace testpanda {
   struct plotter <187> {
     constexpr static const char* name = "photons/phiWidth";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.phiWidth);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.phiWidth);
       return output;
     }
   };
@@ -2548,11 +2222,9 @@ namespace testpanda {
   struct plotter <188> {
     constexpr static const char* name = "photons/highpt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.highpt);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.highpt);
       return output;
     }
   };
@@ -2562,11 +2234,9 @@ namespace testpanda {
   struct plotter <189> {
     constexpr static const char* name = "photons/mipEnergy";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.mipEnergy);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.mipEnergy);
       return output;
     }
   };
@@ -2576,11 +2246,9 @@ namespace testpanda {
   struct plotter <190> {
     constexpr static const char* name = "photons/pixelVeto";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.pixelVeto);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.pixelVeto);
       return output;
     }
   };
@@ -2590,11 +2258,9 @@ namespace testpanda {
   struct plotter <191> {
     constexpr static const char* name = "photons/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -2604,11 +2270,9 @@ namespace testpanda {
   struct plotter <192> {
     constexpr static const char* name = "photons/pfPt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.pfPt);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.pfPt);
       return output;
     }
   };
@@ -2618,11 +2282,9 @@ namespace testpanda {
   struct plotter <193> {
     constexpr static const char* name = "photons/eleft";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.eleft);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.eleft);
       return output;
     }
   };
@@ -2632,11 +2294,9 @@ namespace testpanda {
   struct plotter <194> {
     constexpr static const char* name = "photons/sipip";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.sipip);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.sipip);
       return output;
     }
   };
@@ -2646,11 +2306,9 @@ namespace testpanda {
   struct plotter <195> {
     constexpr static const char* name = "photons/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -2660,11 +2318,9 @@ namespace testpanda {
   struct plotter <196> {
     constexpr static const char* name = "photons/tight";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.tight);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.tight);
       return output;
     }
   };
@@ -2674,11 +2330,9 @@ namespace testpanda {
   struct plotter <197> {
     constexpr static const char* name = "photons/genIso";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.genIso);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.genIso);
       return output;
     }
   };
@@ -2688,11 +2342,9 @@ namespace testpanda {
   struct plotter <198> {
     constexpr static const char* name = "photons/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.e());
       return output;
     }
   };
@@ -2702,11 +2354,9 @@ namespace testpanda {
   struct plotter <199> {
     constexpr static const char* name = "photons/sieie";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.sieie);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.sieie);
       return output;
     }
   };
@@ -2716,11 +2366,9 @@ namespace testpanda {
   struct plotter <200> {
     constexpr static const char* name = "photons/medium";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.medium);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.medium);
       return output;
     }
   };
@@ -2730,11 +2378,9 @@ namespace testpanda {
   struct plotter <201> {
     constexpr static const char* name = "photons/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -2744,11 +2390,9 @@ namespace testpanda {
   struct plotter <202> {
     constexpr static const char* name = "photons/loose";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.loose);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.loose);
       return output;
     }
   };
@@ -2758,11 +2402,9 @@ namespace testpanda {
   struct plotter <203> {
     constexpr static const char* name = "photons/eright";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.eright);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.eright);
       return output;
     }
   };
@@ -2772,11 +2414,9 @@ namespace testpanda {
   struct plotter <204> {
     constexpr static const char* name = "photons/nhIso";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.nhIso);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.nhIso);
       return output;
     }
   };
@@ -2786,11 +2426,9 @@ namespace testpanda {
   struct plotter <205> {
     constexpr static const char* name = "photons/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -2800,11 +2438,9 @@ namespace testpanda {
   struct plotter <206> {
     constexpr static const char* name = "photons/ebottom";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.ebottom);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.ebottom);
       return output;
     }
   };
@@ -2814,11 +2450,9 @@ namespace testpanda {
   struct plotter <207> {
     constexpr static const char* name = "photons/csafeVeto";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.csafeVeto);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.csafeVeto);
       return output;
     }
   };
@@ -2828,11 +2462,9 @@ namespace testpanda {
   struct plotter <208> {
     constexpr static const char* name = "photons/phIso";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.phIso);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.phIso);
       return output;
     }
   };
@@ -2842,11 +2474,9 @@ namespace testpanda {
   struct plotter <209> {
     constexpr static const char* name = "photons/regPt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.regPt);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.regPt);
       return output;
     }
   };
@@ -2856,11 +2486,9 @@ namespace testpanda {
   struct plotter <210> {
     constexpr static const char* name = "photons/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -2870,11 +2498,9 @@ namespace testpanda {
   struct plotter <211> {
     constexpr static const char* name = "photons/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -2884,11 +2510,9 @@ namespace testpanda {
   struct plotter <212> {
     constexpr static const char* name = "photons/r9";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.r9);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.r9);
       return output;
     }
   };
@@ -2898,11 +2522,9 @@ namespace testpanda {
   struct plotter <213> {
     constexpr static const char* name = "photons/timeSpan";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.timeSpan);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.timeSpan);
       return output;
     }
   };
@@ -2912,11 +2534,9 @@ namespace testpanda {
   struct plotter <214> {
     constexpr static const char* name = "photons/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -2926,11 +2546,9 @@ namespace testpanda {
   struct plotter <215> {
     constexpr static const char* name = "photons/etaWidth";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.etaWidth);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.etaWidth);
       return output;
     }
   };
@@ -2940,11 +2558,9 @@ namespace testpanda {
   struct plotter <216> {
     constexpr static const char* name = "photons/chIso";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.chIso);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.chIso);
       return output;
     }
   };
@@ -2954,11 +2570,9 @@ namespace testpanda {
   struct plotter <217> {
     constexpr static const char* name = "photons/hOverE";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.hOverE);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.hOverE);
       return output;
     }
   };
@@ -2968,11 +2582,9 @@ namespace testpanda {
   struct plotter <218> {
     constexpr static const char* name = "photons/smearedPt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.smearedPt);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.smearedPt);
       return output;
     }
   };
@@ -2982,11 +2594,9 @@ namespace testpanda {
   struct plotter <219> {
     constexpr static const char* name = "photons/time";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.photons)
-      output.push_back(i.time);
-
+      std::vector<float> output;
+      for (auto& i : event.photons)
+        output.push_back(i.time);
       return output;
     }
   };
@@ -3006,11 +2616,9 @@ namespace testpanda {
   struct plotter <221> {
     constexpr static const char* name = "chsAK4Jets/matchedGenJet_isValid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.matchedGenJet.isValid());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.matchedGenJet.isValid());
       return output;
     }
   };
@@ -3020,11 +2628,9 @@ namespace testpanda {
   struct plotter <222> {
     constexpr static const char* name = "chsAK4Jets/constituents_size";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.constituents.size());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.constituents.size());
       return output;
     }
   };
@@ -3034,11 +2640,9 @@ namespace testpanda {
   struct plotter <223> {
     constexpr static const char* name = "chsAK4Jets/secondaryVertex_isValid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.secondaryVertex.isValid());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.secondaryVertex.isValid());
       return output;
     }
   };
@@ -3048,11 +2652,9 @@ namespace testpanda {
   struct plotter <224> {
     constexpr static const char* name = "chsAK4Jets/deepCMVAudsg";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.deepCMVAudsg);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.deepCMVAudsg);
       return output;
     }
   };
@@ -3062,11 +2664,9 @@ namespace testpanda {
   struct plotter <225> {
     constexpr static const char* name = "chsAK4Jets/nhf";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.nhf);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.nhf);
       return output;
     }
   };
@@ -3076,11 +2676,9 @@ namespace testpanda {
   struct plotter <226> {
     constexpr static const char* name = "chsAK4Jets/ptCorrUp";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.ptCorrUp);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.ptCorrUp);
       return output;
     }
   };
@@ -3090,11 +2688,9 @@ namespace testpanda {
   struct plotter <227> {
     constexpr static const char* name = "chsAK4Jets/deepCMVAcc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.deepCMVAcc);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.deepCMVAcc);
       return output;
     }
   };
@@ -3104,11 +2700,9 @@ namespace testpanda {
   struct plotter <228> {
     constexpr static const char* name = "chsAK4Jets/deepCSVudsg";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.deepCSVudsg);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.deepCSVudsg);
       return output;
     }
   };
@@ -3118,11 +2712,9 @@ namespace testpanda {
   struct plotter <229> {
     constexpr static const char* name = "chsAK4Jets/cmva";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.cmva);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.cmva);
       return output;
     }
   };
@@ -3132,11 +2724,9 @@ namespace testpanda {
   struct plotter <230> {
     constexpr static const char* name = "chsAK4Jets/deepCSVcc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.deepCSVcc);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.deepCSVcc);
       return output;
     }
   };
@@ -3146,11 +2736,9 @@ namespace testpanda {
   struct plotter <231> {
     constexpr static const char* name = "chsAK4Jets/deepCMVAbb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.deepCMVAbb);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.deepCMVAbb);
       return output;
     }
   };
@@ -3160,11 +2748,9 @@ namespace testpanda {
   struct plotter <232> {
     constexpr static const char* name = "chsAK4Jets/deepCSVbb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.deepCSVbb);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.deepCSVbb);
       return output;
     }
   };
@@ -3174,11 +2760,9 @@ namespace testpanda {
   struct plotter <233> {
     constexpr static const char* name = "chsAK4Jets/chf";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.chf);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.chf);
       return output;
     }
   };
@@ -3188,11 +2772,9 @@ namespace testpanda {
   struct plotter <234> {
     constexpr static const char* name = "chsAK4Jets/area";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.area);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.area);
       return output;
     }
   };
@@ -3202,11 +2784,9 @@ namespace testpanda {
   struct plotter <235> {
     constexpr static const char* name = "chsAK4Jets/nef";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.nef);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.nef);
       return output;
     }
   };
@@ -3216,11 +2796,9 @@ namespace testpanda {
   struct plotter <236> {
     constexpr static const char* name = "chsAK4Jets/ptCorrDown";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.ptCorrDown);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.ptCorrDown);
       return output;
     }
   };
@@ -3230,11 +2808,9 @@ namespace testpanda {
   struct plotter <237> {
     constexpr static const char* name = "chsAK4Jets/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -3244,11 +2820,9 @@ namespace testpanda {
   struct plotter <238> {
     constexpr static const char* name = "chsAK4Jets/deepCMVAb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.deepCMVAb);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.deepCMVAb);
       return output;
     }
   };
@@ -3258,11 +2832,9 @@ namespace testpanda {
   struct plotter <239> {
     constexpr static const char* name = "chsAK4Jets/tight";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.tight);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.tight);
       return output;
     }
   };
@@ -3272,11 +2844,9 @@ namespace testpanda {
   struct plotter <240> {
     constexpr static const char* name = "chsAK4Jets/puid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.puid);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.puid);
       return output;
     }
   };
@@ -3286,11 +2856,9 @@ namespace testpanda {
   struct plotter <241> {
     constexpr static const char* name = "chsAK4Jets/qgl";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.qgl);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.qgl);
       return output;
     }
   };
@@ -3300,11 +2868,9 @@ namespace testpanda {
   struct plotter <242> {
     constexpr static const char* name = "chsAK4Jets/csv";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.csv);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.csv);
       return output;
     }
   };
@@ -3314,11 +2880,9 @@ namespace testpanda {
   struct plotter <243> {
     constexpr static const char* name = "chsAK4Jets/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.e());
       return output;
     }
   };
@@ -3328,11 +2892,9 @@ namespace testpanda {
   struct plotter <244> {
     constexpr static const char* name = "chsAK4Jets/cef";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.cef);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.cef);
       return output;
     }
   };
@@ -3342,11 +2904,9 @@ namespace testpanda {
   struct plotter <245> {
     constexpr static const char* name = "chsAK4Jets/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -3356,11 +2916,9 @@ namespace testpanda {
   struct plotter <246> {
     constexpr static const char* name = "chsAK4Jets/rawPt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.rawPt);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.rawPt);
       return output;
     }
   };
@@ -3370,11 +2928,9 @@ namespace testpanda {
   struct plotter <247> {
     constexpr static const char* name = "chsAK4Jets/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -3384,11 +2940,9 @@ namespace testpanda {
   struct plotter <248> {
     constexpr static const char* name = "chsAK4Jets/loose";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.loose);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.loose);
       return output;
     }
   };
@@ -3398,11 +2952,9 @@ namespace testpanda {
   struct plotter <249> {
     constexpr static const char* name = "chsAK4Jets/deepCMVAc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.deepCMVAc);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.deepCMVAc);
       return output;
     }
   };
@@ -3412,11 +2964,9 @@ namespace testpanda {
   struct plotter <250> {
     constexpr static const char* name = "chsAK4Jets/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -3426,11 +2976,9 @@ namespace testpanda {
   struct plotter <251> {
     constexpr static const char* name = "chsAK4Jets/monojet";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.monojet);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.monojet);
       return output;
     }
   };
@@ -3440,11 +2988,9 @@ namespace testpanda {
   struct plotter <252> {
     constexpr static const char* name = "chsAK4Jets/ptSmearDown";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.ptSmearDown);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.ptSmearDown);
       return output;
     }
   };
@@ -3454,11 +3000,9 @@ namespace testpanda {
   struct plotter <253> {
     constexpr static const char* name = "chsAK4Jets/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -3468,11 +3012,9 @@ namespace testpanda {
   struct plotter <254> {
     constexpr static const char* name = "chsAK4Jets/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -3482,11 +3024,9 @@ namespace testpanda {
   struct plotter <255> {
     constexpr static const char* name = "chsAK4Jets/deepCSVb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.deepCSVb);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.deepCSVb);
       return output;
     }
   };
@@ -3496,11 +3036,9 @@ namespace testpanda {
   struct plotter <256> {
     constexpr static const char* name = "chsAK4Jets/deepCSVc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.deepCSVc);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.deepCSVc);
       return output;
     }
   };
@@ -3510,11 +3048,9 @@ namespace testpanda {
   struct plotter <257> {
     constexpr static const char* name = "chsAK4Jets/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -3524,11 +3060,9 @@ namespace testpanda {
   struct plotter <258> {
     constexpr static const char* name = "chsAK4Jets/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -3538,11 +3072,9 @@ namespace testpanda {
   struct plotter <259> {
     constexpr static const char* name = "chsAK4Jets/ptSmear";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.ptSmear);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.ptSmear);
       return output;
     }
   };
@@ -3552,11 +3084,9 @@ namespace testpanda {
   struct plotter <260> {
     constexpr static const char* name = "chsAK4Jets/ptSmearUp";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK4Jets)
-      output.push_back(i.ptSmearUp);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK4Jets)
+        output.push_back(i.ptSmearUp);
       return output;
     }
   };
@@ -3576,11 +3106,9 @@ namespace testpanda {
   struct plotter <262> {
     constexpr static const char* name = "puppiAK4Jets/matchedGenJet_isValid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.matchedGenJet.isValid());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.matchedGenJet.isValid());
       return output;
     }
   };
@@ -3590,11 +3118,9 @@ namespace testpanda {
   struct plotter <263> {
     constexpr static const char* name = "puppiAK4Jets/constituents_size";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.constituents.size());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.constituents.size());
       return output;
     }
   };
@@ -3604,11 +3130,9 @@ namespace testpanda {
   struct plotter <264> {
     constexpr static const char* name = "puppiAK4Jets/secondaryVertex_isValid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.secondaryVertex.isValid());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.secondaryVertex.isValid());
       return output;
     }
   };
@@ -3618,11 +3142,9 @@ namespace testpanda {
   struct plotter <265> {
     constexpr static const char* name = "puppiAK4Jets/deepCMVAudsg";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.deepCMVAudsg);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.deepCMVAudsg);
       return output;
     }
   };
@@ -3632,11 +3154,9 @@ namespace testpanda {
   struct plotter <266> {
     constexpr static const char* name = "puppiAK4Jets/nhf";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.nhf);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.nhf);
       return output;
     }
   };
@@ -3646,11 +3166,9 @@ namespace testpanda {
   struct plotter <267> {
     constexpr static const char* name = "puppiAK4Jets/ptCorrUp";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.ptCorrUp);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.ptCorrUp);
       return output;
     }
   };
@@ -3660,11 +3178,9 @@ namespace testpanda {
   struct plotter <268> {
     constexpr static const char* name = "puppiAK4Jets/deepCMVAcc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.deepCMVAcc);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.deepCMVAcc);
       return output;
     }
   };
@@ -3674,11 +3190,9 @@ namespace testpanda {
   struct plotter <269> {
     constexpr static const char* name = "puppiAK4Jets/deepCSVudsg";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.deepCSVudsg);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.deepCSVudsg);
       return output;
     }
   };
@@ -3688,11 +3202,9 @@ namespace testpanda {
   struct plotter <270> {
     constexpr static const char* name = "puppiAK4Jets/cmva";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.cmva);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.cmva);
       return output;
     }
   };
@@ -3702,11 +3214,9 @@ namespace testpanda {
   struct plotter <271> {
     constexpr static const char* name = "puppiAK4Jets/deepCSVcc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.deepCSVcc);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.deepCSVcc);
       return output;
     }
   };
@@ -3716,11 +3226,9 @@ namespace testpanda {
   struct plotter <272> {
     constexpr static const char* name = "puppiAK4Jets/deepCMVAbb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.deepCMVAbb);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.deepCMVAbb);
       return output;
     }
   };
@@ -3730,11 +3238,9 @@ namespace testpanda {
   struct plotter <273> {
     constexpr static const char* name = "puppiAK4Jets/deepCSVbb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.deepCSVbb);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.deepCSVbb);
       return output;
     }
   };
@@ -3744,11 +3250,9 @@ namespace testpanda {
   struct plotter <274> {
     constexpr static const char* name = "puppiAK4Jets/chf";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.chf);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.chf);
       return output;
     }
   };
@@ -3758,11 +3262,9 @@ namespace testpanda {
   struct plotter <275> {
     constexpr static const char* name = "puppiAK4Jets/area";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.area);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.area);
       return output;
     }
   };
@@ -3772,11 +3274,9 @@ namespace testpanda {
   struct plotter <276> {
     constexpr static const char* name = "puppiAK4Jets/nef";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.nef);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.nef);
       return output;
     }
   };
@@ -3786,11 +3286,9 @@ namespace testpanda {
   struct plotter <277> {
     constexpr static const char* name = "puppiAK4Jets/ptCorrDown";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.ptCorrDown);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.ptCorrDown);
       return output;
     }
   };
@@ -3800,11 +3298,9 @@ namespace testpanda {
   struct plotter <278> {
     constexpr static const char* name = "puppiAK4Jets/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -3814,11 +3310,9 @@ namespace testpanda {
   struct plotter <279> {
     constexpr static const char* name = "puppiAK4Jets/deepCMVAb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.deepCMVAb);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.deepCMVAb);
       return output;
     }
   };
@@ -3828,11 +3322,9 @@ namespace testpanda {
   struct plotter <280> {
     constexpr static const char* name = "puppiAK4Jets/tight";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.tight);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.tight);
       return output;
     }
   };
@@ -3842,11 +3334,9 @@ namespace testpanda {
   struct plotter <281> {
     constexpr static const char* name = "puppiAK4Jets/puid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.puid);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.puid);
       return output;
     }
   };
@@ -3856,11 +3346,9 @@ namespace testpanda {
   struct plotter <282> {
     constexpr static const char* name = "puppiAK4Jets/qgl";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.qgl);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.qgl);
       return output;
     }
   };
@@ -3870,11 +3358,9 @@ namespace testpanda {
   struct plotter <283> {
     constexpr static const char* name = "puppiAK4Jets/csv";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.csv);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.csv);
       return output;
     }
   };
@@ -3884,11 +3370,9 @@ namespace testpanda {
   struct plotter <284> {
     constexpr static const char* name = "puppiAK4Jets/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.e());
       return output;
     }
   };
@@ -3898,11 +3382,9 @@ namespace testpanda {
   struct plotter <285> {
     constexpr static const char* name = "puppiAK4Jets/cef";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.cef);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.cef);
       return output;
     }
   };
@@ -3912,11 +3394,9 @@ namespace testpanda {
   struct plotter <286> {
     constexpr static const char* name = "puppiAK4Jets/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -3926,11 +3406,9 @@ namespace testpanda {
   struct plotter <287> {
     constexpr static const char* name = "puppiAK4Jets/rawPt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.rawPt);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.rawPt);
       return output;
     }
   };
@@ -3940,11 +3418,9 @@ namespace testpanda {
   struct plotter <288> {
     constexpr static const char* name = "puppiAK4Jets/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -3954,11 +3430,9 @@ namespace testpanda {
   struct plotter <289> {
     constexpr static const char* name = "puppiAK4Jets/loose";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.loose);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.loose);
       return output;
     }
   };
@@ -3968,11 +3442,9 @@ namespace testpanda {
   struct plotter <290> {
     constexpr static const char* name = "puppiAK4Jets/deepCMVAc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.deepCMVAc);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.deepCMVAc);
       return output;
     }
   };
@@ -3982,11 +3454,9 @@ namespace testpanda {
   struct plotter <291> {
     constexpr static const char* name = "puppiAK4Jets/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -3996,11 +3466,9 @@ namespace testpanda {
   struct plotter <292> {
     constexpr static const char* name = "puppiAK4Jets/monojet";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.monojet);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.monojet);
       return output;
     }
   };
@@ -4010,11 +3478,9 @@ namespace testpanda {
   struct plotter <293> {
     constexpr static const char* name = "puppiAK4Jets/ptSmearDown";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.ptSmearDown);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.ptSmearDown);
       return output;
     }
   };
@@ -4024,11 +3490,9 @@ namespace testpanda {
   struct plotter <294> {
     constexpr static const char* name = "puppiAK4Jets/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -4038,11 +3502,9 @@ namespace testpanda {
   struct plotter <295> {
     constexpr static const char* name = "puppiAK4Jets/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -4052,11 +3514,9 @@ namespace testpanda {
   struct plotter <296> {
     constexpr static const char* name = "puppiAK4Jets/deepCSVb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.deepCSVb);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.deepCSVb);
       return output;
     }
   };
@@ -4066,11 +3526,9 @@ namespace testpanda {
   struct plotter <297> {
     constexpr static const char* name = "puppiAK4Jets/deepCSVc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.deepCSVc);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.deepCSVc);
       return output;
     }
   };
@@ -4080,11 +3538,9 @@ namespace testpanda {
   struct plotter <298> {
     constexpr static const char* name = "puppiAK4Jets/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -4094,11 +3550,9 @@ namespace testpanda {
   struct plotter <299> {
     constexpr static const char* name = "puppiAK4Jets/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -4108,11 +3562,9 @@ namespace testpanda {
   struct plotter <300> {
     constexpr static const char* name = "puppiAK4Jets/ptSmear";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.ptSmear);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.ptSmear);
       return output;
     }
   };
@@ -4122,11 +3574,9 @@ namespace testpanda {
   struct plotter <301> {
     constexpr static const char* name = "puppiAK4Jets/ptSmearUp";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK4Jets)
-      output.push_back(i.ptSmearUp);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK4Jets)
+        output.push_back(i.ptSmearUp);
       return output;
     }
   };
@@ -4146,11 +3596,9 @@ namespace testpanda {
   struct plotter <303> {
     constexpr static const char* name = "chsAK8Jets/subjets_size";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.subjets.size());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.subjets.size());
       return output;
     }
   };
@@ -4160,11 +3608,9 @@ namespace testpanda {
   struct plotter <304> {
     constexpr static const char* name = "chsAK8Jets/deepCMVAudsg";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.deepCMVAudsg);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.deepCMVAudsg);
       return output;
     }
   };
@@ -4174,11 +3620,9 @@ namespace testpanda {
   struct plotter <305> {
     constexpr static const char* name = "chsAK8Jets/nhf";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.nhf);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.nhf);
       return output;
     }
   };
@@ -4188,11 +3632,9 @@ namespace testpanda {
   struct plotter <306> {
     constexpr static const char* name = "chsAK8Jets/ptCorrUp";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.ptCorrUp);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.ptCorrUp);
       return output;
     }
   };
@@ -4202,11 +3644,9 @@ namespace testpanda {
   struct plotter <307> {
     constexpr static const char* name = "chsAK8Jets/cef";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.cef);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.cef);
       return output;
     }
   };
@@ -4216,11 +3656,9 @@ namespace testpanda {
   struct plotter <308> {
     constexpr static const char* name = "chsAK8Jets/deepCSVudsg";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.deepCSVudsg);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.deepCSVudsg);
       return output;
     }
   };
@@ -4230,11 +3668,9 @@ namespace testpanda {
   struct plotter <309> {
     constexpr static const char* name = "chsAK8Jets/tight";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.tight);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.tight);
       return output;
     }
   };
@@ -4244,11 +3680,9 @@ namespace testpanda {
   struct plotter <310> {
     constexpr static const char* name = "chsAK8Jets/cmva";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.cmva);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.cmva);
       return output;
     }
   };
@@ -4258,11 +3692,9 @@ namespace testpanda {
   struct plotter <311> {
     constexpr static const char* name = "chsAK8Jets/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -4272,11 +3704,9 @@ namespace testpanda {
   struct plotter <312> {
     constexpr static const char* name = "chsAK8Jets/deepCMVAbb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.deepCMVAbb);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.deepCMVAbb);
       return output;
     }
   };
@@ -4286,11 +3716,9 @@ namespace testpanda {
   struct plotter <313> {
     constexpr static const char* name = "chsAK8Jets/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -4300,11 +3728,9 @@ namespace testpanda {
   struct plotter <314> {
     constexpr static const char* name = "chsAK8Jets/htt_frec";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.htt_frec);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.htt_frec);
       return output;
     }
   };
@@ -4314,11 +3740,9 @@ namespace testpanda {
   struct plotter <315> {
     constexpr static const char* name = "chsAK8Jets/deepCMVAb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.deepCMVAb);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.deepCMVAb);
       return output;
     }
   };
@@ -4328,11 +3752,9 @@ namespace testpanda {
   struct plotter <316> {
     constexpr static const char* name = "chsAK8Jets/chf";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.chf);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.chf);
       return output;
     }
   };
@@ -4342,11 +3764,9 @@ namespace testpanda {
   struct plotter <317> {
     constexpr static const char* name = "chsAK8Jets/area";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.area);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.area);
       return output;
     }
   };
@@ -4356,11 +3776,9 @@ namespace testpanda {
   struct plotter <318> {
     constexpr static const char* name = "chsAK8Jets/nef";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.nef);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.nef);
       return output;
     }
   };
@@ -4370,11 +3788,9 @@ namespace testpanda {
   struct plotter <319> {
     constexpr static const char* name = "chsAK8Jets/htt_mass";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.htt_mass);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.htt_mass);
       return output;
     }
   };
@@ -4384,11 +3800,9 @@ namespace testpanda {
   struct plotter <320> {
     constexpr static const char* name = "chsAK8Jets/ptCorrDown";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.ptCorrDown);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.ptCorrDown);
       return output;
     }
   };
@@ -4398,11 +3812,9 @@ namespace testpanda {
   struct plotter <321> {
     constexpr static const char* name = "chsAK8Jets/deepCSVbb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.deepCSVbb);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.deepCSVbb);
       return output;
     }
   };
@@ -4412,11 +3824,9 @@ namespace testpanda {
   struct plotter <322> {
     constexpr static const char* name = "chsAK8Jets/tau2";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.tau2);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.tau2);
       return output;
     }
   };
@@ -4426,11 +3836,9 @@ namespace testpanda {
   struct plotter <323> {
     constexpr static const char* name = "chsAK8Jets/tau3";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.tau3);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.tau3);
       return output;
     }
   };
@@ -4440,11 +3848,9 @@ namespace testpanda {
   struct plotter <324> {
     constexpr static const char* name = "chsAK8Jets/puid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.puid);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.puid);
       return output;
     }
   };
@@ -4454,11 +3860,9 @@ namespace testpanda {
   struct plotter <325> {
     constexpr static const char* name = "chsAK8Jets/tau1";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.tau1);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.tau1);
       return output;
     }
   };
@@ -4468,11 +3872,9 @@ namespace testpanda {
   struct plotter <326> {
     constexpr static const char* name = "chsAK8Jets/mSD";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.mSD);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.mSD);
       return output;
     }
   };
@@ -4482,11 +3884,9 @@ namespace testpanda {
   struct plotter <327> {
     constexpr static const char* name = "chsAK8Jets/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.e());
       return output;
     }
   };
@@ -4496,11 +3896,9 @@ namespace testpanda {
   struct plotter <328> {
     constexpr static const char* name = "chsAK8Jets/deepCMVAcc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.deepCMVAcc);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.deepCMVAcc);
       return output;
     }
   };
@@ -4510,11 +3908,9 @@ namespace testpanda {
   struct plotter <329> {
     constexpr static const char* name = "chsAK8Jets/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -4524,11 +3920,9 @@ namespace testpanda {
   struct plotter <330> {
     constexpr static const char* name = "chsAK8Jets/rawPt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.rawPt);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.rawPt);
       return output;
     }
   };
@@ -4538,11 +3932,9 @@ namespace testpanda {
   struct plotter <331> {
     constexpr static const char* name = "chsAK8Jets/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -4552,11 +3944,9 @@ namespace testpanda {
   struct plotter <332> {
     constexpr static const char* name = "chsAK8Jets/double_sub";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.double_sub);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.double_sub);
       return output;
     }
   };
@@ -4566,11 +3956,9 @@ namespace testpanda {
   struct plotter <333> {
     constexpr static const char* name = "chsAK8Jets/loose";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.loose);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.loose);
       return output;
     }
   };
@@ -4580,11 +3968,9 @@ namespace testpanda {
   struct plotter <334> {
     constexpr static const char* name = "chsAK8Jets/ptSmear";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.ptSmear);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.ptSmear);
       return output;
     }
   };
@@ -4594,11 +3980,9 @@ namespace testpanda {
   struct plotter <335> {
     constexpr static const char* name = "chsAK8Jets/deepCMVAc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.deepCMVAc);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.deepCMVAc);
       return output;
     }
   };
@@ -4608,11 +3992,9 @@ namespace testpanda {
   struct plotter <336> {
     constexpr static const char* name = "chsAK8Jets/qgl";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.qgl);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.qgl);
       return output;
     }
   };
@@ -4622,11 +4004,9 @@ namespace testpanda {
   struct plotter <337> {
     constexpr static const char* name = "chsAK8Jets/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -4636,11 +4016,9 @@ namespace testpanda {
   struct plotter <338> {
     constexpr static const char* name = "chsAK8Jets/monojet";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.monojet);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.monojet);
       return output;
     }
   };
@@ -4650,11 +4028,9 @@ namespace testpanda {
   struct plotter <339> {
     constexpr static const char* name = "chsAK8Jets/ptSmearDown";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.ptSmearDown);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.ptSmearDown);
       return output;
     }
   };
@@ -4664,11 +4040,9 @@ namespace testpanda {
   struct plotter <340> {
     constexpr static const char* name = "chsAK8Jets/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -4678,11 +4052,9 @@ namespace testpanda {
   struct plotter <341> {
     constexpr static const char* name = "chsAK8Jets/mPruned";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.mPruned);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.mPruned);
       return output;
     }
   };
@@ -4692,11 +4064,9 @@ namespace testpanda {
   struct plotter <342> {
     constexpr static const char* name = "chsAK8Jets/tau1SD";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.tau1SD);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.tau1SD);
       return output;
     }
   };
@@ -4706,11 +4076,9 @@ namespace testpanda {
   struct plotter <343> {
     constexpr static const char* name = "chsAK8Jets/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -4720,11 +4088,9 @@ namespace testpanda {
   struct plotter <344> {
     constexpr static const char* name = "chsAK8Jets/csv";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.csv);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.csv);
       return output;
     }
   };
@@ -4734,11 +4100,9 @@ namespace testpanda {
   struct plotter <345> {
     constexpr static const char* name = "chsAK8Jets/deepCSVb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.deepCSVb);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.deepCSVb);
       return output;
     }
   };
@@ -4748,11 +4112,9 @@ namespace testpanda {
   struct plotter <346> {
     constexpr static const char* name = "chsAK8Jets/deepCSVc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.deepCSVc);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.deepCSVc);
       return output;
     }
   };
@@ -4762,11 +4124,9 @@ namespace testpanda {
   struct plotter <347> {
     constexpr static const char* name = "chsAK8Jets/tau3SD";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.tau3SD);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.tau3SD);
       return output;
     }
   };
@@ -4776,11 +4136,9 @@ namespace testpanda {
   struct plotter <348> {
     constexpr static const char* name = "chsAK8Jets/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -4790,11 +4148,9 @@ namespace testpanda {
   struct plotter <349> {
     constexpr static const char* name = "chsAK8Jets/deepCSVcc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.deepCSVcc);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.deepCSVcc);
       return output;
     }
   };
@@ -4804,11 +4160,9 @@ namespace testpanda {
   struct plotter <350> {
     constexpr static const char* name = "chsAK8Jets/tau2SD";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.tau2SD);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.tau2SD);
       return output;
     }
   };
@@ -4818,11 +4172,9 @@ namespace testpanda {
   struct plotter <351> {
     constexpr static const char* name = "chsAK8Jets/ptSmearUp";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Jets)
-      output.push_back(i.ptSmearUp);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Jets)
+        output.push_back(i.ptSmearUp);
       return output;
     }
   };
@@ -4842,11 +4194,9 @@ namespace testpanda {
   struct plotter <353> {
     constexpr static const char* name = "chsAK8Subjets/deepCMVAudsg";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.deepCMVAudsg);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.deepCMVAudsg);
       return output;
     }
   };
@@ -4856,11 +4206,9 @@ namespace testpanda {
   struct plotter <354> {
     constexpr static const char* name = "chsAK8Subjets/deepCMVAbb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.deepCMVAbb);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.deepCMVAbb);
       return output;
     }
   };
@@ -4870,11 +4218,9 @@ namespace testpanda {
   struct plotter <355> {
     constexpr static const char* name = "chsAK8Subjets/deepCSVudsg";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.deepCSVudsg);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.deepCSVudsg);
       return output;
     }
   };
@@ -4884,11 +4230,9 @@ namespace testpanda {
   struct plotter <356> {
     constexpr static const char* name = "chsAK8Subjets/cmva";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.cmva);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.cmva);
       return output;
     }
   };
@@ -4898,11 +4242,9 @@ namespace testpanda {
   struct plotter <357> {
     constexpr static const char* name = "chsAK8Subjets/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -4912,11 +4254,9 @@ namespace testpanda {
   struct plotter <358> {
     constexpr static const char* name = "chsAK8Subjets/deepCSVbb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.deepCSVbb);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.deepCSVbb);
       return output;
     }
   };
@@ -4926,11 +4266,9 @@ namespace testpanda {
   struct plotter <359> {
     constexpr static const char* name = "chsAK8Subjets/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -4940,11 +4278,9 @@ namespace testpanda {
   struct plotter <360> {
     constexpr static const char* name = "chsAK8Subjets/deepCMVAb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.deepCMVAb);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.deepCMVAb);
       return output;
     }
   };
@@ -4954,11 +4290,9 @@ namespace testpanda {
   struct plotter <361> {
     constexpr static const char* name = "chsAK8Subjets/deepCMVAc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.deepCMVAc);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.deepCMVAc);
       return output;
     }
   };
@@ -4968,11 +4302,9 @@ namespace testpanda {
   struct plotter <362> {
     constexpr static const char* name = "chsAK8Subjets/qgl";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.qgl);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.qgl);
       return output;
     }
   };
@@ -4982,11 +4314,9 @@ namespace testpanda {
   struct plotter <363> {
     constexpr static const char* name = "chsAK8Subjets/csv";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.csv);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.csv);
       return output;
     }
   };
@@ -4996,11 +4326,9 @@ namespace testpanda {
   struct plotter <364> {
     constexpr static const char* name = "chsAK8Subjets/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.e());
       return output;
     }
   };
@@ -5010,11 +4338,9 @@ namespace testpanda {
   struct plotter <365> {
     constexpr static const char* name = "chsAK8Subjets/deepCMVAcc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.deepCMVAcc);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.deepCMVAcc);
       return output;
     }
   };
@@ -5024,11 +4350,9 @@ namespace testpanda {
   struct plotter <366> {
     constexpr static const char* name = "chsAK8Subjets/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -5038,11 +4362,9 @@ namespace testpanda {
   struct plotter <367> {
     constexpr static const char* name = "chsAK8Subjets/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -5052,11 +4374,9 @@ namespace testpanda {
   struct plotter <368> {
     constexpr static const char* name = "chsAK8Subjets/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -5066,11 +4386,9 @@ namespace testpanda {
   struct plotter <369> {
     constexpr static const char* name = "chsAK8Subjets/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -5080,11 +4398,9 @@ namespace testpanda {
   struct plotter <370> {
     constexpr static const char* name = "chsAK8Subjets/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -5094,11 +4410,9 @@ namespace testpanda {
   struct plotter <371> {
     constexpr static const char* name = "chsAK8Subjets/deepCSVb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.deepCSVb);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.deepCSVb);
       return output;
     }
   };
@@ -5108,11 +4422,9 @@ namespace testpanda {
   struct plotter <372> {
     constexpr static const char* name = "chsAK8Subjets/deepCSVc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.deepCSVc);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.deepCSVc);
       return output;
     }
   };
@@ -5122,11 +4434,9 @@ namespace testpanda {
   struct plotter <373> {
     constexpr static const char* name = "chsAK8Subjets/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -5136,11 +4446,9 @@ namespace testpanda {
   struct plotter <374> {
     constexpr static const char* name = "chsAK8Subjets/deepCSVcc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsAK8Subjets)
-      output.push_back(i.deepCSVcc);
-
+      std::vector<float> output;
+      for (auto& i : event.chsAK8Subjets)
+        output.push_back(i.deepCSVcc);
       return output;
     }
   };
@@ -5160,11 +4468,9 @@ namespace testpanda {
   struct plotter <376> {
     constexpr static const char* name = "chsCA15Jets/subjets_size";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.subjets.size());
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.subjets.size());
       return output;
     }
   };
@@ -5174,11 +4480,9 @@ namespace testpanda {
   struct plotter <377> {
     constexpr static const char* name = "chsCA15Jets/deepCMVAudsg";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.deepCMVAudsg);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.deepCMVAudsg);
       return output;
     }
   };
@@ -5188,11 +4492,9 @@ namespace testpanda {
   struct plotter <378> {
     constexpr static const char* name = "chsCA15Jets/nhf";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.nhf);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.nhf);
       return output;
     }
   };
@@ -5202,11 +4504,9 @@ namespace testpanda {
   struct plotter <379> {
     constexpr static const char* name = "chsCA15Jets/ptCorrUp";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.ptCorrUp);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.ptCorrUp);
       return output;
     }
   };
@@ -5216,11 +4516,9 @@ namespace testpanda {
   struct plotter <380> {
     constexpr static const char* name = "chsCA15Jets/cef";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.cef);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.cef);
       return output;
     }
   };
@@ -5230,11 +4528,9 @@ namespace testpanda {
   struct plotter <381> {
     constexpr static const char* name = "chsCA15Jets/deepCSVudsg";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.deepCSVudsg);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.deepCSVudsg);
       return output;
     }
   };
@@ -5244,11 +4540,9 @@ namespace testpanda {
   struct plotter <382> {
     constexpr static const char* name = "chsCA15Jets/tight";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.tight);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.tight);
       return output;
     }
   };
@@ -5258,11 +4552,9 @@ namespace testpanda {
   struct plotter <383> {
     constexpr static const char* name = "chsCA15Jets/cmva";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.cmva);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.cmva);
       return output;
     }
   };
@@ -5272,11 +4564,9 @@ namespace testpanda {
   struct plotter <384> {
     constexpr static const char* name = "chsCA15Jets/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -5286,11 +4576,9 @@ namespace testpanda {
   struct plotter <385> {
     constexpr static const char* name = "chsCA15Jets/deepCMVAbb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.deepCMVAbb);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.deepCMVAbb);
       return output;
     }
   };
@@ -5300,11 +4588,9 @@ namespace testpanda {
   struct plotter <386> {
     constexpr static const char* name = "chsCA15Jets/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -5314,11 +4600,9 @@ namespace testpanda {
   struct plotter <387> {
     constexpr static const char* name = "chsCA15Jets/htt_frec";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.htt_frec);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.htt_frec);
       return output;
     }
   };
@@ -5328,11 +4612,9 @@ namespace testpanda {
   struct plotter <388> {
     constexpr static const char* name = "chsCA15Jets/deepCMVAb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.deepCMVAb);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.deepCMVAb);
       return output;
     }
   };
@@ -5342,11 +4624,9 @@ namespace testpanda {
   struct plotter <389> {
     constexpr static const char* name = "chsCA15Jets/chf";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.chf);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.chf);
       return output;
     }
   };
@@ -5356,11 +4636,9 @@ namespace testpanda {
   struct plotter <390> {
     constexpr static const char* name = "chsCA15Jets/area";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.area);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.area);
       return output;
     }
   };
@@ -5370,11 +4648,9 @@ namespace testpanda {
   struct plotter <391> {
     constexpr static const char* name = "chsCA15Jets/nef";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.nef);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.nef);
       return output;
     }
   };
@@ -5384,11 +4660,9 @@ namespace testpanda {
   struct plotter <392> {
     constexpr static const char* name = "chsCA15Jets/htt_mass";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.htt_mass);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.htt_mass);
       return output;
     }
   };
@@ -5398,11 +4672,9 @@ namespace testpanda {
   struct plotter <393> {
     constexpr static const char* name = "chsCA15Jets/ptCorrDown";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.ptCorrDown);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.ptCorrDown);
       return output;
     }
   };
@@ -5412,11 +4684,9 @@ namespace testpanda {
   struct plotter <394> {
     constexpr static const char* name = "chsCA15Jets/deepCSVbb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.deepCSVbb);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.deepCSVbb);
       return output;
     }
   };
@@ -5426,11 +4696,9 @@ namespace testpanda {
   struct plotter <395> {
     constexpr static const char* name = "chsCA15Jets/tau2";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.tau2);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.tau2);
       return output;
     }
   };
@@ -5440,11 +4708,9 @@ namespace testpanda {
   struct plotter <396> {
     constexpr static const char* name = "chsCA15Jets/tau3";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.tau3);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.tau3);
       return output;
     }
   };
@@ -5454,11 +4720,9 @@ namespace testpanda {
   struct plotter <397> {
     constexpr static const char* name = "chsCA15Jets/puid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.puid);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.puid);
       return output;
     }
   };
@@ -5468,11 +4732,9 @@ namespace testpanda {
   struct plotter <398> {
     constexpr static const char* name = "chsCA15Jets/tau1";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.tau1);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.tau1);
       return output;
     }
   };
@@ -5482,11 +4744,9 @@ namespace testpanda {
   struct plotter <399> {
     constexpr static const char* name = "chsCA15Jets/mSD";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.mSD);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.mSD);
       return output;
     }
   };
@@ -5496,11 +4756,9 @@ namespace testpanda {
   struct plotter <400> {
     constexpr static const char* name = "chsCA15Jets/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.e());
       return output;
     }
   };
@@ -5510,11 +4768,9 @@ namespace testpanda {
   struct plotter <401> {
     constexpr static const char* name = "chsCA15Jets/deepCMVAcc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.deepCMVAcc);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.deepCMVAcc);
       return output;
     }
   };
@@ -5524,11 +4780,9 @@ namespace testpanda {
   struct plotter <402> {
     constexpr static const char* name = "chsCA15Jets/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -5538,11 +4792,9 @@ namespace testpanda {
   struct plotter <403> {
     constexpr static const char* name = "chsCA15Jets/rawPt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.rawPt);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.rawPt);
       return output;
     }
   };
@@ -5552,11 +4804,9 @@ namespace testpanda {
   struct plotter <404> {
     constexpr static const char* name = "chsCA15Jets/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -5566,11 +4816,9 @@ namespace testpanda {
   struct plotter <405> {
     constexpr static const char* name = "chsCA15Jets/double_sub";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.double_sub);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.double_sub);
       return output;
     }
   };
@@ -5580,11 +4828,9 @@ namespace testpanda {
   struct plotter <406> {
     constexpr static const char* name = "chsCA15Jets/loose";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.loose);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.loose);
       return output;
     }
   };
@@ -5594,11 +4840,9 @@ namespace testpanda {
   struct plotter <407> {
     constexpr static const char* name = "chsCA15Jets/ptSmear";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.ptSmear);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.ptSmear);
       return output;
     }
   };
@@ -5608,11 +4852,9 @@ namespace testpanda {
   struct plotter <408> {
     constexpr static const char* name = "chsCA15Jets/deepCMVAc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.deepCMVAc);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.deepCMVAc);
       return output;
     }
   };
@@ -5622,11 +4864,9 @@ namespace testpanda {
   struct plotter <409> {
     constexpr static const char* name = "chsCA15Jets/qgl";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.qgl);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.qgl);
       return output;
     }
   };
@@ -5636,11 +4876,9 @@ namespace testpanda {
   struct plotter <410> {
     constexpr static const char* name = "chsCA15Jets/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -5650,11 +4888,9 @@ namespace testpanda {
   struct plotter <411> {
     constexpr static const char* name = "chsCA15Jets/monojet";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.monojet);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.monojet);
       return output;
     }
   };
@@ -5664,11 +4900,9 @@ namespace testpanda {
   struct plotter <412> {
     constexpr static const char* name = "chsCA15Jets/ptSmearDown";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.ptSmearDown);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.ptSmearDown);
       return output;
     }
   };
@@ -5678,11 +4912,9 @@ namespace testpanda {
   struct plotter <413> {
     constexpr static const char* name = "chsCA15Jets/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -5692,11 +4924,9 @@ namespace testpanda {
   struct plotter <414> {
     constexpr static const char* name = "chsCA15Jets/mPruned";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.mPruned);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.mPruned);
       return output;
     }
   };
@@ -5706,11 +4936,9 @@ namespace testpanda {
   struct plotter <415> {
     constexpr static const char* name = "chsCA15Jets/tau1SD";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.tau1SD);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.tau1SD);
       return output;
     }
   };
@@ -5720,11 +4948,9 @@ namespace testpanda {
   struct plotter <416> {
     constexpr static const char* name = "chsCA15Jets/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -5734,11 +4960,9 @@ namespace testpanda {
   struct plotter <417> {
     constexpr static const char* name = "chsCA15Jets/csv";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.csv);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.csv);
       return output;
     }
   };
@@ -5748,11 +4972,9 @@ namespace testpanda {
   struct plotter <418> {
     constexpr static const char* name = "chsCA15Jets/deepCSVb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.deepCSVb);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.deepCSVb);
       return output;
     }
   };
@@ -5762,11 +4984,9 @@ namespace testpanda {
   struct plotter <419> {
     constexpr static const char* name = "chsCA15Jets/deepCSVc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.deepCSVc);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.deepCSVc);
       return output;
     }
   };
@@ -5776,11 +4996,9 @@ namespace testpanda {
   struct plotter <420> {
     constexpr static const char* name = "chsCA15Jets/tau3SD";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.tau3SD);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.tau3SD);
       return output;
     }
   };
@@ -5790,11 +5008,9 @@ namespace testpanda {
   struct plotter <421> {
     constexpr static const char* name = "chsCA15Jets/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -5804,11 +5020,9 @@ namespace testpanda {
   struct plotter <422> {
     constexpr static const char* name = "chsCA15Jets/deepCSVcc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.deepCSVcc);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.deepCSVcc);
       return output;
     }
   };
@@ -5818,11 +5032,9 @@ namespace testpanda {
   struct plotter <423> {
     constexpr static const char* name = "chsCA15Jets/tau2SD";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.tau2SD);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.tau2SD);
       return output;
     }
   };
@@ -5832,11 +5044,9 @@ namespace testpanda {
   struct plotter <424> {
     constexpr static const char* name = "chsCA15Jets/ptSmearUp";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Jets)
-      output.push_back(i.ptSmearUp);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Jets)
+        output.push_back(i.ptSmearUp);
       return output;
     }
   };
@@ -5856,11 +5066,9 @@ namespace testpanda {
   struct plotter <426> {
     constexpr static const char* name = "chsCA15Subjets/deepCMVAudsg";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.deepCMVAudsg);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.deepCMVAudsg);
       return output;
     }
   };
@@ -5870,11 +5078,9 @@ namespace testpanda {
   struct plotter <427> {
     constexpr static const char* name = "chsCA15Subjets/deepCMVAbb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.deepCMVAbb);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.deepCMVAbb);
       return output;
     }
   };
@@ -5884,11 +5090,9 @@ namespace testpanda {
   struct plotter <428> {
     constexpr static const char* name = "chsCA15Subjets/deepCSVudsg";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.deepCSVudsg);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.deepCSVudsg);
       return output;
     }
   };
@@ -5898,11 +5102,9 @@ namespace testpanda {
   struct plotter <429> {
     constexpr static const char* name = "chsCA15Subjets/cmva";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.cmva);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.cmva);
       return output;
     }
   };
@@ -5912,11 +5114,9 @@ namespace testpanda {
   struct plotter <430> {
     constexpr static const char* name = "chsCA15Subjets/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -5926,11 +5126,9 @@ namespace testpanda {
   struct plotter <431> {
     constexpr static const char* name = "chsCA15Subjets/deepCSVbb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.deepCSVbb);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.deepCSVbb);
       return output;
     }
   };
@@ -5940,11 +5138,9 @@ namespace testpanda {
   struct plotter <432> {
     constexpr static const char* name = "chsCA15Subjets/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -5954,11 +5150,9 @@ namespace testpanda {
   struct plotter <433> {
     constexpr static const char* name = "chsCA15Subjets/deepCMVAb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.deepCMVAb);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.deepCMVAb);
       return output;
     }
   };
@@ -5968,11 +5162,9 @@ namespace testpanda {
   struct plotter <434> {
     constexpr static const char* name = "chsCA15Subjets/deepCMVAc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.deepCMVAc);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.deepCMVAc);
       return output;
     }
   };
@@ -5982,11 +5174,9 @@ namespace testpanda {
   struct plotter <435> {
     constexpr static const char* name = "chsCA15Subjets/qgl";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.qgl);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.qgl);
       return output;
     }
   };
@@ -5996,11 +5186,9 @@ namespace testpanda {
   struct plotter <436> {
     constexpr static const char* name = "chsCA15Subjets/csv";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.csv);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.csv);
       return output;
     }
   };
@@ -6010,11 +5198,9 @@ namespace testpanda {
   struct plotter <437> {
     constexpr static const char* name = "chsCA15Subjets/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.e());
       return output;
     }
   };
@@ -6024,11 +5210,9 @@ namespace testpanda {
   struct plotter <438> {
     constexpr static const char* name = "chsCA15Subjets/deepCMVAcc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.deepCMVAcc);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.deepCMVAcc);
       return output;
     }
   };
@@ -6038,11 +5222,9 @@ namespace testpanda {
   struct plotter <439> {
     constexpr static const char* name = "chsCA15Subjets/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -6052,11 +5234,9 @@ namespace testpanda {
   struct plotter <440> {
     constexpr static const char* name = "chsCA15Subjets/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -6066,11 +5246,9 @@ namespace testpanda {
   struct plotter <441> {
     constexpr static const char* name = "chsCA15Subjets/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -6080,11 +5258,9 @@ namespace testpanda {
   struct plotter <442> {
     constexpr static const char* name = "chsCA15Subjets/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -6094,11 +5270,9 @@ namespace testpanda {
   struct plotter <443> {
     constexpr static const char* name = "chsCA15Subjets/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -6108,11 +5282,9 @@ namespace testpanda {
   struct plotter <444> {
     constexpr static const char* name = "chsCA15Subjets/deepCSVb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.deepCSVb);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.deepCSVb);
       return output;
     }
   };
@@ -6122,11 +5294,9 @@ namespace testpanda {
   struct plotter <445> {
     constexpr static const char* name = "chsCA15Subjets/deepCSVc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.deepCSVc);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.deepCSVc);
       return output;
     }
   };
@@ -6136,11 +5306,9 @@ namespace testpanda {
   struct plotter <446> {
     constexpr static const char* name = "chsCA15Subjets/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -6150,11 +5318,9 @@ namespace testpanda {
   struct plotter <447> {
     constexpr static const char* name = "chsCA15Subjets/deepCSVcc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.chsCA15Subjets)
-      output.push_back(i.deepCSVcc);
-
+      std::vector<float> output;
+      for (auto& i : event.chsCA15Subjets)
+        output.push_back(i.deepCSVcc);
       return output;
     }
   };
@@ -6174,11 +5340,9 @@ namespace testpanda {
   struct plotter <449> {
     constexpr static const char* name = "puppiAK8Jets/subjets_size";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.subjets.size());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.subjets.size());
       return output;
     }
   };
@@ -6188,11 +5352,9 @@ namespace testpanda {
   struct plotter <450> {
     constexpr static const char* name = "puppiAK8Jets/deepCMVAudsg";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.deepCMVAudsg);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.deepCMVAudsg);
       return output;
     }
   };
@@ -6202,11 +5364,9 @@ namespace testpanda {
   struct plotter <451> {
     constexpr static const char* name = "puppiAK8Jets/nhf";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.nhf);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.nhf);
       return output;
     }
   };
@@ -6216,11 +5376,9 @@ namespace testpanda {
   struct plotter <452> {
     constexpr static const char* name = "puppiAK8Jets/ptCorrUp";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.ptCorrUp);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.ptCorrUp);
       return output;
     }
   };
@@ -6230,11 +5388,9 @@ namespace testpanda {
   struct plotter <453> {
     constexpr static const char* name = "puppiAK8Jets/cef";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.cef);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.cef);
       return output;
     }
   };
@@ -6244,11 +5400,9 @@ namespace testpanda {
   struct plotter <454> {
     constexpr static const char* name = "puppiAK8Jets/deepCSVudsg";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.deepCSVudsg);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.deepCSVudsg);
       return output;
     }
   };
@@ -6258,11 +5412,9 @@ namespace testpanda {
   struct plotter <455> {
     constexpr static const char* name = "puppiAK8Jets/tight";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.tight);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.tight);
       return output;
     }
   };
@@ -6272,11 +5424,9 @@ namespace testpanda {
   struct plotter <456> {
     constexpr static const char* name = "puppiAK8Jets/cmva";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.cmva);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.cmva);
       return output;
     }
   };
@@ -6286,11 +5436,9 @@ namespace testpanda {
   struct plotter <457> {
     constexpr static const char* name = "puppiAK8Jets/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -6300,11 +5448,9 @@ namespace testpanda {
   struct plotter <458> {
     constexpr static const char* name = "puppiAK8Jets/deepCMVAbb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.deepCMVAbb);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.deepCMVAbb);
       return output;
     }
   };
@@ -6314,11 +5460,9 @@ namespace testpanda {
   struct plotter <459> {
     constexpr static const char* name = "puppiAK8Jets/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -6328,11 +5472,9 @@ namespace testpanda {
   struct plotter <460> {
     constexpr static const char* name = "puppiAK8Jets/htt_frec";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.htt_frec);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.htt_frec);
       return output;
     }
   };
@@ -6342,11 +5484,9 @@ namespace testpanda {
   struct plotter <461> {
     constexpr static const char* name = "puppiAK8Jets/deepCMVAb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.deepCMVAb);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.deepCMVAb);
       return output;
     }
   };
@@ -6356,11 +5496,9 @@ namespace testpanda {
   struct plotter <462> {
     constexpr static const char* name = "puppiAK8Jets/chf";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.chf);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.chf);
       return output;
     }
   };
@@ -6370,11 +5508,9 @@ namespace testpanda {
   struct plotter <463> {
     constexpr static const char* name = "puppiAK8Jets/area";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.area);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.area);
       return output;
     }
   };
@@ -6384,11 +5520,9 @@ namespace testpanda {
   struct plotter <464> {
     constexpr static const char* name = "puppiAK8Jets/nef";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.nef);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.nef);
       return output;
     }
   };
@@ -6398,11 +5532,9 @@ namespace testpanda {
   struct plotter <465> {
     constexpr static const char* name = "puppiAK8Jets/htt_mass";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.htt_mass);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.htt_mass);
       return output;
     }
   };
@@ -6412,11 +5544,9 @@ namespace testpanda {
   struct plotter <466> {
     constexpr static const char* name = "puppiAK8Jets/ptCorrDown";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.ptCorrDown);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.ptCorrDown);
       return output;
     }
   };
@@ -6426,11 +5556,9 @@ namespace testpanda {
   struct plotter <467> {
     constexpr static const char* name = "puppiAK8Jets/deepCSVbb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.deepCSVbb);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.deepCSVbb);
       return output;
     }
   };
@@ -6440,11 +5568,9 @@ namespace testpanda {
   struct plotter <468> {
     constexpr static const char* name = "puppiAK8Jets/tau2";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.tau2);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.tau2);
       return output;
     }
   };
@@ -6454,11 +5580,9 @@ namespace testpanda {
   struct plotter <469> {
     constexpr static const char* name = "puppiAK8Jets/tau3";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.tau3);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.tau3);
       return output;
     }
   };
@@ -6468,11 +5592,9 @@ namespace testpanda {
   struct plotter <470> {
     constexpr static const char* name = "puppiAK8Jets/puid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.puid);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.puid);
       return output;
     }
   };
@@ -6482,11 +5604,9 @@ namespace testpanda {
   struct plotter <471> {
     constexpr static const char* name = "puppiAK8Jets/tau1";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.tau1);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.tau1);
       return output;
     }
   };
@@ -6496,11 +5616,9 @@ namespace testpanda {
   struct plotter <472> {
     constexpr static const char* name = "puppiAK8Jets/mSD";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.mSD);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.mSD);
       return output;
     }
   };
@@ -6510,11 +5628,9 @@ namespace testpanda {
   struct plotter <473> {
     constexpr static const char* name = "puppiAK8Jets/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.e());
       return output;
     }
   };
@@ -6524,11 +5640,9 @@ namespace testpanda {
   struct plotter <474> {
     constexpr static const char* name = "puppiAK8Jets/deepCMVAcc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.deepCMVAcc);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.deepCMVAcc);
       return output;
     }
   };
@@ -6538,11 +5652,9 @@ namespace testpanda {
   struct plotter <475> {
     constexpr static const char* name = "puppiAK8Jets/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -6552,11 +5664,9 @@ namespace testpanda {
   struct plotter <476> {
     constexpr static const char* name = "puppiAK8Jets/rawPt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.rawPt);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.rawPt);
       return output;
     }
   };
@@ -6566,11 +5676,9 @@ namespace testpanda {
   struct plotter <477> {
     constexpr static const char* name = "puppiAK8Jets/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -6580,11 +5688,9 @@ namespace testpanda {
   struct plotter <478> {
     constexpr static const char* name = "puppiAK8Jets/double_sub";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.double_sub);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.double_sub);
       return output;
     }
   };
@@ -6594,11 +5700,9 @@ namespace testpanda {
   struct plotter <479> {
     constexpr static const char* name = "puppiAK8Jets/loose";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.loose);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.loose);
       return output;
     }
   };
@@ -6608,11 +5712,9 @@ namespace testpanda {
   struct plotter <480> {
     constexpr static const char* name = "puppiAK8Jets/ptSmear";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.ptSmear);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.ptSmear);
       return output;
     }
   };
@@ -6622,11 +5724,9 @@ namespace testpanda {
   struct plotter <481> {
     constexpr static const char* name = "puppiAK8Jets/deepCMVAc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.deepCMVAc);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.deepCMVAc);
       return output;
     }
   };
@@ -6636,11 +5736,9 @@ namespace testpanda {
   struct plotter <482> {
     constexpr static const char* name = "puppiAK8Jets/qgl";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.qgl);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.qgl);
       return output;
     }
   };
@@ -6650,11 +5748,9 @@ namespace testpanda {
   struct plotter <483> {
     constexpr static const char* name = "puppiAK8Jets/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -6664,11 +5760,9 @@ namespace testpanda {
   struct plotter <484> {
     constexpr static const char* name = "puppiAK8Jets/monojet";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.monojet);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.monojet);
       return output;
     }
   };
@@ -6678,11 +5772,9 @@ namespace testpanda {
   struct plotter <485> {
     constexpr static const char* name = "puppiAK8Jets/ptSmearDown";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.ptSmearDown);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.ptSmearDown);
       return output;
     }
   };
@@ -6692,11 +5784,9 @@ namespace testpanda {
   struct plotter <486> {
     constexpr static const char* name = "puppiAK8Jets/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -6706,11 +5796,9 @@ namespace testpanda {
   struct plotter <487> {
     constexpr static const char* name = "puppiAK8Jets/mPruned";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.mPruned);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.mPruned);
       return output;
     }
   };
@@ -6720,11 +5808,9 @@ namespace testpanda {
   struct plotter <488> {
     constexpr static const char* name = "puppiAK8Jets/tau1SD";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.tau1SD);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.tau1SD);
       return output;
     }
   };
@@ -6734,11 +5820,9 @@ namespace testpanda {
   struct plotter <489> {
     constexpr static const char* name = "puppiAK8Jets/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -6748,11 +5832,9 @@ namespace testpanda {
   struct plotter <490> {
     constexpr static const char* name = "puppiAK8Jets/csv";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.csv);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.csv);
       return output;
     }
   };
@@ -6762,11 +5844,9 @@ namespace testpanda {
   struct plotter <491> {
     constexpr static const char* name = "puppiAK8Jets/deepCSVb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.deepCSVb);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.deepCSVb);
       return output;
     }
   };
@@ -6776,11 +5856,9 @@ namespace testpanda {
   struct plotter <492> {
     constexpr static const char* name = "puppiAK8Jets/deepCSVc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.deepCSVc);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.deepCSVc);
       return output;
     }
   };
@@ -6790,11 +5868,9 @@ namespace testpanda {
   struct plotter <493> {
     constexpr static const char* name = "puppiAK8Jets/tau3SD";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.tau3SD);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.tau3SD);
       return output;
     }
   };
@@ -6804,11 +5880,9 @@ namespace testpanda {
   struct plotter <494> {
     constexpr static const char* name = "puppiAK8Jets/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -6818,11 +5892,9 @@ namespace testpanda {
   struct plotter <495> {
     constexpr static const char* name = "puppiAK8Jets/deepCSVcc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.deepCSVcc);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.deepCSVcc);
       return output;
     }
   };
@@ -6832,11 +5904,9 @@ namespace testpanda {
   struct plotter <496> {
     constexpr static const char* name = "puppiAK8Jets/tau2SD";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.tau2SD);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.tau2SD);
       return output;
     }
   };
@@ -6846,11 +5916,9 @@ namespace testpanda {
   struct plotter <497> {
     constexpr static const char* name = "puppiAK8Jets/ptSmearUp";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Jets)
-      output.push_back(i.ptSmearUp);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Jets)
+        output.push_back(i.ptSmearUp);
       return output;
     }
   };
@@ -6870,11 +5938,9 @@ namespace testpanda {
   struct plotter <499> {
     constexpr static const char* name = "puppiAK8Subjets/deepCMVAudsg";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.deepCMVAudsg);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.deepCMVAudsg);
       return output;
     }
   };
@@ -6884,11 +5950,9 @@ namespace testpanda {
   struct plotter <500> {
     constexpr static const char* name = "puppiAK8Subjets/deepCMVAbb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.deepCMVAbb);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.deepCMVAbb);
       return output;
     }
   };
@@ -6898,11 +5962,9 @@ namespace testpanda {
   struct plotter <501> {
     constexpr static const char* name = "puppiAK8Subjets/deepCSVudsg";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.deepCSVudsg);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.deepCSVudsg);
       return output;
     }
   };
@@ -6912,11 +5974,9 @@ namespace testpanda {
   struct plotter <502> {
     constexpr static const char* name = "puppiAK8Subjets/cmva";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.cmva);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.cmva);
       return output;
     }
   };
@@ -6926,11 +5986,9 @@ namespace testpanda {
   struct plotter <503> {
     constexpr static const char* name = "puppiAK8Subjets/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -6940,11 +5998,9 @@ namespace testpanda {
   struct plotter <504> {
     constexpr static const char* name = "puppiAK8Subjets/deepCSVbb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.deepCSVbb);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.deepCSVbb);
       return output;
     }
   };
@@ -6954,11 +6010,9 @@ namespace testpanda {
   struct plotter <505> {
     constexpr static const char* name = "puppiAK8Subjets/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -6968,11 +6022,9 @@ namespace testpanda {
   struct plotter <506> {
     constexpr static const char* name = "puppiAK8Subjets/deepCMVAb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.deepCMVAb);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.deepCMVAb);
       return output;
     }
   };
@@ -6982,11 +6034,9 @@ namespace testpanda {
   struct plotter <507> {
     constexpr static const char* name = "puppiAK8Subjets/deepCMVAc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.deepCMVAc);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.deepCMVAc);
       return output;
     }
   };
@@ -6996,11 +6046,9 @@ namespace testpanda {
   struct plotter <508> {
     constexpr static const char* name = "puppiAK8Subjets/qgl";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.qgl);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.qgl);
       return output;
     }
   };
@@ -7010,11 +6058,9 @@ namespace testpanda {
   struct plotter <509> {
     constexpr static const char* name = "puppiAK8Subjets/csv";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.csv);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.csv);
       return output;
     }
   };
@@ -7024,11 +6070,9 @@ namespace testpanda {
   struct plotter <510> {
     constexpr static const char* name = "puppiAK8Subjets/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.e());
       return output;
     }
   };
@@ -7038,11 +6082,9 @@ namespace testpanda {
   struct plotter <511> {
     constexpr static const char* name = "puppiAK8Subjets/deepCMVAcc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.deepCMVAcc);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.deepCMVAcc);
       return output;
     }
   };
@@ -7052,11 +6094,9 @@ namespace testpanda {
   struct plotter <512> {
     constexpr static const char* name = "puppiAK8Subjets/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -7066,11 +6106,9 @@ namespace testpanda {
   struct plotter <513> {
     constexpr static const char* name = "puppiAK8Subjets/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -7080,11 +6118,9 @@ namespace testpanda {
   struct plotter <514> {
     constexpr static const char* name = "puppiAK8Subjets/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -7094,11 +6130,9 @@ namespace testpanda {
   struct plotter <515> {
     constexpr static const char* name = "puppiAK8Subjets/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -7108,11 +6142,9 @@ namespace testpanda {
   struct plotter <516> {
     constexpr static const char* name = "puppiAK8Subjets/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -7122,11 +6154,9 @@ namespace testpanda {
   struct plotter <517> {
     constexpr static const char* name = "puppiAK8Subjets/deepCSVb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.deepCSVb);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.deepCSVb);
       return output;
     }
   };
@@ -7136,11 +6166,9 @@ namespace testpanda {
   struct plotter <518> {
     constexpr static const char* name = "puppiAK8Subjets/deepCSVc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.deepCSVc);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.deepCSVc);
       return output;
     }
   };
@@ -7150,11 +6178,9 @@ namespace testpanda {
   struct plotter <519> {
     constexpr static const char* name = "puppiAK8Subjets/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -7164,11 +6190,9 @@ namespace testpanda {
   struct plotter <520> {
     constexpr static const char* name = "puppiAK8Subjets/deepCSVcc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiAK8Subjets)
-      output.push_back(i.deepCSVcc);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiAK8Subjets)
+        output.push_back(i.deepCSVcc);
       return output;
     }
   };
@@ -7188,11 +6212,9 @@ namespace testpanda {
   struct plotter <522> {
     constexpr static const char* name = "puppiCA15Jets/subjets_size";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.subjets.size());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.subjets.size());
       return output;
     }
   };
@@ -7202,11 +6224,9 @@ namespace testpanda {
   struct plotter <523> {
     constexpr static const char* name = "puppiCA15Jets/deepCMVAudsg";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.deepCMVAudsg);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.deepCMVAudsg);
       return output;
     }
   };
@@ -7216,11 +6236,9 @@ namespace testpanda {
   struct plotter <524> {
     constexpr static const char* name = "puppiCA15Jets/nhf";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.nhf);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.nhf);
       return output;
     }
   };
@@ -7230,11 +6248,9 @@ namespace testpanda {
   struct plotter <525> {
     constexpr static const char* name = "puppiCA15Jets/ptCorrUp";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.ptCorrUp);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.ptCorrUp);
       return output;
     }
   };
@@ -7244,11 +6260,9 @@ namespace testpanda {
   struct plotter <526> {
     constexpr static const char* name = "puppiCA15Jets/cef";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.cef);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.cef);
       return output;
     }
   };
@@ -7258,11 +6272,9 @@ namespace testpanda {
   struct plotter <527> {
     constexpr static const char* name = "puppiCA15Jets/deepCSVudsg";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.deepCSVudsg);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.deepCSVudsg);
       return output;
     }
   };
@@ -7272,11 +6284,9 @@ namespace testpanda {
   struct plotter <528> {
     constexpr static const char* name = "puppiCA15Jets/tight";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.tight);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.tight);
       return output;
     }
   };
@@ -7286,11 +6296,9 @@ namespace testpanda {
   struct plotter <529> {
     constexpr static const char* name = "puppiCA15Jets/cmva";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.cmva);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.cmva);
       return output;
     }
   };
@@ -7300,11 +6308,9 @@ namespace testpanda {
   struct plotter <530> {
     constexpr static const char* name = "puppiCA15Jets/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -7314,11 +6320,9 @@ namespace testpanda {
   struct plotter <531> {
     constexpr static const char* name = "puppiCA15Jets/deepCMVAbb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.deepCMVAbb);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.deepCMVAbb);
       return output;
     }
   };
@@ -7328,11 +6332,9 @@ namespace testpanda {
   struct plotter <532> {
     constexpr static const char* name = "puppiCA15Jets/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -7342,11 +6344,9 @@ namespace testpanda {
   struct plotter <533> {
     constexpr static const char* name = "puppiCA15Jets/htt_frec";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.htt_frec);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.htt_frec);
       return output;
     }
   };
@@ -7356,11 +6356,9 @@ namespace testpanda {
   struct plotter <534> {
     constexpr static const char* name = "puppiCA15Jets/deepCMVAb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.deepCMVAb);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.deepCMVAb);
       return output;
     }
   };
@@ -7370,11 +6368,9 @@ namespace testpanda {
   struct plotter <535> {
     constexpr static const char* name = "puppiCA15Jets/chf";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.chf);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.chf);
       return output;
     }
   };
@@ -7384,11 +6380,9 @@ namespace testpanda {
   struct plotter <536> {
     constexpr static const char* name = "puppiCA15Jets/area";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.area);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.area);
       return output;
     }
   };
@@ -7398,11 +6392,9 @@ namespace testpanda {
   struct plotter <537> {
     constexpr static const char* name = "puppiCA15Jets/nef";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.nef);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.nef);
       return output;
     }
   };
@@ -7412,11 +6404,9 @@ namespace testpanda {
   struct plotter <538> {
     constexpr static const char* name = "puppiCA15Jets/htt_mass";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.htt_mass);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.htt_mass);
       return output;
     }
   };
@@ -7426,11 +6416,9 @@ namespace testpanda {
   struct plotter <539> {
     constexpr static const char* name = "puppiCA15Jets/ptCorrDown";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.ptCorrDown);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.ptCorrDown);
       return output;
     }
   };
@@ -7440,11 +6428,9 @@ namespace testpanda {
   struct plotter <540> {
     constexpr static const char* name = "puppiCA15Jets/deepCSVbb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.deepCSVbb);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.deepCSVbb);
       return output;
     }
   };
@@ -7454,11 +6440,9 @@ namespace testpanda {
   struct plotter <541> {
     constexpr static const char* name = "puppiCA15Jets/tau2";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.tau2);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.tau2);
       return output;
     }
   };
@@ -7468,11 +6452,9 @@ namespace testpanda {
   struct plotter <542> {
     constexpr static const char* name = "puppiCA15Jets/tau3";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.tau3);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.tau3);
       return output;
     }
   };
@@ -7482,11 +6464,9 @@ namespace testpanda {
   struct plotter <543> {
     constexpr static const char* name = "puppiCA15Jets/puid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.puid);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.puid);
       return output;
     }
   };
@@ -7496,11 +6476,9 @@ namespace testpanda {
   struct plotter <544> {
     constexpr static const char* name = "puppiCA15Jets/tau1";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.tau1);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.tau1);
       return output;
     }
   };
@@ -7510,11 +6488,9 @@ namespace testpanda {
   struct plotter <545> {
     constexpr static const char* name = "puppiCA15Jets/mSD";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.mSD);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.mSD);
       return output;
     }
   };
@@ -7524,11 +6500,9 @@ namespace testpanda {
   struct plotter <546> {
     constexpr static const char* name = "puppiCA15Jets/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.e());
       return output;
     }
   };
@@ -7538,11 +6512,9 @@ namespace testpanda {
   struct plotter <547> {
     constexpr static const char* name = "puppiCA15Jets/deepCMVAcc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.deepCMVAcc);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.deepCMVAcc);
       return output;
     }
   };
@@ -7552,11 +6524,9 @@ namespace testpanda {
   struct plotter <548> {
     constexpr static const char* name = "puppiCA15Jets/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -7566,11 +6536,9 @@ namespace testpanda {
   struct plotter <549> {
     constexpr static const char* name = "puppiCA15Jets/rawPt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.rawPt);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.rawPt);
       return output;
     }
   };
@@ -7580,11 +6548,9 @@ namespace testpanda {
   struct plotter <550> {
     constexpr static const char* name = "puppiCA15Jets/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -7594,11 +6560,9 @@ namespace testpanda {
   struct plotter <551> {
     constexpr static const char* name = "puppiCA15Jets/double_sub";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.double_sub);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.double_sub);
       return output;
     }
   };
@@ -7608,11 +6572,9 @@ namespace testpanda {
   struct plotter <552> {
     constexpr static const char* name = "puppiCA15Jets/loose";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.loose);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.loose);
       return output;
     }
   };
@@ -7622,11 +6584,9 @@ namespace testpanda {
   struct plotter <553> {
     constexpr static const char* name = "puppiCA15Jets/ptSmear";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.ptSmear);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.ptSmear);
       return output;
     }
   };
@@ -7636,11 +6596,9 @@ namespace testpanda {
   struct plotter <554> {
     constexpr static const char* name = "puppiCA15Jets/deepCMVAc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.deepCMVAc);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.deepCMVAc);
       return output;
     }
   };
@@ -7650,11 +6608,9 @@ namespace testpanda {
   struct plotter <555> {
     constexpr static const char* name = "puppiCA15Jets/qgl";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.qgl);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.qgl);
       return output;
     }
   };
@@ -7664,11 +6620,9 @@ namespace testpanda {
   struct plotter <556> {
     constexpr static const char* name = "puppiCA15Jets/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -7678,11 +6632,9 @@ namespace testpanda {
   struct plotter <557> {
     constexpr static const char* name = "puppiCA15Jets/monojet";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.monojet);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.monojet);
       return output;
     }
   };
@@ -7692,11 +6644,9 @@ namespace testpanda {
   struct plotter <558> {
     constexpr static const char* name = "puppiCA15Jets/ptSmearDown";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.ptSmearDown);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.ptSmearDown);
       return output;
     }
   };
@@ -7706,11 +6656,9 @@ namespace testpanda {
   struct plotter <559> {
     constexpr static const char* name = "puppiCA15Jets/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -7720,11 +6668,9 @@ namespace testpanda {
   struct plotter <560> {
     constexpr static const char* name = "puppiCA15Jets/mPruned";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.mPruned);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.mPruned);
       return output;
     }
   };
@@ -7734,11 +6680,9 @@ namespace testpanda {
   struct plotter <561> {
     constexpr static const char* name = "puppiCA15Jets/tau1SD";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.tau1SD);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.tau1SD);
       return output;
     }
   };
@@ -7748,11 +6692,9 @@ namespace testpanda {
   struct plotter <562> {
     constexpr static const char* name = "puppiCA15Jets/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -7762,11 +6704,9 @@ namespace testpanda {
   struct plotter <563> {
     constexpr static const char* name = "puppiCA15Jets/csv";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.csv);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.csv);
       return output;
     }
   };
@@ -7776,11 +6716,9 @@ namespace testpanda {
   struct plotter <564> {
     constexpr static const char* name = "puppiCA15Jets/deepCSVb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.deepCSVb);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.deepCSVb);
       return output;
     }
   };
@@ -7790,11 +6728,9 @@ namespace testpanda {
   struct plotter <565> {
     constexpr static const char* name = "puppiCA15Jets/deepCSVc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.deepCSVc);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.deepCSVc);
       return output;
     }
   };
@@ -7804,11 +6740,9 @@ namespace testpanda {
   struct plotter <566> {
     constexpr static const char* name = "puppiCA15Jets/tau3SD";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.tau3SD);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.tau3SD);
       return output;
     }
   };
@@ -7818,11 +6752,9 @@ namespace testpanda {
   struct plotter <567> {
     constexpr static const char* name = "puppiCA15Jets/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -7832,11 +6764,9 @@ namespace testpanda {
   struct plotter <568> {
     constexpr static const char* name = "puppiCA15Jets/deepCSVcc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.deepCSVcc);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.deepCSVcc);
       return output;
     }
   };
@@ -7846,11 +6776,9 @@ namespace testpanda {
   struct plotter <569> {
     constexpr static const char* name = "puppiCA15Jets/tau2SD";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.tau2SD);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.tau2SD);
       return output;
     }
   };
@@ -7860,11 +6788,9 @@ namespace testpanda {
   struct plotter <570> {
     constexpr static const char* name = "puppiCA15Jets/ptSmearUp";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Jets)
-      output.push_back(i.ptSmearUp);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Jets)
+        output.push_back(i.ptSmearUp);
       return output;
     }
   };
@@ -7884,11 +6810,9 @@ namespace testpanda {
   struct plotter <572> {
     constexpr static const char* name = "puppiCA15Subjets/deepCMVAudsg";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.deepCMVAudsg);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.deepCMVAudsg);
       return output;
     }
   };
@@ -7898,11 +6822,9 @@ namespace testpanda {
   struct plotter <573> {
     constexpr static const char* name = "puppiCA15Subjets/deepCMVAbb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.deepCMVAbb);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.deepCMVAbb);
       return output;
     }
   };
@@ -7912,11 +6834,9 @@ namespace testpanda {
   struct plotter <574> {
     constexpr static const char* name = "puppiCA15Subjets/deepCSVudsg";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.deepCSVudsg);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.deepCSVudsg);
       return output;
     }
   };
@@ -7926,11 +6846,9 @@ namespace testpanda {
   struct plotter <575> {
     constexpr static const char* name = "puppiCA15Subjets/cmva";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.cmva);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.cmva);
       return output;
     }
   };
@@ -7940,11 +6858,9 @@ namespace testpanda {
   struct plotter <576> {
     constexpr static const char* name = "puppiCA15Subjets/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -7954,11 +6870,9 @@ namespace testpanda {
   struct plotter <577> {
     constexpr static const char* name = "puppiCA15Subjets/deepCSVbb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.deepCSVbb);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.deepCSVbb);
       return output;
     }
   };
@@ -7968,11 +6882,9 @@ namespace testpanda {
   struct plotter <578> {
     constexpr static const char* name = "puppiCA15Subjets/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -7982,11 +6894,9 @@ namespace testpanda {
   struct plotter <579> {
     constexpr static const char* name = "puppiCA15Subjets/deepCMVAb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.deepCMVAb);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.deepCMVAb);
       return output;
     }
   };
@@ -7996,11 +6906,9 @@ namespace testpanda {
   struct plotter <580> {
     constexpr static const char* name = "puppiCA15Subjets/deepCMVAc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.deepCMVAc);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.deepCMVAc);
       return output;
     }
   };
@@ -8010,11 +6918,9 @@ namespace testpanda {
   struct plotter <581> {
     constexpr static const char* name = "puppiCA15Subjets/qgl";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.qgl);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.qgl);
       return output;
     }
   };
@@ -8024,11 +6930,9 @@ namespace testpanda {
   struct plotter <582> {
     constexpr static const char* name = "puppiCA15Subjets/csv";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.csv);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.csv);
       return output;
     }
   };
@@ -8038,11 +6942,9 @@ namespace testpanda {
   struct plotter <583> {
     constexpr static const char* name = "puppiCA15Subjets/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.e());
       return output;
     }
   };
@@ -8052,11 +6954,9 @@ namespace testpanda {
   struct plotter <584> {
     constexpr static const char* name = "puppiCA15Subjets/deepCMVAcc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.deepCMVAcc);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.deepCMVAcc);
       return output;
     }
   };
@@ -8066,11 +6966,9 @@ namespace testpanda {
   struct plotter <585> {
     constexpr static const char* name = "puppiCA15Subjets/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -8080,11 +6978,9 @@ namespace testpanda {
   struct plotter <586> {
     constexpr static const char* name = "puppiCA15Subjets/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -8094,11 +6990,9 @@ namespace testpanda {
   struct plotter <587> {
     constexpr static const char* name = "puppiCA15Subjets/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -8108,11 +7002,9 @@ namespace testpanda {
   struct plotter <588> {
     constexpr static const char* name = "puppiCA15Subjets/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -8122,11 +7014,9 @@ namespace testpanda {
   struct plotter <589> {
     constexpr static const char* name = "puppiCA15Subjets/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -8136,11 +7026,9 @@ namespace testpanda {
   struct plotter <590> {
     constexpr static const char* name = "puppiCA15Subjets/deepCSVb";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.deepCSVb);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.deepCSVb);
       return output;
     }
   };
@@ -8150,11 +7038,9 @@ namespace testpanda {
   struct plotter <591> {
     constexpr static const char* name = "puppiCA15Subjets/deepCSVc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.deepCSVc);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.deepCSVc);
       return output;
     }
   };
@@ -8164,11 +7050,9 @@ namespace testpanda {
   struct plotter <592> {
     constexpr static const char* name = "puppiCA15Subjets/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -8178,11 +7062,9 @@ namespace testpanda {
   struct plotter <593> {
     constexpr static const char* name = "puppiCA15Subjets/deepCSVcc";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.puppiCA15Subjets)
-      output.push_back(i.deepCSVcc);
-
+      std::vector<float> output;
+      for (auto& i : event.puppiCA15Subjets)
+        output.push_back(i.deepCSVcc);
       return output;
     }
   };
@@ -8202,11 +7084,9 @@ namespace testpanda {
   struct plotter <595> {
     constexpr static const char* name = "ak4GenJets/partonFlavor";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak4GenJets)
-      output.push_back(i.partonFlavor);
-
+      std::vector<float> output;
+      for (auto& i : event.ak4GenJets)
+        output.push_back(i.partonFlavor);
       return output;
     }
   };
@@ -8216,11 +7096,9 @@ namespace testpanda {
   struct plotter <596> {
     constexpr static const char* name = "ak4GenJets/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak4GenJets)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.ak4GenJets)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -8230,11 +7108,9 @@ namespace testpanda {
   struct plotter <597> {
     constexpr static const char* name = "ak4GenJets/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak4GenJets)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.ak4GenJets)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -8244,11 +7120,9 @@ namespace testpanda {
   struct plotter <598> {
     constexpr static const char* name = "ak4GenJets/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak4GenJets)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.ak4GenJets)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -8258,11 +7132,9 @@ namespace testpanda {
   struct plotter <599> {
     constexpr static const char* name = "ak4GenJets/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak4GenJets)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.ak4GenJets)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -8272,11 +7144,9 @@ namespace testpanda {
   struct plotter <600> {
     constexpr static const char* name = "ak4GenJets/pdgid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak4GenJets)
-      output.push_back(i.pdgid);
-
+      std::vector<float> output;
+      for (auto& i : event.ak4GenJets)
+        output.push_back(i.pdgid);
       return output;
     }
   };
@@ -8286,11 +7156,9 @@ namespace testpanda {
   struct plotter <601> {
     constexpr static const char* name = "ak4GenJets/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak4GenJets)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.ak4GenJets)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -8300,11 +7168,9 @@ namespace testpanda {
   struct plotter <602> {
     constexpr static const char* name = "ak4GenJets/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak4GenJets)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.ak4GenJets)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -8314,11 +7180,9 @@ namespace testpanda {
   struct plotter <603> {
     constexpr static const char* name = "ak4GenJets/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak4GenJets)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.ak4GenJets)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -8328,11 +7192,9 @@ namespace testpanda {
   struct plotter <604> {
     constexpr static const char* name = "ak4GenJets/numB";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak4GenJets)
-      output.push_back(i.numB);
-
+      std::vector<float> output;
+      for (auto& i : event.ak4GenJets)
+        output.push_back(i.numB);
       return output;
     }
   };
@@ -8342,11 +7204,9 @@ namespace testpanda {
   struct plotter <605> {
     constexpr static const char* name = "ak4GenJets/numC";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak4GenJets)
-      output.push_back(i.numC);
-
+      std::vector<float> output;
+      for (auto& i : event.ak4GenJets)
+        output.push_back(i.numC);
       return output;
     }
   };
@@ -8356,11 +7216,9 @@ namespace testpanda {
   struct plotter <606> {
     constexpr static const char* name = "ak4GenJets/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak4GenJets)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.ak4GenJets)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -8370,11 +7228,9 @@ namespace testpanda {
   struct plotter <607> {
     constexpr static const char* name = "ak4GenJets/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak4GenJets)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.ak4GenJets)
+        output.push_back(i.e());
       return output;
     }
   };
@@ -8394,11 +7250,9 @@ namespace testpanda {
   struct plotter <609> {
     constexpr static const char* name = "ak8GenJets/partonFlavor";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak8GenJets)
-      output.push_back(i.partonFlavor);
-
+      std::vector<float> output;
+      for (auto& i : event.ak8GenJets)
+        output.push_back(i.partonFlavor);
       return output;
     }
   };
@@ -8408,11 +7262,9 @@ namespace testpanda {
   struct plotter <610> {
     constexpr static const char* name = "ak8GenJets/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak8GenJets)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.ak8GenJets)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -8422,11 +7274,9 @@ namespace testpanda {
   struct plotter <611> {
     constexpr static const char* name = "ak8GenJets/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak8GenJets)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.ak8GenJets)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -8436,11 +7286,9 @@ namespace testpanda {
   struct plotter <612> {
     constexpr static const char* name = "ak8GenJets/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak8GenJets)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.ak8GenJets)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -8450,11 +7298,9 @@ namespace testpanda {
   struct plotter <613> {
     constexpr static const char* name = "ak8GenJets/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak8GenJets)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.ak8GenJets)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -8464,11 +7310,9 @@ namespace testpanda {
   struct plotter <614> {
     constexpr static const char* name = "ak8GenJets/pdgid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak8GenJets)
-      output.push_back(i.pdgid);
-
+      std::vector<float> output;
+      for (auto& i : event.ak8GenJets)
+        output.push_back(i.pdgid);
       return output;
     }
   };
@@ -8478,11 +7322,9 @@ namespace testpanda {
   struct plotter <615> {
     constexpr static const char* name = "ak8GenJets/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak8GenJets)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.ak8GenJets)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -8492,11 +7334,9 @@ namespace testpanda {
   struct plotter <616> {
     constexpr static const char* name = "ak8GenJets/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak8GenJets)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.ak8GenJets)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -8506,11 +7346,9 @@ namespace testpanda {
   struct plotter <617> {
     constexpr static const char* name = "ak8GenJets/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak8GenJets)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.ak8GenJets)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -8520,11 +7358,9 @@ namespace testpanda {
   struct plotter <618> {
     constexpr static const char* name = "ak8GenJets/numB";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak8GenJets)
-      output.push_back(i.numB);
-
+      std::vector<float> output;
+      for (auto& i : event.ak8GenJets)
+        output.push_back(i.numB);
       return output;
     }
   };
@@ -8534,11 +7370,9 @@ namespace testpanda {
   struct plotter <619> {
     constexpr static const char* name = "ak8GenJets/numC";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak8GenJets)
-      output.push_back(i.numC);
-
+      std::vector<float> output;
+      for (auto& i : event.ak8GenJets)
+        output.push_back(i.numC);
       return output;
     }
   };
@@ -8548,11 +7382,9 @@ namespace testpanda {
   struct plotter <620> {
     constexpr static const char* name = "ak8GenJets/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak8GenJets)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.ak8GenJets)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -8562,11 +7394,9 @@ namespace testpanda {
   struct plotter <621> {
     constexpr static const char* name = "ak8GenJets/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ak8GenJets)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.ak8GenJets)
+        output.push_back(i.e());
       return output;
     }
   };
@@ -8586,11 +7416,9 @@ namespace testpanda {
   struct plotter <623> {
     constexpr static const char* name = "ca15GenJets/partonFlavor";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ca15GenJets)
-      output.push_back(i.partonFlavor);
-
+      std::vector<float> output;
+      for (auto& i : event.ca15GenJets)
+        output.push_back(i.partonFlavor);
       return output;
     }
   };
@@ -8600,11 +7428,9 @@ namespace testpanda {
   struct plotter <624> {
     constexpr static const char* name = "ca15GenJets/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ca15GenJets)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.ca15GenJets)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -8614,11 +7440,9 @@ namespace testpanda {
   struct plotter <625> {
     constexpr static const char* name = "ca15GenJets/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ca15GenJets)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.ca15GenJets)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -8628,11 +7452,9 @@ namespace testpanda {
   struct plotter <626> {
     constexpr static const char* name = "ca15GenJets/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ca15GenJets)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.ca15GenJets)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -8642,11 +7464,9 @@ namespace testpanda {
   struct plotter <627> {
     constexpr static const char* name = "ca15GenJets/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ca15GenJets)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.ca15GenJets)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -8656,11 +7476,9 @@ namespace testpanda {
   struct plotter <628> {
     constexpr static const char* name = "ca15GenJets/pdgid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ca15GenJets)
-      output.push_back(i.pdgid);
-
+      std::vector<float> output;
+      for (auto& i : event.ca15GenJets)
+        output.push_back(i.pdgid);
       return output;
     }
   };
@@ -8670,11 +7488,9 @@ namespace testpanda {
   struct plotter <629> {
     constexpr static const char* name = "ca15GenJets/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ca15GenJets)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.ca15GenJets)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -8684,11 +7500,9 @@ namespace testpanda {
   struct plotter <630> {
     constexpr static const char* name = "ca15GenJets/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ca15GenJets)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.ca15GenJets)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -8698,11 +7512,9 @@ namespace testpanda {
   struct plotter <631> {
     constexpr static const char* name = "ca15GenJets/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ca15GenJets)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.ca15GenJets)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -8712,11 +7524,9 @@ namespace testpanda {
   struct plotter <632> {
     constexpr static const char* name = "ca15GenJets/numB";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ca15GenJets)
-      output.push_back(i.numB);
-
+      std::vector<float> output;
+      for (auto& i : event.ca15GenJets)
+        output.push_back(i.numB);
       return output;
     }
   };
@@ -8726,11 +7536,9 @@ namespace testpanda {
   struct plotter <633> {
     constexpr static const char* name = "ca15GenJets/numC";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ca15GenJets)
-      output.push_back(i.numC);
-
+      std::vector<float> output;
+      for (auto& i : event.ca15GenJets)
+        output.push_back(i.numC);
       return output;
     }
   };
@@ -8740,11 +7548,9 @@ namespace testpanda {
   struct plotter <634> {
     constexpr static const char* name = "ca15GenJets/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ca15GenJets)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.ca15GenJets)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -8754,11 +7560,9 @@ namespace testpanda {
   struct plotter <635> {
     constexpr static const char* name = "ca15GenJets/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.ca15GenJets)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.ca15GenJets)
+        output.push_back(i.e());
       return output;
     }
   };
@@ -8778,11 +7582,9 @@ namespace testpanda {
   struct plotter <637> {
     constexpr static const char* name = "genParticles/parent_isValid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.genParticles)
-      output.push_back(i.parent.isValid());
-
+      std::vector<float> output;
+      for (auto& i : event.genParticles)
+        output.push_back(i.parent.isValid());
       return output;
     }
   };
@@ -8792,11 +7594,9 @@ namespace testpanda {
   struct plotter <638> {
     constexpr static const char* name = "genParticles/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.genParticles)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.genParticles)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -8806,11 +7606,9 @@ namespace testpanda {
   struct plotter <639> {
     constexpr static const char* name = "genParticles/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.genParticles)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.genParticles)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -8820,11 +7618,9 @@ namespace testpanda {
   struct plotter <640> {
     constexpr static const char* name = "genParticles/statusFlags";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.genParticles)
-      output.push_back(i.statusFlags);
-
+      std::vector<float> output;
+      for (auto& i : event.genParticles)
+        output.push_back(i.statusFlags);
       return output;
     }
   };
@@ -8834,11 +7630,9 @@ namespace testpanda {
   struct plotter <641> {
     constexpr static const char* name = "genParticles/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.genParticles)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.genParticles)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -8848,11 +7642,9 @@ namespace testpanda {
   struct plotter <642> {
     constexpr static const char* name = "genParticles/pdgid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.genParticles)
-      output.push_back(i.pdgid);
-
+      std::vector<float> output;
+      for (auto& i : event.genParticles)
+        output.push_back(i.pdgid);
       return output;
     }
   };
@@ -8862,11 +7654,9 @@ namespace testpanda {
   struct plotter <643> {
     constexpr static const char* name = "genParticles/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.genParticles)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.genParticles)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -8876,11 +7666,9 @@ namespace testpanda {
   struct plotter <644> {
     constexpr static const char* name = "genParticles/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.genParticles)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.genParticles)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -8890,11 +7678,9 @@ namespace testpanda {
   struct plotter <645> {
     constexpr static const char* name = "genParticles/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.genParticles)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.genParticles)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -8904,11 +7690,9 @@ namespace testpanda {
   struct plotter <646> {
     constexpr static const char* name = "genParticles/finalState";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.genParticles)
-      output.push_back(i.finalState);
-
+      std::vector<float> output;
+      for (auto& i : event.genParticles)
+        output.push_back(i.finalState);
       return output;
     }
   };
@@ -8918,11 +7702,9 @@ namespace testpanda {
   struct plotter <647> {
     constexpr static const char* name = "genParticles/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.genParticles)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.genParticles)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -8932,11 +7714,9 @@ namespace testpanda {
   struct plotter <648> {
     constexpr static const char* name = "genParticles/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.genParticles)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.genParticles)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -8946,11 +7726,9 @@ namespace testpanda {
   struct plotter <649> {
     constexpr static const char* name = "genParticles/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.genParticles)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.genParticles)
+        output.push_back(i.e());
       return output;
     }
   };
@@ -9000,11 +7778,9 @@ namespace testpanda {
   struct plotter <654> {
     constexpr static const char* name = "partons/pt";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.partons)
-      output.push_back(i.pt());
-
+      std::vector<float> output;
+      for (auto& i : event.partons)
+        output.push_back(i.pt());
       return output;
     }
   };
@@ -9014,11 +7790,9 @@ namespace testpanda {
   struct plotter <655> {
     constexpr static const char* name = "partons/p";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.partons)
-      output.push_back(i.p());
-
+      std::vector<float> output;
+      for (auto& i : event.partons)
+        output.push_back(i.p());
       return output;
     }
   };
@@ -9028,11 +7802,9 @@ namespace testpanda {
   struct plotter <656> {
     constexpr static const char* name = "partons/eta";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.partons)
-      output.push_back(i.eta());
-
+      std::vector<float> output;
+      for (auto& i : event.partons)
+        output.push_back(i.eta());
       return output;
     }
   };
@@ -9042,11 +7814,9 @@ namespace testpanda {
   struct plotter <657> {
     constexpr static const char* name = "partons/m";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.partons)
-      output.push_back(i.m());
-
+      std::vector<float> output;
+      for (auto& i : event.partons)
+        output.push_back(i.m());
       return output;
     }
   };
@@ -9056,11 +7826,9 @@ namespace testpanda {
   struct plotter <658> {
     constexpr static const char* name = "partons/pdgid";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.partons)
-      output.push_back(i.pdgid);
-
+      std::vector<float> output;
+      for (auto& i : event.partons)
+        output.push_back(i.pdgid);
       return output;
     }
   };
@@ -9070,11 +7838,9 @@ namespace testpanda {
   struct plotter <659> {
     constexpr static const char* name = "partons/phi";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.partons)
-      output.push_back(i.phi());
-
+      std::vector<float> output;
+      for (auto& i : event.partons)
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -9084,11 +7850,9 @@ namespace testpanda {
   struct plotter <660> {
     constexpr static const char* name = "partons/pz";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.partons)
-      output.push_back(i.pz());
-
+      std::vector<float> output;
+      for (auto& i : event.partons)
+        output.push_back(i.pz());
       return output;
     }
   };
@@ -9098,11 +7862,9 @@ namespace testpanda {
   struct plotter <661> {
     constexpr static const char* name = "partons/py";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.partons)
-      output.push_back(i.py());
-
+      std::vector<float> output;
+      for (auto& i : event.partons)
+        output.push_back(i.py());
       return output;
     }
   };
@@ -9112,11 +7874,9 @@ namespace testpanda {
   struct plotter <662> {
     constexpr static const char* name = "partons/px";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.partons)
-      output.push_back(i.px());
-
+      std::vector<float> output;
+      for (auto& i : event.partons)
+        output.push_back(i.px());
       return output;
     }
   };
@@ -9126,11 +7886,9 @@ namespace testpanda {
   struct plotter <663> {
     constexpr static const char* name = "partons/e";
     std::vector<float> operator () (panda::Event& event) {
-  
-    std::vector<float> output;
-    for (auto& i : event.partons)
-      output.push_back(i.e());
-
+      std::vector<float> output;
+      for (auto& i : event.partons)
+        output.push_back(i.e());
       return output;
     }
   };

--- a/RelVal/interface/EnumerateBranches.h
+++ b/RelVal/interface/EnumerateBranches.h
@@ -4,9836 +4,9839 @@
 #include <vector>
 #include "PandaTree/Objects/interface/Event.h"
 
+namespace testpanda {
 
-template <int P>
-struct plotter {
-  constexpr static const char* name = nullptr;
-};
-
-
-template <>
-struct plotter <0> {
-  constexpr static const char* name = "common/eventNumber";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.eventNumber)};
-    return output;
-  }
-};
+  template <int P>
+  struct plotter {
+    constexpr static const char* name = nullptr;
+  };
 
 
-template <>
-struct plotter <1> {
-  constexpr static const char* name = "common/runNumber";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.runNumber)};
-    return output;
-  }
-};
+  template <>
+  struct plotter <0> {
+    constexpr static const char* name = "common/eventNumber";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.eventNumber)};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <2> {
-  constexpr static const char* name = "common/weight";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.weight)};
-    return output;
-  }
-};
+  template <>
+  struct plotter <1> {
+    constexpr static const char* name = "common/runNumber";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.runNumber)};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <3> {
-  constexpr static const char* name = "common/isData";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.isData)};
-    return output;
-  }
-};
+  template <>
+  struct plotter <2> {
+    constexpr static const char* name = "common/weight";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.weight)};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <4> {
-  constexpr static const char* name = "common/lumiNumber";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.lumiNumber)};
-    return output;
-  }
-};
+  template <>
+  struct plotter <3> {
+    constexpr static const char* name = "common/isData";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.isData)};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <5> {
-  constexpr static const char* name = "common/rhoCentralCalo";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.rhoCentralCalo)};
-    return output;
-  }
-};
+  template <>
+  struct plotter <4> {
+    constexpr static const char* name = "common/lumiNumber";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.lumiNumber)};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <6> {
-  constexpr static const char* name = "common/npv";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.npv)};
-    return output;
-  }
-};
+  template <>
+  struct plotter <5> {
+    constexpr static const char* name = "common/rhoCentralCalo";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.rhoCentralCalo)};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <7> {
-  constexpr static const char* name = "common/rho";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.rho)};
-    return output;
-  }
-};
+  template <>
+  struct plotter <6> {
+    constexpr static const char* name = "common/npv";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.npv)};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <8> {
-  constexpr static const char* name = "common/npvTrue";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.npvTrue)};
-    return output;
-  }
-};
+  template <>
+  struct plotter <7> {
+    constexpr static const char* name = "common/rho";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.rho)};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <9> {
-  constexpr static const char* name = "genReweight/r5f1DW";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.genReweight.r5f1DW)};
-    return output;
-  }
-};
+  template <>
+  struct plotter <8> {
+    constexpr static const char* name = "common/npvTrue";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.npvTrue)};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <10> {
-  constexpr static const char* name = "genReweight/r2f2DW";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.genReweight.r2f2DW)};
-    return output;
-  }
-};
+  template <>
+  struct plotter <9> {
+    constexpr static const char* name = "genReweight/r5f1DW";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.genReweight.r5f1DW)};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <11> {
-  constexpr static const char* name = "genReweight/r2f1DW";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.genReweight.r2f1DW)};
-    return output;
-  }
-};
+  template <>
+  struct plotter <10> {
+    constexpr static const char* name = "genReweight/r2f2DW";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.genReweight.r2f2DW)};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <12> {
-  constexpr static const char* name = "genReweight/pdfDW";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.genReweight.pdfDW)};
-    return output;
-  }
-};
+  template <>
+  struct plotter <11> {
+    constexpr static const char* name = "genReweight/r2f1DW";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.genReweight.r2f1DW)};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <13> {
-  constexpr static const char* name = "genReweight/r1f5DW";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.genReweight.r1f5DW)};
-    return output;
-  }
-};
+  template <>
+  struct plotter <12> {
+    constexpr static const char* name = "genReweight/pdfDW";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.genReweight.pdfDW)};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <14> {
-  constexpr static const char* name = "genReweight/r5f5DW";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.genReweight.r5f5DW)};
-    return output;
-  }
-};
+  template <>
+  struct plotter <13> {
+    constexpr static const char* name = "genReweight/r1f5DW";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.genReweight.r1f5DW)};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <15> {
-  constexpr static const char* name = "genReweight/r1f2DW";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.genReweight.r1f2DW)};
-    return output;
-  }
-};
+  template <>
+  struct plotter <14> {
+    constexpr static const char* name = "genReweight/r5f5DW";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.genReweight.r5f5DW)};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <16> {
-  constexpr static const char* name = "pfCandidates/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.pfCandidates.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <15> {
+    constexpr static const char* name = "genReweight/r1f2DW";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.genReweight.r1f2DW)};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <17> {
-  constexpr static const char* name = "pfCandidates/vertex_isValid";
-  std::vector<float> operator () (panda::Event& event) {
+  template <>
+  struct plotter <16> {
+    constexpr static const char* name = "pfCandidates/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.pfCandidates.size())};
+      return output;
+    }
+  };
 
+
+  template <>
+  struct plotter <17> {
+    constexpr static const char* name = "pfCandidates/vertex_isValid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.pfCandidates)
       output.push_back(i.vertex.isValid());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <18> {
-  constexpr static const char* name = "pfCandidates/track_isValid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <18> {
+    constexpr static const char* name = "pfCandidates/track_isValid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.pfCandidates)
       output.push_back(i.track.isValid());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <19> {
-  constexpr static const char* name = "pfCandidates/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <19> {
+    constexpr static const char* name = "pfCandidates/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.pfCandidates)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <20> {
-  constexpr static const char* name = "pfCandidates/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <20> {
+    constexpr static const char* name = "pfCandidates/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.pfCandidates)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <21> {
-  constexpr static const char* name = "pfCandidates/puppiWNoLep";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <21> {
+    constexpr static const char* name = "pfCandidates/puppiWNoLep";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.pfCandidates)
       output.push_back(i.puppiWNoLep());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <22> {
-  constexpr static const char* name = "pfCandidates/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <22> {
+    constexpr static const char* name = "pfCandidates/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.pfCandidates)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <23> {
-  constexpr static const char* name = "pfCandidates/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <23> {
+    constexpr static const char* name = "pfCandidates/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.pfCandidates)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <24> {
-  constexpr static const char* name = "pfCandidates/pdgId";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <24> {
+    constexpr static const char* name = "pfCandidates/pdgId";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.pfCandidates)
       output.push_back(i.pdgId());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <25> {
-  constexpr static const char* name = "pfCandidates/hCalFrac";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <25> {
+    constexpr static const char* name = "pfCandidates/hCalFrac";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.pfCandidates)
       output.push_back(i.hCalFrac);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <26> {
-  constexpr static const char* name = "pfCandidates/ptype";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <26> {
+    constexpr static const char* name = "pfCandidates/ptype";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.pfCandidates)
       output.push_back(i.ptype);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <27> {
-  constexpr static const char* name = "pfCandidates/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <27> {
+    constexpr static const char* name = "pfCandidates/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.pfCandidates)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <28> {
-  constexpr static const char* name = "pfCandidates/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <28> {
+    constexpr static const char* name = "pfCandidates/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.pfCandidates)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <29> {
-  constexpr static const char* name = "pfCandidates/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <29> {
+    constexpr static const char* name = "pfCandidates/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.pfCandidates)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <30> {
-  constexpr static const char* name = "pfCandidates/q";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <30> {
+    constexpr static const char* name = "pfCandidates/q";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.pfCandidates)
       output.push_back(i.q());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <31> {
-  constexpr static const char* name = "pfCandidates/puppiW";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <31> {
+    constexpr static const char* name = "pfCandidates/puppiW";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.pfCandidates)
       output.push_back(i.puppiW());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <32> {
-  constexpr static const char* name = "pfCandidates/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <32> {
+    constexpr static const char* name = "pfCandidates/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.pfCandidates)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <33> {
-  constexpr static const char* name = "pfCandidates/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <33> {
+    constexpr static const char* name = "pfCandidates/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.pfCandidates)
       output.push_back(i.e());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <34> {
-  constexpr static const char* name = "vertices/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.vertices.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <34> {
+    constexpr static const char* name = "vertices/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.vertices.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <35> {
-  constexpr static const char* name = "vertices/chi2";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <35> {
+    constexpr static const char* name = "vertices/chi2";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.vertices)
       output.push_back(i.chi2);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <36> {
-  constexpr static const char* name = "vertices/ntrk";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <36> {
+    constexpr static const char* name = "vertices/ntrk";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.vertices)
       output.push_back(i.ntrk);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <37> {
-  constexpr static const char* name = "vertices/ndof";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <37> {
+    constexpr static const char* name = "vertices/ndof";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.vertices)
       output.push_back(i.ndof);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <38> {
-  constexpr static const char* name = "vertices/score";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <38> {
+    constexpr static const char* name = "vertices/score";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.vertices)
       output.push_back(i.score);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <39> {
-  constexpr static const char* name = "vertices/normChi2";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <39> {
+    constexpr static const char* name = "vertices/normChi2";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.vertices)
       output.push_back(i.normChi2());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <40> {
-  constexpr static const char* name = "vertices/pfRangeMax";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <40> {
+    constexpr static const char* name = "vertices/pfRangeMax";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.vertices)
       output.push_back(i.pfRangeMax);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <41> {
-  constexpr static const char* name = "vertices/y";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <41> {
+    constexpr static const char* name = "vertices/y";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.vertices)
       output.push_back(i.y);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <42> {
-  constexpr static const char* name = "vertices/x";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <42> {
+    constexpr static const char* name = "vertices/x";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.vertices)
       output.push_back(i.x);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <43> {
-  constexpr static const char* name = "vertices/z";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <43> {
+    constexpr static const char* name = "vertices/z";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.vertices)
       output.push_back(i.z);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <44> {
-  constexpr static const char* name = "secondaryVertices/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.secondaryVertices.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <44> {
+    constexpr static const char* name = "secondaryVertices/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.secondaryVertices.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <45> {
-  constexpr static const char* name = "secondaryVertices/daughters_size";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <45> {
+    constexpr static const char* name = "secondaryVertices/daughters_size";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.secondaryVertices)
       output.push_back(i.daughters.size());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <46> {
-  constexpr static const char* name = "secondaryVertices/vtx3DVal";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <46> {
+    constexpr static const char* name = "secondaryVertices/vtx3DVal";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.secondaryVertices)
       output.push_back(i.vtx3DVal);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <47> {
-  constexpr static const char* name = "secondaryVertices/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <47> {
+    constexpr static const char* name = "secondaryVertices/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.secondaryVertices)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <48> {
-  constexpr static const char* name = "secondaryVertices/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <48> {
+    constexpr static const char* name = "secondaryVertices/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.secondaryVertices)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <49> {
-  constexpr static const char* name = "secondaryVertices/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <49> {
+    constexpr static const char* name = "secondaryVertices/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.secondaryVertices)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <50> {
-  constexpr static const char* name = "secondaryVertices/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <50> {
+    constexpr static const char* name = "secondaryVertices/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.secondaryVertices)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <51> {
-  constexpr static const char* name = "secondaryVertices/chi2";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <51> {
+    constexpr static const char* name = "secondaryVertices/chi2";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.secondaryVertices)
       output.push_back(i.chi2);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <52> {
-  constexpr static const char* name = "secondaryVertices/significance";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <52> {
+    constexpr static const char* name = "secondaryVertices/significance";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.secondaryVertices)
       output.push_back(i.significance);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <53> {
-  constexpr static const char* name = "secondaryVertices/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <53> {
+    constexpr static const char* name = "secondaryVertices/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.secondaryVertices)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <54> {
-  constexpr static const char* name = "secondaryVertices/ndof";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <54> {
+    constexpr static const char* name = "secondaryVertices/ndof";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.secondaryVertices)
       output.push_back(i.ndof);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <55> {
-  constexpr static const char* name = "secondaryVertices/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <55> {
+    constexpr static const char* name = "secondaryVertices/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.secondaryVertices)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <56> {
-  constexpr static const char* name = "secondaryVertices/vtx3DeVal";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <56> {
+    constexpr static const char* name = "secondaryVertices/vtx3DeVal";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.secondaryVertices)
       output.push_back(i.vtx3DeVal);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <57> {
-  constexpr static const char* name = "secondaryVertices/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <57> {
+    constexpr static const char* name = "secondaryVertices/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.secondaryVertices)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <58> {
-  constexpr static const char* name = "secondaryVertices/normChi2";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <58> {
+    constexpr static const char* name = "secondaryVertices/normChi2";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.secondaryVertices)
       output.push_back(i.normChi2());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <59> {
-  constexpr static const char* name = "secondaryVertices/ntrk";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <59> {
+    constexpr static const char* name = "secondaryVertices/ntrk";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.secondaryVertices)
       output.push_back(i.ntrk);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <60> {
-  constexpr static const char* name = "secondaryVertices/y";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <60> {
+    constexpr static const char* name = "secondaryVertices/y";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.secondaryVertices)
       output.push_back(i.y);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <61> {
-  constexpr static const char* name = "secondaryVertices/x";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <61> {
+    constexpr static const char* name = "secondaryVertices/x";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.secondaryVertices)
       output.push_back(i.x);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <62> {
-  constexpr static const char* name = "secondaryVertices/z";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <62> {
+    constexpr static const char* name = "secondaryVertices/z";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.secondaryVertices)
       output.push_back(i.z);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <63> {
-  constexpr static const char* name = "secondaryVertices/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <63> {
+    constexpr static const char* name = "secondaryVertices/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.secondaryVertices)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <64> {
-  constexpr static const char* name = "secondaryVertices/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <64> {
+    constexpr static const char* name = "secondaryVertices/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.secondaryVertices)
       output.push_back(i.e());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <65> {
-  constexpr static const char* name = "tracks/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.tracks.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <65> {
+    constexpr static const char* name = "tracks/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.tracks.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <66> {
-  constexpr static const char* name = "tracks/dxy";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <66> {
+    constexpr static const char* name = "tracks/dxy";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.tracks)
       output.push_back(i.dxy());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <67> {
-  constexpr static const char* name = "tracks/dPhi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <67> {
+    constexpr static const char* name = "tracks/dPhi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.tracks)
       output.push_back(i.dPhi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <68> {
-  constexpr static const char* name = "tracks/dz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <68> {
+    constexpr static const char* name = "tracks/dz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.tracks)
       output.push_back(i.dz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <69> {
-  constexpr static const char* name = "tracks/ptError";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <69> {
+    constexpr static const char* name = "tracks/ptError";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.tracks)
       output.push_back(i.ptError());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <70> {
-  constexpr static const char* name = "superClusters/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.superClusters.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <70> {
+    constexpr static const char* name = "superClusters/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.superClusters.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <71> {
-  constexpr static const char* name = "superClusters/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <71> {
+    constexpr static const char* name = "superClusters/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.superClusters)
       output.push_back(i.phi);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <72> {
-  constexpr static const char* name = "superClusters/rawPt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <72> {
+    constexpr static const char* name = "superClusters/rawPt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.superClusters)
       output.push_back(i.rawPt);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <73> {
-  constexpr static const char* name = "superClusters/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <73> {
+    constexpr static const char* name = "superClusters/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.superClusters)
       output.push_back(i.eta);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <74> {
-  constexpr static const char* name = "electrons/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.electrons.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <74> {
+    constexpr static const char* name = "electrons/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.electrons.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <75> {
-  constexpr static const char* name = "electrons/superCluster_isValid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <75> {
+    constexpr static const char* name = "electrons/superCluster_isValid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.superCluster.isValid());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <76> {
-  constexpr static const char* name = "electrons/dxy";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <76> {
+    constexpr static const char* name = "electrons/dxy";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.dxy);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <77> {
-  constexpr static const char* name = "electrons/chIso";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <77> {
+    constexpr static const char* name = "electrons/chIso";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.chIso);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <78> {
-  constexpr static const char* name = "electrons/phIsoPh";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <78> {
+    constexpr static const char* name = "electrons/phIsoPh";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.phIsoPh);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <79> {
-  constexpr static const char* name = "electrons/trackIso";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <79> {
+    constexpr static const char* name = "electrons/trackIso";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.trackIso);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <80> {
-  constexpr static const char* name = "electrons/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <80> {
+    constexpr static const char* name = "electrons/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <81> {
-  constexpr static const char* name = "electrons/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <81> {
+    constexpr static const char* name = "electrons/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <82> {
-  constexpr static const char* name = "electrons/ecalIso";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <82> {
+    constexpr static const char* name = "electrons/ecalIso";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.ecalIso);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <83> {
-  constexpr static const char* name = "electrons/medium";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <83> {
+    constexpr static const char* name = "electrons/medium";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.medium);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <84> {
-  constexpr static const char* name = "electrons/isoPUOffset";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <84> {
+    constexpr static const char* name = "electrons/isoPUOffset";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.isoPUOffset);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <85> {
-  constexpr static const char* name = "electrons/pfPt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <85> {
+    constexpr static const char* name = "electrons/pfPt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.pfPt);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <86> {
-  constexpr static const char* name = "electrons/trackP";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <86> {
+    constexpr static const char* name = "electrons/trackP";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.trackP);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <87> {
-  constexpr static const char* name = "electrons/ecalE";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <87> {
+    constexpr static const char* name = "electrons/ecalE";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.ecalE);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <88> {
-  constexpr static const char* name = "electrons/sipip";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <88> {
+    constexpr static const char* name = "electrons/sipip";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.sipip);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <89> {
-  constexpr static const char* name = "electrons/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <89> {
+    constexpr static const char* name = "electrons/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <90> {
-  constexpr static const char* name = "electrons/hltsafe";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <90> {
+    constexpr static const char* name = "electrons/hltsafe";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.hltsafe);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <91> {
-  constexpr static const char* name = "electrons/tripleCharge";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <91> {
+    constexpr static const char* name = "electrons/tripleCharge";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.tripleCharge);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <92> {
-  constexpr static const char* name = "electrons/charge";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <92> {
+    constexpr static const char* name = "electrons/charge";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.charge);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <93> {
-  constexpr static const char* name = "electrons/dEtaInSeed";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <93> {
+    constexpr static const char* name = "electrons/dEtaInSeed";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.dEtaInSeed);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <94> {
-  constexpr static const char* name = "electrons/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <94> {
+    constexpr static const char* name = "electrons/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.e());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <95> {
-  constexpr static const char* name = "electrons/tight";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <95> {
+    constexpr static const char* name = "electrons/tight";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.tight);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <96> {
-  constexpr static const char* name = "electrons/sieie";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <96> {
+    constexpr static const char* name = "electrons/sieie";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.sieie);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <97> {
-  constexpr static const char* name = "electrons/eseed";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <97> {
+    constexpr static const char* name = "electrons/eseed";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.eseed);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <98> {
-  constexpr static const char* name = "electrons/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <98> {
+    constexpr static const char* name = "electrons/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <99> {
-  constexpr static const char* name = "electrons/veto";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <99> {
+    constexpr static const char* name = "electrons/veto";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.veto);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <100> {
-  constexpr static const char* name = "electrons/conversionVeto";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <100> {
+    constexpr static const char* name = "electrons/conversionVeto";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.conversionVeto);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <101> {
-  constexpr static const char* name = "electrons/loose";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <101> {
+    constexpr static const char* name = "electrons/loose";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.loose);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <102> {
-  constexpr static const char* name = "electrons/regPt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <102> {
+    constexpr static const char* name = "electrons/regPt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.regPt);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <103> {
-  constexpr static const char* name = "electrons/nhIso";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <103> {
+    constexpr static const char* name = "electrons/nhIso";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.nhIso);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <104> {
-  constexpr static const char* name = "electrons/dPhiIn";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <104> {
+    constexpr static const char* name = "electrons/dPhiIn";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.dPhiIn);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <105> {
-  constexpr static const char* name = "electrons/dz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <105> {
+    constexpr static const char* name = "electrons/dz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.dz);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <106> {
-  constexpr static const char* name = "electrons/chIsoPh";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <106> {
+    constexpr static const char* name = "electrons/chIsoPh";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.chIsoPh);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <107> {
-  constexpr static const char* name = "electrons/phIso";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <107> {
+    constexpr static const char* name = "electrons/phIso";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.phIso);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <108> {
-  constexpr static const char* name = "electrons/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <108> {
+    constexpr static const char* name = "electrons/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <109> {
-  constexpr static const char* name = "electrons/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <109> {
+    constexpr static const char* name = "electrons/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <110> {
-  constexpr static const char* name = "electrons/nhIsoPh";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <110> {
+    constexpr static const char* name = "electrons/nhIsoPh";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.nhIsoPh);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <111> {
-  constexpr static const char* name = "electrons/hcalIso";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <111> {
+    constexpr static const char* name = "electrons/hcalIso";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.hcalIso);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <112> {
-  constexpr static const char* name = "electrons/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <112> {
+    constexpr static const char* name = "electrons/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <113> {
-  constexpr static const char* name = "electrons/puIso";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <113> {
+    constexpr static const char* name = "electrons/puIso";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.puIso);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <114> {
-  constexpr static const char* name = "electrons/combIso";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <114> {
+    constexpr static const char* name = "electrons/combIso";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.combIso());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <115> {
-  constexpr static const char* name = "electrons/r9";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <115> {
+    constexpr static const char* name = "electrons/r9";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.r9);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <116> {
-  constexpr static const char* name = "electrons/nMissingHits";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <116> {
+    constexpr static const char* name = "electrons/nMissingHits";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.nMissingHits);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <117> {
-  constexpr static const char* name = "electrons/hOverE";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <117> {
+    constexpr static const char* name = "electrons/hOverE";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.hOverE);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <118> {
-  constexpr static const char* name = "electrons/smearedPt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <118> {
+    constexpr static const char* name = "electrons/smearedPt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.smearedPt);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <119> {
-  constexpr static const char* name = "electrons/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <119> {
+    constexpr static const char* name = "electrons/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.electrons)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <120> {
-  constexpr static const char* name = "muons/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.muons.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <120> {
+    constexpr static const char* name = "muons/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.muons.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <121> {
-  constexpr static const char* name = "muons/dxy";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <121> {
+    constexpr static const char* name = "muons/dxy";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.dxy);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <122> {
-  constexpr static const char* name = "muons/global";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <122> {
+    constexpr static const char* name = "muons/global";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.global);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <123> {
-  constexpr static const char* name = "muons/chIso";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <123> {
+    constexpr static const char* name = "muons/chIso";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.chIso);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <124> {
-  constexpr static const char* name = "muons/normChi2";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <124> {
+    constexpr static const char* name = "muons/normChi2";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.normChi2);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <125> {
-  constexpr static const char* name = "muons/trkLayersWithMmt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <125> {
+    constexpr static const char* name = "muons/trkLayersWithMmt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.trkLayersWithMmt);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <126> {
-  constexpr static const char* name = "muons/pfPt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <126> {
+    constexpr static const char* name = "muons/pfPt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.pfPt);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <127> {
-  constexpr static const char* name = "muons/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <127> {
+    constexpr static const char* name = "muons/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <128> {
-  constexpr static const char* name = "muons/hltsafe";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <128> {
+    constexpr static const char* name = "muons/hltsafe";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.hltsafe);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <129> {
-  constexpr static const char* name = "muons/tight";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <129> {
+    constexpr static const char* name = "muons/tight";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.tight);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <130> {
-  constexpr static const char* name = "muons/charge";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <130> {
+    constexpr static const char* name = "muons/charge";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.charge);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <131> {
-  constexpr static const char* name = "muons/tracker";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <131> {
+    constexpr static const char* name = "muons/tracker";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.tracker);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <132> {
-  constexpr static const char* name = "muons/pf";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <132> {
+    constexpr static const char* name = "muons/pf";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.pf);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <133> {
-  constexpr static const char* name = "muons/segmentCompatibility";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <133> {
+    constexpr static const char* name = "muons/segmentCompatibility";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.segmentCompatibility);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <134> {
-  constexpr static const char* name = "muons/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <134> {
+    constexpr static const char* name = "muons/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.e());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <135> {
-  constexpr static const char* name = "muons/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <135> {
+    constexpr static const char* name = "muons/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <136> {
-  constexpr static const char* name = "muons/medium";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <136> {
+    constexpr static const char* name = "muons/medium";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.medium);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <137> {
-  constexpr static const char* name = "muons/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <137> {
+    constexpr static const char* name = "muons/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <138> {
-  constexpr static const char* name = "muons/validFraction";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <138> {
+    constexpr static const char* name = "muons/validFraction";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.validFraction);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <139> {
-  constexpr static const char* name = "muons/nMatched";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <139> {
+    constexpr static const char* name = "muons/nMatched";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.nMatched);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <140> {
-  constexpr static const char* name = "muons/loose";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <140> {
+    constexpr static const char* name = "muons/loose";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.loose);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <141> {
-  constexpr static const char* name = "muons/mediumBtoF";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <141> {
+    constexpr static const char* name = "muons/mediumBtoF";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.mediumBtoF);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <142> {
-  constexpr static const char* name = "muons/nValidPixel";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <142> {
+    constexpr static const char* name = "muons/nValidPixel";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.nValidPixel);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <143> {
-  constexpr static const char* name = "muons/nhIso";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <143> {
+    constexpr static const char* name = "muons/nhIso";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.nhIso);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <144> {
-  constexpr static const char* name = "muons/nValidMuon";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <144> {
+    constexpr static const char* name = "muons/nValidMuon";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.nValidMuon);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <145> {
-  constexpr static const char* name = "muons/dz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <145> {
+    constexpr static const char* name = "muons/dz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.dz);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <146> {
-  constexpr static const char* name = "muons/chi2LocalPosition";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <146> {
+    constexpr static const char* name = "muons/chi2LocalPosition";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.chi2LocalPosition);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <147> {
-  constexpr static const char* name = "muons/pixLayersWithMmt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <147> {
+    constexpr static const char* name = "muons/pixLayersWithMmt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.pixLayersWithMmt);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <148> {
-  constexpr static const char* name = "muons/phIso";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <148> {
+    constexpr static const char* name = "muons/phIso";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.phIso);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <149> {
-  constexpr static const char* name = "muons/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <149> {
+    constexpr static const char* name = "muons/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <150> {
-  constexpr static const char* name = "muons/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <150> {
+    constexpr static const char* name = "muons/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <151> {
-  constexpr static const char* name = "muons/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <151> {
+    constexpr static const char* name = "muons/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <152> {
-  constexpr static const char* name = "muons/puIso";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <152> {
+    constexpr static const char* name = "muons/puIso";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.puIso);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <153> {
-  constexpr static const char* name = "muons/combIso";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <153> {
+    constexpr static const char* name = "muons/combIso";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.combIso());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <154> {
-  constexpr static const char* name = "muons/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <154> {
+    constexpr static const char* name = "muons/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <155> {
-  constexpr static const char* name = "muons/r03Iso";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <155> {
+    constexpr static const char* name = "muons/r03Iso";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.r03Iso);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <156> {
-  constexpr static const char* name = "muons/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <156> {
+    constexpr static const char* name = "muons/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <157> {
-  constexpr static const char* name = "muons/trkKink";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <157> {
+    constexpr static const char* name = "muons/trkKink";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.trkKink);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <158> {
-  constexpr static const char* name = "muons/soft";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <158> {
+    constexpr static const char* name = "muons/soft";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.muons)
       output.push_back(i.soft);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <159> {
-  constexpr static const char* name = "taus/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.taus.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <159> {
+    constexpr static const char* name = "taus/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.taus.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <160> {
-  constexpr static const char* name = "taus/vertex_isValid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <160> {
+    constexpr static const char* name = "taus/vertex_isValid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.taus)
       output.push_back(i.vertex.isValid());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <161> {
-  constexpr static const char* name = "taus/matchedGen_isValid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <161> {
+    constexpr static const char* name = "taus/matchedGen_isValid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.taus)
       output.push_back(i.matchedGen.isValid());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <162> {
-  constexpr static const char* name = "taus/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <162> {
+    constexpr static const char* name = "taus/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.taus)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <163> {
-  constexpr static const char* name = "taus/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <163> {
+    constexpr static const char* name = "taus/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.taus)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <164> {
-  constexpr static const char* name = "taus/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <164> {
+    constexpr static const char* name = "taus/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.taus)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <165> {
-  constexpr static const char* name = "taus/decayMode";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <165> {
+    constexpr static const char* name = "taus/decayMode";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.taus)
       output.push_back(i.decayMode);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <166> {
-  constexpr static const char* name = "taus/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <166> {
+    constexpr static const char* name = "taus/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.taus)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <167> {
-  constexpr static const char* name = "taus/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <167> {
+    constexpr static const char* name = "taus/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.taus)
       output.push_back(i.e());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <168> {
-  constexpr static const char* name = "taus/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <168> {
+    constexpr static const char* name = "taus/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.taus)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <169> {
-  constexpr static const char* name = "taus/isoDeltaBetaCorr";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <169> {
+    constexpr static const char* name = "taus/isoDeltaBetaCorr";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.taus)
       output.push_back(i.isoDeltaBetaCorr);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <170> {
-  constexpr static const char* name = "taus/charge";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <170> {
+    constexpr static const char* name = "taus/charge";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.taus)
       output.push_back(i.charge);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <171> {
-  constexpr static const char* name = "taus/iso";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <171> {
+    constexpr static const char* name = "taus/iso";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.taus)
       output.push_back(i.iso);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <172> {
-  constexpr static const char* name = "taus/looseIsoMVA";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <172> {
+    constexpr static const char* name = "taus/looseIsoMVA";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.taus)
       output.push_back(i.looseIsoMVA);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <173> {
-  constexpr static const char* name = "taus/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <173> {
+    constexpr static const char* name = "taus/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.taus)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <174> {
-  constexpr static const char* name = "taus/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <174> {
+    constexpr static const char* name = "taus/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.taus)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <175> {
-  constexpr static const char* name = "taus/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <175> {
+    constexpr static const char* name = "taus/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.taus)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <176> {
-  constexpr static const char* name = "taus/looseIsoMVAOld";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <176> {
+    constexpr static const char* name = "taus/looseIsoMVAOld";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.taus)
       output.push_back(i.looseIsoMVAOld);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <177> {
-  constexpr static const char* name = "taus/decayModeNew";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <177> {
+    constexpr static const char* name = "taus/decayModeNew";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.taus)
       output.push_back(i.decayModeNew);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <178> {
-  constexpr static const char* name = "photons/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.photons.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <178> {
+    constexpr static const char* name = "photons/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.photons.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <179> {
-  constexpr static const char* name = "photons/superCluster_isValid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <179> {
+    constexpr static const char* name = "photons/superCluster_isValid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.superCluster.isValid());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <180> {
-  constexpr static const char* name = "photons/matchedPF_isValid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <180> {
+    constexpr static const char* name = "photons/matchedPF_isValid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.matchedPF.isValid());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <181> {
-  constexpr static const char* name = "photons/matchedGen_isValid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <181> {
+    constexpr static const char* name = "photons/matchedGen_isValid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.matchedGen.isValid());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <182> {
-  constexpr static const char* name = "photons/emax";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <182> {
+    constexpr static const char* name = "photons/emax";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.emax);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <183> {
-  constexpr static const char* name = "photons/chIsoMax";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <183> {
+    constexpr static const char* name = "photons/chIsoMax";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.chIsoMax);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <184> {
-  constexpr static const char* name = "photons/e2nd";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <184> {
+    constexpr static const char* name = "photons/e2nd";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.e2nd);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <185> {
-  constexpr static const char* name = "photons/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <185> {
+    constexpr static const char* name = "photons/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <186> {
-  constexpr static const char* name = "photons/etop";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <186> {
+    constexpr static const char* name = "photons/etop";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.etop);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <187> {
-  constexpr static const char* name = "photons/phiWidth";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <187> {
+    constexpr static const char* name = "photons/phiWidth";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.phiWidth);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <188> {
-  constexpr static const char* name = "photons/highpt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <188> {
+    constexpr static const char* name = "photons/highpt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.highpt);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <189> {
-  constexpr static const char* name = "photons/mipEnergy";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <189> {
+    constexpr static const char* name = "photons/mipEnergy";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.mipEnergy);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <190> {
-  constexpr static const char* name = "photons/pixelVeto";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <190> {
+    constexpr static const char* name = "photons/pixelVeto";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.pixelVeto);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <191> {
-  constexpr static const char* name = "photons/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <191> {
+    constexpr static const char* name = "photons/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <192> {
-  constexpr static const char* name = "photons/pfPt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <192> {
+    constexpr static const char* name = "photons/pfPt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.pfPt);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <193> {
-  constexpr static const char* name = "photons/eleft";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <193> {
+    constexpr static const char* name = "photons/eleft";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.eleft);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <194> {
-  constexpr static const char* name = "photons/sipip";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <194> {
+    constexpr static const char* name = "photons/sipip";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.sipip);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <195> {
-  constexpr static const char* name = "photons/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <195> {
+    constexpr static const char* name = "photons/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <196> {
-  constexpr static const char* name = "photons/tight";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <196> {
+    constexpr static const char* name = "photons/tight";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.tight);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <197> {
-  constexpr static const char* name = "photons/genIso";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <197> {
+    constexpr static const char* name = "photons/genIso";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.genIso);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <198> {
-  constexpr static const char* name = "photons/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <198> {
+    constexpr static const char* name = "photons/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.e());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <199> {
-  constexpr static const char* name = "photons/sieie";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <199> {
+    constexpr static const char* name = "photons/sieie";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.sieie);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <200> {
-  constexpr static const char* name = "photons/medium";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <200> {
+    constexpr static const char* name = "photons/medium";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.medium);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <201> {
-  constexpr static const char* name = "photons/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <201> {
+    constexpr static const char* name = "photons/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <202> {
-  constexpr static const char* name = "photons/loose";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <202> {
+    constexpr static const char* name = "photons/loose";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.loose);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <203> {
-  constexpr static const char* name = "photons/eright";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <203> {
+    constexpr static const char* name = "photons/eright";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.eright);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <204> {
-  constexpr static const char* name = "photons/nhIso";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <204> {
+    constexpr static const char* name = "photons/nhIso";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.nhIso);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <205> {
-  constexpr static const char* name = "photons/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <205> {
+    constexpr static const char* name = "photons/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <206> {
-  constexpr static const char* name = "photons/ebottom";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <206> {
+    constexpr static const char* name = "photons/ebottom";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.ebottom);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <207> {
-  constexpr static const char* name = "photons/csafeVeto";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <207> {
+    constexpr static const char* name = "photons/csafeVeto";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.csafeVeto);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <208> {
-  constexpr static const char* name = "photons/phIso";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <208> {
+    constexpr static const char* name = "photons/phIso";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.phIso);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <209> {
-  constexpr static const char* name = "photons/regPt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <209> {
+    constexpr static const char* name = "photons/regPt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.regPt);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <210> {
-  constexpr static const char* name = "photons/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <210> {
+    constexpr static const char* name = "photons/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <211> {
-  constexpr static const char* name = "photons/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <211> {
+    constexpr static const char* name = "photons/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <212> {
-  constexpr static const char* name = "photons/r9";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <212> {
+    constexpr static const char* name = "photons/r9";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.r9);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <213> {
-  constexpr static const char* name = "photons/timeSpan";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <213> {
+    constexpr static const char* name = "photons/timeSpan";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.timeSpan);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <214> {
-  constexpr static const char* name = "photons/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <214> {
+    constexpr static const char* name = "photons/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <215> {
-  constexpr static const char* name = "photons/etaWidth";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <215> {
+    constexpr static const char* name = "photons/etaWidth";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.etaWidth);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <216> {
-  constexpr static const char* name = "photons/chIso";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <216> {
+    constexpr static const char* name = "photons/chIso";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.chIso);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <217> {
-  constexpr static const char* name = "photons/hOverE";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <217> {
+    constexpr static const char* name = "photons/hOverE";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.hOverE);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <218> {
-  constexpr static const char* name = "photons/smearedPt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <218> {
+    constexpr static const char* name = "photons/smearedPt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.smearedPt);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <219> {
-  constexpr static const char* name = "photons/time";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <219> {
+    constexpr static const char* name = "photons/time";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.photons)
       output.push_back(i.time);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <220> {
-  constexpr static const char* name = "chsAK4Jets/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.chsAK4Jets.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <220> {
+    constexpr static const char* name = "chsAK4Jets/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.chsAK4Jets.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <221> {
-  constexpr static const char* name = "chsAK4Jets/matchedGenJet_isValid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <221> {
+    constexpr static const char* name = "chsAK4Jets/matchedGenJet_isValid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.matchedGenJet.isValid());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <222> {
-  constexpr static const char* name = "chsAK4Jets/constituents_size";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <222> {
+    constexpr static const char* name = "chsAK4Jets/constituents_size";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.constituents.size());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <223> {
-  constexpr static const char* name = "chsAK4Jets/secondaryVertex_isValid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <223> {
+    constexpr static const char* name = "chsAK4Jets/secondaryVertex_isValid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.secondaryVertex.isValid());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <224> {
-  constexpr static const char* name = "chsAK4Jets/deepCMVAudsg";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <224> {
+    constexpr static const char* name = "chsAK4Jets/deepCMVAudsg";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.deepCMVAudsg);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <225> {
-  constexpr static const char* name = "chsAK4Jets/nhf";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <225> {
+    constexpr static const char* name = "chsAK4Jets/nhf";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.nhf);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <226> {
-  constexpr static const char* name = "chsAK4Jets/ptCorrUp";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <226> {
+    constexpr static const char* name = "chsAK4Jets/ptCorrUp";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.ptCorrUp);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <227> {
-  constexpr static const char* name = "chsAK4Jets/deepCMVAcc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <227> {
+    constexpr static const char* name = "chsAK4Jets/deepCMVAcc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.deepCMVAcc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <228> {
-  constexpr static const char* name = "chsAK4Jets/deepCSVudsg";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <228> {
+    constexpr static const char* name = "chsAK4Jets/deepCSVudsg";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.deepCSVudsg);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <229> {
-  constexpr static const char* name = "chsAK4Jets/cmva";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <229> {
+    constexpr static const char* name = "chsAK4Jets/cmva";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.cmva);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <230> {
-  constexpr static const char* name = "chsAK4Jets/deepCSVcc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <230> {
+    constexpr static const char* name = "chsAK4Jets/deepCSVcc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.deepCSVcc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <231> {
-  constexpr static const char* name = "chsAK4Jets/deepCMVAbb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <231> {
+    constexpr static const char* name = "chsAK4Jets/deepCMVAbb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.deepCMVAbb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <232> {
-  constexpr static const char* name = "chsAK4Jets/deepCSVbb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <232> {
+    constexpr static const char* name = "chsAK4Jets/deepCSVbb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.deepCSVbb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <233> {
-  constexpr static const char* name = "chsAK4Jets/chf";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <233> {
+    constexpr static const char* name = "chsAK4Jets/chf";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.chf);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <234> {
-  constexpr static const char* name = "chsAK4Jets/area";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <234> {
+    constexpr static const char* name = "chsAK4Jets/area";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.area);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <235> {
-  constexpr static const char* name = "chsAK4Jets/nef";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <235> {
+    constexpr static const char* name = "chsAK4Jets/nef";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.nef);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <236> {
-  constexpr static const char* name = "chsAK4Jets/ptCorrDown";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <236> {
+    constexpr static const char* name = "chsAK4Jets/ptCorrDown";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.ptCorrDown);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <237> {
-  constexpr static const char* name = "chsAK4Jets/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <237> {
+    constexpr static const char* name = "chsAK4Jets/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <238> {
-  constexpr static const char* name = "chsAK4Jets/deepCMVAb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <238> {
+    constexpr static const char* name = "chsAK4Jets/deepCMVAb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.deepCMVAb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <239> {
-  constexpr static const char* name = "chsAK4Jets/tight";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <239> {
+    constexpr static const char* name = "chsAK4Jets/tight";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.tight);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <240> {
-  constexpr static const char* name = "chsAK4Jets/puid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <240> {
+    constexpr static const char* name = "chsAK4Jets/puid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.puid);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <241> {
-  constexpr static const char* name = "chsAK4Jets/qgl";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <241> {
+    constexpr static const char* name = "chsAK4Jets/qgl";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.qgl);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <242> {
-  constexpr static const char* name = "chsAK4Jets/csv";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <242> {
+    constexpr static const char* name = "chsAK4Jets/csv";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.csv);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <243> {
-  constexpr static const char* name = "chsAK4Jets/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <243> {
+    constexpr static const char* name = "chsAK4Jets/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.e());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <244> {
-  constexpr static const char* name = "chsAK4Jets/cef";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <244> {
+    constexpr static const char* name = "chsAK4Jets/cef";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.cef);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <245> {
-  constexpr static const char* name = "chsAK4Jets/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <245> {
+    constexpr static const char* name = "chsAK4Jets/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <246> {
-  constexpr static const char* name = "chsAK4Jets/rawPt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <246> {
+    constexpr static const char* name = "chsAK4Jets/rawPt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.rawPt);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <247> {
-  constexpr static const char* name = "chsAK4Jets/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <247> {
+    constexpr static const char* name = "chsAK4Jets/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <248> {
-  constexpr static const char* name = "chsAK4Jets/loose";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <248> {
+    constexpr static const char* name = "chsAK4Jets/loose";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.loose);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <249> {
-  constexpr static const char* name = "chsAK4Jets/deepCMVAc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <249> {
+    constexpr static const char* name = "chsAK4Jets/deepCMVAc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.deepCMVAc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <250> {
-  constexpr static const char* name = "chsAK4Jets/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <250> {
+    constexpr static const char* name = "chsAK4Jets/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <251> {
-  constexpr static const char* name = "chsAK4Jets/monojet";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <251> {
+    constexpr static const char* name = "chsAK4Jets/monojet";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.monojet);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <252> {
-  constexpr static const char* name = "chsAK4Jets/ptSmearDown";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <252> {
+    constexpr static const char* name = "chsAK4Jets/ptSmearDown";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.ptSmearDown);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <253> {
-  constexpr static const char* name = "chsAK4Jets/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <253> {
+    constexpr static const char* name = "chsAK4Jets/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <254> {
-  constexpr static const char* name = "chsAK4Jets/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <254> {
+    constexpr static const char* name = "chsAK4Jets/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <255> {
-  constexpr static const char* name = "chsAK4Jets/deepCSVb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <255> {
+    constexpr static const char* name = "chsAK4Jets/deepCSVb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.deepCSVb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <256> {
-  constexpr static const char* name = "chsAK4Jets/deepCSVc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <256> {
+    constexpr static const char* name = "chsAK4Jets/deepCSVc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.deepCSVc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <257> {
-  constexpr static const char* name = "chsAK4Jets/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <257> {
+    constexpr static const char* name = "chsAK4Jets/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <258> {
-  constexpr static const char* name = "chsAK4Jets/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <258> {
+    constexpr static const char* name = "chsAK4Jets/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <259> {
-  constexpr static const char* name = "chsAK4Jets/ptSmear";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <259> {
+    constexpr static const char* name = "chsAK4Jets/ptSmear";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.ptSmear);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <260> {
-  constexpr static const char* name = "chsAK4Jets/ptSmearUp";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <260> {
+    constexpr static const char* name = "chsAK4Jets/ptSmearUp";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK4Jets)
       output.push_back(i.ptSmearUp);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <261> {
-  constexpr static const char* name = "puppiAK4Jets/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.puppiAK4Jets.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <261> {
+    constexpr static const char* name = "puppiAK4Jets/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.puppiAK4Jets.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <262> {
-  constexpr static const char* name = "puppiAK4Jets/matchedGenJet_isValid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <262> {
+    constexpr static const char* name = "puppiAK4Jets/matchedGenJet_isValid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.matchedGenJet.isValid());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <263> {
-  constexpr static const char* name = "puppiAK4Jets/constituents_size";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <263> {
+    constexpr static const char* name = "puppiAK4Jets/constituents_size";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.constituents.size());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <264> {
-  constexpr static const char* name = "puppiAK4Jets/secondaryVertex_isValid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <264> {
+    constexpr static const char* name = "puppiAK4Jets/secondaryVertex_isValid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.secondaryVertex.isValid());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <265> {
-  constexpr static const char* name = "puppiAK4Jets/deepCMVAudsg";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <265> {
+    constexpr static const char* name = "puppiAK4Jets/deepCMVAudsg";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.deepCMVAudsg);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <266> {
-  constexpr static const char* name = "puppiAK4Jets/nhf";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <266> {
+    constexpr static const char* name = "puppiAK4Jets/nhf";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.nhf);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <267> {
-  constexpr static const char* name = "puppiAK4Jets/ptCorrUp";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <267> {
+    constexpr static const char* name = "puppiAK4Jets/ptCorrUp";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.ptCorrUp);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <268> {
-  constexpr static const char* name = "puppiAK4Jets/deepCMVAcc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <268> {
+    constexpr static const char* name = "puppiAK4Jets/deepCMVAcc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.deepCMVAcc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <269> {
-  constexpr static const char* name = "puppiAK4Jets/deepCSVudsg";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <269> {
+    constexpr static const char* name = "puppiAK4Jets/deepCSVudsg";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.deepCSVudsg);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <270> {
-  constexpr static const char* name = "puppiAK4Jets/cmva";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <270> {
+    constexpr static const char* name = "puppiAK4Jets/cmva";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.cmva);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <271> {
-  constexpr static const char* name = "puppiAK4Jets/deepCSVcc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <271> {
+    constexpr static const char* name = "puppiAK4Jets/deepCSVcc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.deepCSVcc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <272> {
-  constexpr static const char* name = "puppiAK4Jets/deepCMVAbb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <272> {
+    constexpr static const char* name = "puppiAK4Jets/deepCMVAbb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.deepCMVAbb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <273> {
-  constexpr static const char* name = "puppiAK4Jets/deepCSVbb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <273> {
+    constexpr static const char* name = "puppiAK4Jets/deepCSVbb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.deepCSVbb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <274> {
-  constexpr static const char* name = "puppiAK4Jets/chf";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <274> {
+    constexpr static const char* name = "puppiAK4Jets/chf";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.chf);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <275> {
-  constexpr static const char* name = "puppiAK4Jets/area";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <275> {
+    constexpr static const char* name = "puppiAK4Jets/area";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.area);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <276> {
-  constexpr static const char* name = "puppiAK4Jets/nef";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <276> {
+    constexpr static const char* name = "puppiAK4Jets/nef";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.nef);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <277> {
-  constexpr static const char* name = "puppiAK4Jets/ptCorrDown";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <277> {
+    constexpr static const char* name = "puppiAK4Jets/ptCorrDown";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.ptCorrDown);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <278> {
-  constexpr static const char* name = "puppiAK4Jets/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <278> {
+    constexpr static const char* name = "puppiAK4Jets/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <279> {
-  constexpr static const char* name = "puppiAK4Jets/deepCMVAb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <279> {
+    constexpr static const char* name = "puppiAK4Jets/deepCMVAb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.deepCMVAb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <280> {
-  constexpr static const char* name = "puppiAK4Jets/tight";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <280> {
+    constexpr static const char* name = "puppiAK4Jets/tight";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.tight);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <281> {
-  constexpr static const char* name = "puppiAK4Jets/puid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <281> {
+    constexpr static const char* name = "puppiAK4Jets/puid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.puid);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <282> {
-  constexpr static const char* name = "puppiAK4Jets/qgl";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <282> {
+    constexpr static const char* name = "puppiAK4Jets/qgl";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.qgl);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <283> {
-  constexpr static const char* name = "puppiAK4Jets/csv";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <283> {
+    constexpr static const char* name = "puppiAK4Jets/csv";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.csv);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <284> {
-  constexpr static const char* name = "puppiAK4Jets/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <284> {
+    constexpr static const char* name = "puppiAK4Jets/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.e());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <285> {
-  constexpr static const char* name = "puppiAK4Jets/cef";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <285> {
+    constexpr static const char* name = "puppiAK4Jets/cef";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.cef);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <286> {
-  constexpr static const char* name = "puppiAK4Jets/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <286> {
+    constexpr static const char* name = "puppiAK4Jets/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <287> {
-  constexpr static const char* name = "puppiAK4Jets/rawPt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <287> {
+    constexpr static const char* name = "puppiAK4Jets/rawPt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.rawPt);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <288> {
-  constexpr static const char* name = "puppiAK4Jets/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <288> {
+    constexpr static const char* name = "puppiAK4Jets/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <289> {
-  constexpr static const char* name = "puppiAK4Jets/loose";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <289> {
+    constexpr static const char* name = "puppiAK4Jets/loose";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.loose);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <290> {
-  constexpr static const char* name = "puppiAK4Jets/deepCMVAc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <290> {
+    constexpr static const char* name = "puppiAK4Jets/deepCMVAc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.deepCMVAc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <291> {
-  constexpr static const char* name = "puppiAK4Jets/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <291> {
+    constexpr static const char* name = "puppiAK4Jets/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <292> {
-  constexpr static const char* name = "puppiAK4Jets/monojet";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <292> {
+    constexpr static const char* name = "puppiAK4Jets/monojet";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.monojet);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <293> {
-  constexpr static const char* name = "puppiAK4Jets/ptSmearDown";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <293> {
+    constexpr static const char* name = "puppiAK4Jets/ptSmearDown";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.ptSmearDown);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <294> {
-  constexpr static const char* name = "puppiAK4Jets/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <294> {
+    constexpr static const char* name = "puppiAK4Jets/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <295> {
-  constexpr static const char* name = "puppiAK4Jets/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <295> {
+    constexpr static const char* name = "puppiAK4Jets/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <296> {
-  constexpr static const char* name = "puppiAK4Jets/deepCSVb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <296> {
+    constexpr static const char* name = "puppiAK4Jets/deepCSVb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.deepCSVb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <297> {
-  constexpr static const char* name = "puppiAK4Jets/deepCSVc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <297> {
+    constexpr static const char* name = "puppiAK4Jets/deepCSVc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.deepCSVc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <298> {
-  constexpr static const char* name = "puppiAK4Jets/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <298> {
+    constexpr static const char* name = "puppiAK4Jets/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <299> {
-  constexpr static const char* name = "puppiAK4Jets/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <299> {
+    constexpr static const char* name = "puppiAK4Jets/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <300> {
-  constexpr static const char* name = "puppiAK4Jets/ptSmear";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <300> {
+    constexpr static const char* name = "puppiAK4Jets/ptSmear";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.ptSmear);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <301> {
-  constexpr static const char* name = "puppiAK4Jets/ptSmearUp";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <301> {
+    constexpr static const char* name = "puppiAK4Jets/ptSmearUp";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK4Jets)
       output.push_back(i.ptSmearUp);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <302> {
-  constexpr static const char* name = "chsAK8Jets/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.chsAK8Jets.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <302> {
+    constexpr static const char* name = "chsAK8Jets/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.chsAK8Jets.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <303> {
-  constexpr static const char* name = "chsAK8Jets/subjets_size";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <303> {
+    constexpr static const char* name = "chsAK8Jets/subjets_size";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.subjets.size());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <304> {
-  constexpr static const char* name = "chsAK8Jets/deepCMVAudsg";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <304> {
+    constexpr static const char* name = "chsAK8Jets/deepCMVAudsg";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.deepCMVAudsg);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <305> {
-  constexpr static const char* name = "chsAK8Jets/nhf";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <305> {
+    constexpr static const char* name = "chsAK8Jets/nhf";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.nhf);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <306> {
-  constexpr static const char* name = "chsAK8Jets/ptCorrUp";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <306> {
+    constexpr static const char* name = "chsAK8Jets/ptCorrUp";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.ptCorrUp);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <307> {
-  constexpr static const char* name = "chsAK8Jets/cef";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <307> {
+    constexpr static const char* name = "chsAK8Jets/cef";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.cef);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <308> {
-  constexpr static const char* name = "chsAK8Jets/deepCSVudsg";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <308> {
+    constexpr static const char* name = "chsAK8Jets/deepCSVudsg";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.deepCSVudsg);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <309> {
-  constexpr static const char* name = "chsAK8Jets/tight";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <309> {
+    constexpr static const char* name = "chsAK8Jets/tight";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.tight);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <310> {
-  constexpr static const char* name = "chsAK8Jets/cmva";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <310> {
+    constexpr static const char* name = "chsAK8Jets/cmva";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.cmva);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <311> {
-  constexpr static const char* name = "chsAK8Jets/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <311> {
+    constexpr static const char* name = "chsAK8Jets/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <312> {
-  constexpr static const char* name = "chsAK8Jets/deepCMVAbb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <312> {
+    constexpr static const char* name = "chsAK8Jets/deepCMVAbb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.deepCMVAbb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <313> {
-  constexpr static const char* name = "chsAK8Jets/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <313> {
+    constexpr static const char* name = "chsAK8Jets/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <314> {
-  constexpr static const char* name = "chsAK8Jets/htt_frec";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <314> {
+    constexpr static const char* name = "chsAK8Jets/htt_frec";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.htt_frec);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <315> {
-  constexpr static const char* name = "chsAK8Jets/deepCMVAb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <315> {
+    constexpr static const char* name = "chsAK8Jets/deepCMVAb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.deepCMVAb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <316> {
-  constexpr static const char* name = "chsAK8Jets/chf";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <316> {
+    constexpr static const char* name = "chsAK8Jets/chf";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.chf);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <317> {
-  constexpr static const char* name = "chsAK8Jets/area";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <317> {
+    constexpr static const char* name = "chsAK8Jets/area";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.area);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <318> {
-  constexpr static const char* name = "chsAK8Jets/nef";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <318> {
+    constexpr static const char* name = "chsAK8Jets/nef";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.nef);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <319> {
-  constexpr static const char* name = "chsAK8Jets/htt_mass";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <319> {
+    constexpr static const char* name = "chsAK8Jets/htt_mass";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.htt_mass);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <320> {
-  constexpr static const char* name = "chsAK8Jets/ptCorrDown";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <320> {
+    constexpr static const char* name = "chsAK8Jets/ptCorrDown";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.ptCorrDown);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <321> {
-  constexpr static const char* name = "chsAK8Jets/deepCSVbb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <321> {
+    constexpr static const char* name = "chsAK8Jets/deepCSVbb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.deepCSVbb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <322> {
-  constexpr static const char* name = "chsAK8Jets/tau2";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <322> {
+    constexpr static const char* name = "chsAK8Jets/tau2";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.tau2);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <323> {
-  constexpr static const char* name = "chsAK8Jets/tau3";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <323> {
+    constexpr static const char* name = "chsAK8Jets/tau3";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.tau3);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <324> {
-  constexpr static const char* name = "chsAK8Jets/puid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <324> {
+    constexpr static const char* name = "chsAK8Jets/puid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.puid);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <325> {
-  constexpr static const char* name = "chsAK8Jets/tau1";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <325> {
+    constexpr static const char* name = "chsAK8Jets/tau1";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.tau1);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <326> {
-  constexpr static const char* name = "chsAK8Jets/mSD";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <326> {
+    constexpr static const char* name = "chsAK8Jets/mSD";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.mSD);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <327> {
-  constexpr static const char* name = "chsAK8Jets/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <327> {
+    constexpr static const char* name = "chsAK8Jets/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.e());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <328> {
-  constexpr static const char* name = "chsAK8Jets/deepCMVAcc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <328> {
+    constexpr static const char* name = "chsAK8Jets/deepCMVAcc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.deepCMVAcc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <329> {
-  constexpr static const char* name = "chsAK8Jets/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <329> {
+    constexpr static const char* name = "chsAK8Jets/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <330> {
-  constexpr static const char* name = "chsAK8Jets/rawPt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <330> {
+    constexpr static const char* name = "chsAK8Jets/rawPt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.rawPt);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <331> {
-  constexpr static const char* name = "chsAK8Jets/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <331> {
+    constexpr static const char* name = "chsAK8Jets/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <332> {
-  constexpr static const char* name = "chsAK8Jets/double_sub";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <332> {
+    constexpr static const char* name = "chsAK8Jets/double_sub";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.double_sub);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <333> {
-  constexpr static const char* name = "chsAK8Jets/loose";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <333> {
+    constexpr static const char* name = "chsAK8Jets/loose";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.loose);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <334> {
-  constexpr static const char* name = "chsAK8Jets/ptSmear";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <334> {
+    constexpr static const char* name = "chsAK8Jets/ptSmear";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.ptSmear);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <335> {
-  constexpr static const char* name = "chsAK8Jets/deepCMVAc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <335> {
+    constexpr static const char* name = "chsAK8Jets/deepCMVAc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.deepCMVAc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <336> {
-  constexpr static const char* name = "chsAK8Jets/qgl";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <336> {
+    constexpr static const char* name = "chsAK8Jets/qgl";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.qgl);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <337> {
-  constexpr static const char* name = "chsAK8Jets/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <337> {
+    constexpr static const char* name = "chsAK8Jets/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <338> {
-  constexpr static const char* name = "chsAK8Jets/monojet";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <338> {
+    constexpr static const char* name = "chsAK8Jets/monojet";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.monojet);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <339> {
-  constexpr static const char* name = "chsAK8Jets/ptSmearDown";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <339> {
+    constexpr static const char* name = "chsAK8Jets/ptSmearDown";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.ptSmearDown);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <340> {
-  constexpr static const char* name = "chsAK8Jets/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <340> {
+    constexpr static const char* name = "chsAK8Jets/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <341> {
-  constexpr static const char* name = "chsAK8Jets/mPruned";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <341> {
+    constexpr static const char* name = "chsAK8Jets/mPruned";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.mPruned);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <342> {
-  constexpr static const char* name = "chsAK8Jets/tau1SD";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <342> {
+    constexpr static const char* name = "chsAK8Jets/tau1SD";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.tau1SD);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <343> {
-  constexpr static const char* name = "chsAK8Jets/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <343> {
+    constexpr static const char* name = "chsAK8Jets/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <344> {
-  constexpr static const char* name = "chsAK8Jets/csv";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <344> {
+    constexpr static const char* name = "chsAK8Jets/csv";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.csv);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <345> {
-  constexpr static const char* name = "chsAK8Jets/deepCSVb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <345> {
+    constexpr static const char* name = "chsAK8Jets/deepCSVb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.deepCSVb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <346> {
-  constexpr static const char* name = "chsAK8Jets/deepCSVc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <346> {
+    constexpr static const char* name = "chsAK8Jets/deepCSVc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.deepCSVc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <347> {
-  constexpr static const char* name = "chsAK8Jets/tau3SD";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <347> {
+    constexpr static const char* name = "chsAK8Jets/tau3SD";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.tau3SD);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <348> {
-  constexpr static const char* name = "chsAK8Jets/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <348> {
+    constexpr static const char* name = "chsAK8Jets/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <349> {
-  constexpr static const char* name = "chsAK8Jets/deepCSVcc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <349> {
+    constexpr static const char* name = "chsAK8Jets/deepCSVcc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.deepCSVcc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <350> {
-  constexpr static const char* name = "chsAK8Jets/tau2SD";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <350> {
+    constexpr static const char* name = "chsAK8Jets/tau2SD";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.tau2SD);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <351> {
-  constexpr static const char* name = "chsAK8Jets/ptSmearUp";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <351> {
+    constexpr static const char* name = "chsAK8Jets/ptSmearUp";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Jets)
       output.push_back(i.ptSmearUp);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <352> {
-  constexpr static const char* name = "chsAK8Subjets/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.chsAK8Subjets.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <352> {
+    constexpr static const char* name = "chsAK8Subjets/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.chsAK8Subjets.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <353> {
-  constexpr static const char* name = "chsAK8Subjets/deepCMVAudsg";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <353> {
+    constexpr static const char* name = "chsAK8Subjets/deepCMVAudsg";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.deepCMVAudsg);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <354> {
-  constexpr static const char* name = "chsAK8Subjets/deepCMVAbb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <354> {
+    constexpr static const char* name = "chsAK8Subjets/deepCMVAbb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.deepCMVAbb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <355> {
-  constexpr static const char* name = "chsAK8Subjets/deepCSVudsg";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <355> {
+    constexpr static const char* name = "chsAK8Subjets/deepCSVudsg";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.deepCSVudsg);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <356> {
-  constexpr static const char* name = "chsAK8Subjets/cmva";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <356> {
+    constexpr static const char* name = "chsAK8Subjets/cmva";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.cmva);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <357> {
-  constexpr static const char* name = "chsAK8Subjets/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <357> {
+    constexpr static const char* name = "chsAK8Subjets/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <358> {
-  constexpr static const char* name = "chsAK8Subjets/deepCSVbb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <358> {
+    constexpr static const char* name = "chsAK8Subjets/deepCSVbb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.deepCSVbb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <359> {
-  constexpr static const char* name = "chsAK8Subjets/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <359> {
+    constexpr static const char* name = "chsAK8Subjets/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <360> {
-  constexpr static const char* name = "chsAK8Subjets/deepCMVAb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <360> {
+    constexpr static const char* name = "chsAK8Subjets/deepCMVAb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.deepCMVAb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <361> {
-  constexpr static const char* name = "chsAK8Subjets/deepCMVAc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <361> {
+    constexpr static const char* name = "chsAK8Subjets/deepCMVAc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.deepCMVAc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <362> {
-  constexpr static const char* name = "chsAK8Subjets/qgl";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <362> {
+    constexpr static const char* name = "chsAK8Subjets/qgl";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.qgl);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <363> {
-  constexpr static const char* name = "chsAK8Subjets/csv";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <363> {
+    constexpr static const char* name = "chsAK8Subjets/csv";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.csv);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <364> {
-  constexpr static const char* name = "chsAK8Subjets/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <364> {
+    constexpr static const char* name = "chsAK8Subjets/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.e());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <365> {
-  constexpr static const char* name = "chsAK8Subjets/deepCMVAcc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <365> {
+    constexpr static const char* name = "chsAK8Subjets/deepCMVAcc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.deepCMVAcc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <366> {
-  constexpr static const char* name = "chsAK8Subjets/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <366> {
+    constexpr static const char* name = "chsAK8Subjets/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <367> {
-  constexpr static const char* name = "chsAK8Subjets/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <367> {
+    constexpr static const char* name = "chsAK8Subjets/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <368> {
-  constexpr static const char* name = "chsAK8Subjets/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <368> {
+    constexpr static const char* name = "chsAK8Subjets/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <369> {
-  constexpr static const char* name = "chsAK8Subjets/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <369> {
+    constexpr static const char* name = "chsAK8Subjets/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <370> {
-  constexpr static const char* name = "chsAK8Subjets/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <370> {
+    constexpr static const char* name = "chsAK8Subjets/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <371> {
-  constexpr static const char* name = "chsAK8Subjets/deepCSVb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <371> {
+    constexpr static const char* name = "chsAK8Subjets/deepCSVb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.deepCSVb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <372> {
-  constexpr static const char* name = "chsAK8Subjets/deepCSVc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <372> {
+    constexpr static const char* name = "chsAK8Subjets/deepCSVc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.deepCSVc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <373> {
-  constexpr static const char* name = "chsAK8Subjets/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <373> {
+    constexpr static const char* name = "chsAK8Subjets/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <374> {
-  constexpr static const char* name = "chsAK8Subjets/deepCSVcc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <374> {
+    constexpr static const char* name = "chsAK8Subjets/deepCSVcc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsAK8Subjets)
       output.push_back(i.deepCSVcc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <375> {
-  constexpr static const char* name = "chsCA15Jets/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.chsCA15Jets.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <375> {
+    constexpr static const char* name = "chsCA15Jets/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.chsCA15Jets.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <376> {
-  constexpr static const char* name = "chsCA15Jets/subjets_size";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <376> {
+    constexpr static const char* name = "chsCA15Jets/subjets_size";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.subjets.size());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <377> {
-  constexpr static const char* name = "chsCA15Jets/deepCMVAudsg";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <377> {
+    constexpr static const char* name = "chsCA15Jets/deepCMVAudsg";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.deepCMVAudsg);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <378> {
-  constexpr static const char* name = "chsCA15Jets/nhf";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <378> {
+    constexpr static const char* name = "chsCA15Jets/nhf";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.nhf);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <379> {
-  constexpr static const char* name = "chsCA15Jets/ptCorrUp";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <379> {
+    constexpr static const char* name = "chsCA15Jets/ptCorrUp";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.ptCorrUp);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <380> {
-  constexpr static const char* name = "chsCA15Jets/cef";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <380> {
+    constexpr static const char* name = "chsCA15Jets/cef";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.cef);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <381> {
-  constexpr static const char* name = "chsCA15Jets/deepCSVudsg";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <381> {
+    constexpr static const char* name = "chsCA15Jets/deepCSVudsg";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.deepCSVudsg);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <382> {
-  constexpr static const char* name = "chsCA15Jets/tight";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <382> {
+    constexpr static const char* name = "chsCA15Jets/tight";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.tight);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <383> {
-  constexpr static const char* name = "chsCA15Jets/cmva";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <383> {
+    constexpr static const char* name = "chsCA15Jets/cmva";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.cmva);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <384> {
-  constexpr static const char* name = "chsCA15Jets/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <384> {
+    constexpr static const char* name = "chsCA15Jets/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <385> {
-  constexpr static const char* name = "chsCA15Jets/deepCMVAbb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <385> {
+    constexpr static const char* name = "chsCA15Jets/deepCMVAbb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.deepCMVAbb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <386> {
-  constexpr static const char* name = "chsCA15Jets/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <386> {
+    constexpr static const char* name = "chsCA15Jets/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <387> {
-  constexpr static const char* name = "chsCA15Jets/htt_frec";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <387> {
+    constexpr static const char* name = "chsCA15Jets/htt_frec";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.htt_frec);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <388> {
-  constexpr static const char* name = "chsCA15Jets/deepCMVAb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <388> {
+    constexpr static const char* name = "chsCA15Jets/deepCMVAb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.deepCMVAb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <389> {
-  constexpr static const char* name = "chsCA15Jets/chf";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <389> {
+    constexpr static const char* name = "chsCA15Jets/chf";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.chf);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <390> {
-  constexpr static const char* name = "chsCA15Jets/area";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <390> {
+    constexpr static const char* name = "chsCA15Jets/area";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.area);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <391> {
-  constexpr static const char* name = "chsCA15Jets/nef";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <391> {
+    constexpr static const char* name = "chsCA15Jets/nef";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.nef);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <392> {
-  constexpr static const char* name = "chsCA15Jets/htt_mass";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <392> {
+    constexpr static const char* name = "chsCA15Jets/htt_mass";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.htt_mass);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <393> {
-  constexpr static const char* name = "chsCA15Jets/ptCorrDown";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <393> {
+    constexpr static const char* name = "chsCA15Jets/ptCorrDown";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.ptCorrDown);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <394> {
-  constexpr static const char* name = "chsCA15Jets/deepCSVbb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <394> {
+    constexpr static const char* name = "chsCA15Jets/deepCSVbb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.deepCSVbb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <395> {
-  constexpr static const char* name = "chsCA15Jets/tau2";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <395> {
+    constexpr static const char* name = "chsCA15Jets/tau2";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.tau2);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <396> {
-  constexpr static const char* name = "chsCA15Jets/tau3";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <396> {
+    constexpr static const char* name = "chsCA15Jets/tau3";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.tau3);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <397> {
-  constexpr static const char* name = "chsCA15Jets/puid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <397> {
+    constexpr static const char* name = "chsCA15Jets/puid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.puid);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <398> {
-  constexpr static const char* name = "chsCA15Jets/tau1";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <398> {
+    constexpr static const char* name = "chsCA15Jets/tau1";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.tau1);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <399> {
-  constexpr static const char* name = "chsCA15Jets/mSD";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <399> {
+    constexpr static const char* name = "chsCA15Jets/mSD";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.mSD);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <400> {
-  constexpr static const char* name = "chsCA15Jets/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <400> {
+    constexpr static const char* name = "chsCA15Jets/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.e());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <401> {
-  constexpr static const char* name = "chsCA15Jets/deepCMVAcc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <401> {
+    constexpr static const char* name = "chsCA15Jets/deepCMVAcc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.deepCMVAcc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <402> {
-  constexpr static const char* name = "chsCA15Jets/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <402> {
+    constexpr static const char* name = "chsCA15Jets/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <403> {
-  constexpr static const char* name = "chsCA15Jets/rawPt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <403> {
+    constexpr static const char* name = "chsCA15Jets/rawPt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.rawPt);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <404> {
-  constexpr static const char* name = "chsCA15Jets/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <404> {
+    constexpr static const char* name = "chsCA15Jets/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <405> {
-  constexpr static const char* name = "chsCA15Jets/double_sub";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <405> {
+    constexpr static const char* name = "chsCA15Jets/double_sub";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.double_sub);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <406> {
-  constexpr static const char* name = "chsCA15Jets/loose";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <406> {
+    constexpr static const char* name = "chsCA15Jets/loose";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.loose);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <407> {
-  constexpr static const char* name = "chsCA15Jets/ptSmear";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <407> {
+    constexpr static const char* name = "chsCA15Jets/ptSmear";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.ptSmear);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <408> {
-  constexpr static const char* name = "chsCA15Jets/deepCMVAc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <408> {
+    constexpr static const char* name = "chsCA15Jets/deepCMVAc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.deepCMVAc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <409> {
-  constexpr static const char* name = "chsCA15Jets/qgl";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <409> {
+    constexpr static const char* name = "chsCA15Jets/qgl";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.qgl);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <410> {
-  constexpr static const char* name = "chsCA15Jets/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <410> {
+    constexpr static const char* name = "chsCA15Jets/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <411> {
-  constexpr static const char* name = "chsCA15Jets/monojet";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <411> {
+    constexpr static const char* name = "chsCA15Jets/monojet";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.monojet);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <412> {
-  constexpr static const char* name = "chsCA15Jets/ptSmearDown";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <412> {
+    constexpr static const char* name = "chsCA15Jets/ptSmearDown";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.ptSmearDown);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <413> {
-  constexpr static const char* name = "chsCA15Jets/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <413> {
+    constexpr static const char* name = "chsCA15Jets/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <414> {
-  constexpr static const char* name = "chsCA15Jets/mPruned";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <414> {
+    constexpr static const char* name = "chsCA15Jets/mPruned";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.mPruned);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <415> {
-  constexpr static const char* name = "chsCA15Jets/tau1SD";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <415> {
+    constexpr static const char* name = "chsCA15Jets/tau1SD";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.tau1SD);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <416> {
-  constexpr static const char* name = "chsCA15Jets/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <416> {
+    constexpr static const char* name = "chsCA15Jets/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <417> {
-  constexpr static const char* name = "chsCA15Jets/csv";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <417> {
+    constexpr static const char* name = "chsCA15Jets/csv";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.csv);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <418> {
-  constexpr static const char* name = "chsCA15Jets/deepCSVb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <418> {
+    constexpr static const char* name = "chsCA15Jets/deepCSVb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.deepCSVb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <419> {
-  constexpr static const char* name = "chsCA15Jets/deepCSVc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <419> {
+    constexpr static const char* name = "chsCA15Jets/deepCSVc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.deepCSVc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <420> {
-  constexpr static const char* name = "chsCA15Jets/tau3SD";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <420> {
+    constexpr static const char* name = "chsCA15Jets/tau3SD";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.tau3SD);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <421> {
-  constexpr static const char* name = "chsCA15Jets/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <421> {
+    constexpr static const char* name = "chsCA15Jets/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <422> {
-  constexpr static const char* name = "chsCA15Jets/deepCSVcc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <422> {
+    constexpr static const char* name = "chsCA15Jets/deepCSVcc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.deepCSVcc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <423> {
-  constexpr static const char* name = "chsCA15Jets/tau2SD";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <423> {
+    constexpr static const char* name = "chsCA15Jets/tau2SD";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.tau2SD);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <424> {
-  constexpr static const char* name = "chsCA15Jets/ptSmearUp";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <424> {
+    constexpr static const char* name = "chsCA15Jets/ptSmearUp";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Jets)
       output.push_back(i.ptSmearUp);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <425> {
-  constexpr static const char* name = "chsCA15Subjets/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.chsCA15Subjets.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <425> {
+    constexpr static const char* name = "chsCA15Subjets/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.chsCA15Subjets.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <426> {
-  constexpr static const char* name = "chsCA15Subjets/deepCMVAudsg";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <426> {
+    constexpr static const char* name = "chsCA15Subjets/deepCMVAudsg";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.deepCMVAudsg);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <427> {
-  constexpr static const char* name = "chsCA15Subjets/deepCMVAbb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <427> {
+    constexpr static const char* name = "chsCA15Subjets/deepCMVAbb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.deepCMVAbb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <428> {
-  constexpr static const char* name = "chsCA15Subjets/deepCSVudsg";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <428> {
+    constexpr static const char* name = "chsCA15Subjets/deepCSVudsg";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.deepCSVudsg);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <429> {
-  constexpr static const char* name = "chsCA15Subjets/cmva";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <429> {
+    constexpr static const char* name = "chsCA15Subjets/cmva";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.cmva);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <430> {
-  constexpr static const char* name = "chsCA15Subjets/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <430> {
+    constexpr static const char* name = "chsCA15Subjets/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <431> {
-  constexpr static const char* name = "chsCA15Subjets/deepCSVbb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <431> {
+    constexpr static const char* name = "chsCA15Subjets/deepCSVbb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.deepCSVbb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <432> {
-  constexpr static const char* name = "chsCA15Subjets/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <432> {
+    constexpr static const char* name = "chsCA15Subjets/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <433> {
-  constexpr static const char* name = "chsCA15Subjets/deepCMVAb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <433> {
+    constexpr static const char* name = "chsCA15Subjets/deepCMVAb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.deepCMVAb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <434> {
-  constexpr static const char* name = "chsCA15Subjets/deepCMVAc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <434> {
+    constexpr static const char* name = "chsCA15Subjets/deepCMVAc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.deepCMVAc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <435> {
-  constexpr static const char* name = "chsCA15Subjets/qgl";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <435> {
+    constexpr static const char* name = "chsCA15Subjets/qgl";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.qgl);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <436> {
-  constexpr static const char* name = "chsCA15Subjets/csv";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <436> {
+    constexpr static const char* name = "chsCA15Subjets/csv";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.csv);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <437> {
-  constexpr static const char* name = "chsCA15Subjets/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <437> {
+    constexpr static const char* name = "chsCA15Subjets/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.e());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <438> {
-  constexpr static const char* name = "chsCA15Subjets/deepCMVAcc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <438> {
+    constexpr static const char* name = "chsCA15Subjets/deepCMVAcc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.deepCMVAcc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <439> {
-  constexpr static const char* name = "chsCA15Subjets/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <439> {
+    constexpr static const char* name = "chsCA15Subjets/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <440> {
-  constexpr static const char* name = "chsCA15Subjets/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <440> {
+    constexpr static const char* name = "chsCA15Subjets/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <441> {
-  constexpr static const char* name = "chsCA15Subjets/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <441> {
+    constexpr static const char* name = "chsCA15Subjets/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <442> {
-  constexpr static const char* name = "chsCA15Subjets/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <442> {
+    constexpr static const char* name = "chsCA15Subjets/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <443> {
-  constexpr static const char* name = "chsCA15Subjets/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <443> {
+    constexpr static const char* name = "chsCA15Subjets/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <444> {
-  constexpr static const char* name = "chsCA15Subjets/deepCSVb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <444> {
+    constexpr static const char* name = "chsCA15Subjets/deepCSVb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.deepCSVb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <445> {
-  constexpr static const char* name = "chsCA15Subjets/deepCSVc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <445> {
+    constexpr static const char* name = "chsCA15Subjets/deepCSVc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.deepCSVc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <446> {
-  constexpr static const char* name = "chsCA15Subjets/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <446> {
+    constexpr static const char* name = "chsCA15Subjets/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <447> {
-  constexpr static const char* name = "chsCA15Subjets/deepCSVcc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <447> {
+    constexpr static const char* name = "chsCA15Subjets/deepCSVcc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.chsCA15Subjets)
       output.push_back(i.deepCSVcc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <448> {
-  constexpr static const char* name = "puppiAK8Jets/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.puppiAK8Jets.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <448> {
+    constexpr static const char* name = "puppiAK8Jets/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.puppiAK8Jets.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <449> {
-  constexpr static const char* name = "puppiAK8Jets/subjets_size";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <449> {
+    constexpr static const char* name = "puppiAK8Jets/subjets_size";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.subjets.size());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <450> {
-  constexpr static const char* name = "puppiAK8Jets/deepCMVAudsg";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <450> {
+    constexpr static const char* name = "puppiAK8Jets/deepCMVAudsg";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.deepCMVAudsg);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <451> {
-  constexpr static const char* name = "puppiAK8Jets/nhf";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <451> {
+    constexpr static const char* name = "puppiAK8Jets/nhf";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.nhf);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <452> {
-  constexpr static const char* name = "puppiAK8Jets/ptCorrUp";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <452> {
+    constexpr static const char* name = "puppiAK8Jets/ptCorrUp";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.ptCorrUp);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <453> {
-  constexpr static const char* name = "puppiAK8Jets/cef";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <453> {
+    constexpr static const char* name = "puppiAK8Jets/cef";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.cef);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <454> {
-  constexpr static const char* name = "puppiAK8Jets/deepCSVudsg";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <454> {
+    constexpr static const char* name = "puppiAK8Jets/deepCSVudsg";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.deepCSVudsg);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <455> {
-  constexpr static const char* name = "puppiAK8Jets/tight";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <455> {
+    constexpr static const char* name = "puppiAK8Jets/tight";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.tight);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <456> {
-  constexpr static const char* name = "puppiAK8Jets/cmva";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <456> {
+    constexpr static const char* name = "puppiAK8Jets/cmva";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.cmva);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <457> {
-  constexpr static const char* name = "puppiAK8Jets/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <457> {
+    constexpr static const char* name = "puppiAK8Jets/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <458> {
-  constexpr static const char* name = "puppiAK8Jets/deepCMVAbb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <458> {
+    constexpr static const char* name = "puppiAK8Jets/deepCMVAbb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.deepCMVAbb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <459> {
-  constexpr static const char* name = "puppiAK8Jets/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <459> {
+    constexpr static const char* name = "puppiAK8Jets/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <460> {
-  constexpr static const char* name = "puppiAK8Jets/htt_frec";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <460> {
+    constexpr static const char* name = "puppiAK8Jets/htt_frec";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.htt_frec);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <461> {
-  constexpr static const char* name = "puppiAK8Jets/deepCMVAb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <461> {
+    constexpr static const char* name = "puppiAK8Jets/deepCMVAb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.deepCMVAb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <462> {
-  constexpr static const char* name = "puppiAK8Jets/chf";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <462> {
+    constexpr static const char* name = "puppiAK8Jets/chf";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.chf);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <463> {
-  constexpr static const char* name = "puppiAK8Jets/area";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <463> {
+    constexpr static const char* name = "puppiAK8Jets/area";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.area);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <464> {
-  constexpr static const char* name = "puppiAK8Jets/nef";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <464> {
+    constexpr static const char* name = "puppiAK8Jets/nef";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.nef);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <465> {
-  constexpr static const char* name = "puppiAK8Jets/htt_mass";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <465> {
+    constexpr static const char* name = "puppiAK8Jets/htt_mass";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.htt_mass);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <466> {
-  constexpr static const char* name = "puppiAK8Jets/ptCorrDown";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <466> {
+    constexpr static const char* name = "puppiAK8Jets/ptCorrDown";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.ptCorrDown);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <467> {
-  constexpr static const char* name = "puppiAK8Jets/deepCSVbb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <467> {
+    constexpr static const char* name = "puppiAK8Jets/deepCSVbb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.deepCSVbb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <468> {
-  constexpr static const char* name = "puppiAK8Jets/tau2";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <468> {
+    constexpr static const char* name = "puppiAK8Jets/tau2";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.tau2);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <469> {
-  constexpr static const char* name = "puppiAK8Jets/tau3";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <469> {
+    constexpr static const char* name = "puppiAK8Jets/tau3";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.tau3);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <470> {
-  constexpr static const char* name = "puppiAK8Jets/puid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <470> {
+    constexpr static const char* name = "puppiAK8Jets/puid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.puid);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <471> {
-  constexpr static const char* name = "puppiAK8Jets/tau1";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <471> {
+    constexpr static const char* name = "puppiAK8Jets/tau1";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.tau1);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <472> {
-  constexpr static const char* name = "puppiAK8Jets/mSD";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <472> {
+    constexpr static const char* name = "puppiAK8Jets/mSD";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.mSD);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <473> {
-  constexpr static const char* name = "puppiAK8Jets/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <473> {
+    constexpr static const char* name = "puppiAK8Jets/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.e());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <474> {
-  constexpr static const char* name = "puppiAK8Jets/deepCMVAcc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <474> {
+    constexpr static const char* name = "puppiAK8Jets/deepCMVAcc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.deepCMVAcc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <475> {
-  constexpr static const char* name = "puppiAK8Jets/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <475> {
+    constexpr static const char* name = "puppiAK8Jets/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <476> {
-  constexpr static const char* name = "puppiAK8Jets/rawPt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <476> {
+    constexpr static const char* name = "puppiAK8Jets/rawPt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.rawPt);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <477> {
-  constexpr static const char* name = "puppiAK8Jets/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <477> {
+    constexpr static const char* name = "puppiAK8Jets/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <478> {
-  constexpr static const char* name = "puppiAK8Jets/double_sub";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <478> {
+    constexpr static const char* name = "puppiAK8Jets/double_sub";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.double_sub);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <479> {
-  constexpr static const char* name = "puppiAK8Jets/loose";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <479> {
+    constexpr static const char* name = "puppiAK8Jets/loose";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.loose);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <480> {
-  constexpr static const char* name = "puppiAK8Jets/ptSmear";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <480> {
+    constexpr static const char* name = "puppiAK8Jets/ptSmear";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.ptSmear);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <481> {
-  constexpr static const char* name = "puppiAK8Jets/deepCMVAc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <481> {
+    constexpr static const char* name = "puppiAK8Jets/deepCMVAc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.deepCMVAc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <482> {
-  constexpr static const char* name = "puppiAK8Jets/qgl";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <482> {
+    constexpr static const char* name = "puppiAK8Jets/qgl";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.qgl);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <483> {
-  constexpr static const char* name = "puppiAK8Jets/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <483> {
+    constexpr static const char* name = "puppiAK8Jets/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <484> {
-  constexpr static const char* name = "puppiAK8Jets/monojet";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <484> {
+    constexpr static const char* name = "puppiAK8Jets/monojet";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.monojet);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <485> {
-  constexpr static const char* name = "puppiAK8Jets/ptSmearDown";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <485> {
+    constexpr static const char* name = "puppiAK8Jets/ptSmearDown";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.ptSmearDown);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <486> {
-  constexpr static const char* name = "puppiAK8Jets/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <486> {
+    constexpr static const char* name = "puppiAK8Jets/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <487> {
-  constexpr static const char* name = "puppiAK8Jets/mPruned";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <487> {
+    constexpr static const char* name = "puppiAK8Jets/mPruned";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.mPruned);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <488> {
-  constexpr static const char* name = "puppiAK8Jets/tau1SD";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <488> {
+    constexpr static const char* name = "puppiAK8Jets/tau1SD";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.tau1SD);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <489> {
-  constexpr static const char* name = "puppiAK8Jets/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <489> {
+    constexpr static const char* name = "puppiAK8Jets/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <490> {
-  constexpr static const char* name = "puppiAK8Jets/csv";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <490> {
+    constexpr static const char* name = "puppiAK8Jets/csv";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.csv);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <491> {
-  constexpr static const char* name = "puppiAK8Jets/deepCSVb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <491> {
+    constexpr static const char* name = "puppiAK8Jets/deepCSVb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.deepCSVb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <492> {
-  constexpr static const char* name = "puppiAK8Jets/deepCSVc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <492> {
+    constexpr static const char* name = "puppiAK8Jets/deepCSVc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.deepCSVc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <493> {
-  constexpr static const char* name = "puppiAK8Jets/tau3SD";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <493> {
+    constexpr static const char* name = "puppiAK8Jets/tau3SD";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.tau3SD);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <494> {
-  constexpr static const char* name = "puppiAK8Jets/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <494> {
+    constexpr static const char* name = "puppiAK8Jets/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <495> {
-  constexpr static const char* name = "puppiAK8Jets/deepCSVcc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <495> {
+    constexpr static const char* name = "puppiAK8Jets/deepCSVcc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.deepCSVcc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <496> {
-  constexpr static const char* name = "puppiAK8Jets/tau2SD";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <496> {
+    constexpr static const char* name = "puppiAK8Jets/tau2SD";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.tau2SD);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <497> {
-  constexpr static const char* name = "puppiAK8Jets/ptSmearUp";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <497> {
+    constexpr static const char* name = "puppiAK8Jets/ptSmearUp";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Jets)
       output.push_back(i.ptSmearUp);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <498> {
-  constexpr static const char* name = "puppiAK8Subjets/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.puppiAK8Subjets.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <498> {
+    constexpr static const char* name = "puppiAK8Subjets/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.puppiAK8Subjets.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <499> {
-  constexpr static const char* name = "puppiAK8Subjets/deepCMVAudsg";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <499> {
+    constexpr static const char* name = "puppiAK8Subjets/deepCMVAudsg";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.deepCMVAudsg);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <500> {
-  constexpr static const char* name = "puppiAK8Subjets/deepCMVAbb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <500> {
+    constexpr static const char* name = "puppiAK8Subjets/deepCMVAbb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.deepCMVAbb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <501> {
-  constexpr static const char* name = "puppiAK8Subjets/deepCSVudsg";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <501> {
+    constexpr static const char* name = "puppiAK8Subjets/deepCSVudsg";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.deepCSVudsg);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <502> {
-  constexpr static const char* name = "puppiAK8Subjets/cmva";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <502> {
+    constexpr static const char* name = "puppiAK8Subjets/cmva";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.cmva);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <503> {
-  constexpr static const char* name = "puppiAK8Subjets/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <503> {
+    constexpr static const char* name = "puppiAK8Subjets/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <504> {
-  constexpr static const char* name = "puppiAK8Subjets/deepCSVbb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <504> {
+    constexpr static const char* name = "puppiAK8Subjets/deepCSVbb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.deepCSVbb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <505> {
-  constexpr static const char* name = "puppiAK8Subjets/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <505> {
+    constexpr static const char* name = "puppiAK8Subjets/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <506> {
-  constexpr static const char* name = "puppiAK8Subjets/deepCMVAb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <506> {
+    constexpr static const char* name = "puppiAK8Subjets/deepCMVAb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.deepCMVAb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <507> {
-  constexpr static const char* name = "puppiAK8Subjets/deepCMVAc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <507> {
+    constexpr static const char* name = "puppiAK8Subjets/deepCMVAc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.deepCMVAc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <508> {
-  constexpr static const char* name = "puppiAK8Subjets/qgl";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <508> {
+    constexpr static const char* name = "puppiAK8Subjets/qgl";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.qgl);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <509> {
-  constexpr static const char* name = "puppiAK8Subjets/csv";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <509> {
+    constexpr static const char* name = "puppiAK8Subjets/csv";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.csv);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <510> {
-  constexpr static const char* name = "puppiAK8Subjets/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <510> {
+    constexpr static const char* name = "puppiAK8Subjets/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.e());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <511> {
-  constexpr static const char* name = "puppiAK8Subjets/deepCMVAcc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <511> {
+    constexpr static const char* name = "puppiAK8Subjets/deepCMVAcc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.deepCMVAcc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <512> {
-  constexpr static const char* name = "puppiAK8Subjets/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <512> {
+    constexpr static const char* name = "puppiAK8Subjets/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <513> {
-  constexpr static const char* name = "puppiAK8Subjets/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <513> {
+    constexpr static const char* name = "puppiAK8Subjets/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <514> {
-  constexpr static const char* name = "puppiAK8Subjets/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <514> {
+    constexpr static const char* name = "puppiAK8Subjets/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <515> {
-  constexpr static const char* name = "puppiAK8Subjets/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <515> {
+    constexpr static const char* name = "puppiAK8Subjets/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <516> {
-  constexpr static const char* name = "puppiAK8Subjets/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <516> {
+    constexpr static const char* name = "puppiAK8Subjets/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <517> {
-  constexpr static const char* name = "puppiAK8Subjets/deepCSVb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <517> {
+    constexpr static const char* name = "puppiAK8Subjets/deepCSVb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.deepCSVb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <518> {
-  constexpr static const char* name = "puppiAK8Subjets/deepCSVc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <518> {
+    constexpr static const char* name = "puppiAK8Subjets/deepCSVc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.deepCSVc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <519> {
-  constexpr static const char* name = "puppiAK8Subjets/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <519> {
+    constexpr static const char* name = "puppiAK8Subjets/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <520> {
-  constexpr static const char* name = "puppiAK8Subjets/deepCSVcc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <520> {
+    constexpr static const char* name = "puppiAK8Subjets/deepCSVcc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiAK8Subjets)
       output.push_back(i.deepCSVcc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <521> {
-  constexpr static const char* name = "puppiCA15Jets/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.puppiCA15Jets.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <521> {
+    constexpr static const char* name = "puppiCA15Jets/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.puppiCA15Jets.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <522> {
-  constexpr static const char* name = "puppiCA15Jets/subjets_size";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <522> {
+    constexpr static const char* name = "puppiCA15Jets/subjets_size";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.subjets.size());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <523> {
-  constexpr static const char* name = "puppiCA15Jets/deepCMVAudsg";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <523> {
+    constexpr static const char* name = "puppiCA15Jets/deepCMVAudsg";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.deepCMVAudsg);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <524> {
-  constexpr static const char* name = "puppiCA15Jets/nhf";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <524> {
+    constexpr static const char* name = "puppiCA15Jets/nhf";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.nhf);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <525> {
-  constexpr static const char* name = "puppiCA15Jets/ptCorrUp";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <525> {
+    constexpr static const char* name = "puppiCA15Jets/ptCorrUp";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.ptCorrUp);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <526> {
-  constexpr static const char* name = "puppiCA15Jets/cef";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <526> {
+    constexpr static const char* name = "puppiCA15Jets/cef";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.cef);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <527> {
-  constexpr static const char* name = "puppiCA15Jets/deepCSVudsg";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <527> {
+    constexpr static const char* name = "puppiCA15Jets/deepCSVudsg";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.deepCSVudsg);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <528> {
-  constexpr static const char* name = "puppiCA15Jets/tight";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <528> {
+    constexpr static const char* name = "puppiCA15Jets/tight";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.tight);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <529> {
-  constexpr static const char* name = "puppiCA15Jets/cmva";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <529> {
+    constexpr static const char* name = "puppiCA15Jets/cmva";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.cmva);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <530> {
-  constexpr static const char* name = "puppiCA15Jets/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <530> {
+    constexpr static const char* name = "puppiCA15Jets/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <531> {
-  constexpr static const char* name = "puppiCA15Jets/deepCMVAbb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <531> {
+    constexpr static const char* name = "puppiCA15Jets/deepCMVAbb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.deepCMVAbb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <532> {
-  constexpr static const char* name = "puppiCA15Jets/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <532> {
+    constexpr static const char* name = "puppiCA15Jets/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <533> {
-  constexpr static const char* name = "puppiCA15Jets/htt_frec";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <533> {
+    constexpr static const char* name = "puppiCA15Jets/htt_frec";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.htt_frec);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <534> {
-  constexpr static const char* name = "puppiCA15Jets/deepCMVAb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <534> {
+    constexpr static const char* name = "puppiCA15Jets/deepCMVAb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.deepCMVAb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <535> {
-  constexpr static const char* name = "puppiCA15Jets/chf";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <535> {
+    constexpr static const char* name = "puppiCA15Jets/chf";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.chf);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <536> {
-  constexpr static const char* name = "puppiCA15Jets/area";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <536> {
+    constexpr static const char* name = "puppiCA15Jets/area";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.area);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <537> {
-  constexpr static const char* name = "puppiCA15Jets/nef";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <537> {
+    constexpr static const char* name = "puppiCA15Jets/nef";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.nef);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <538> {
-  constexpr static const char* name = "puppiCA15Jets/htt_mass";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <538> {
+    constexpr static const char* name = "puppiCA15Jets/htt_mass";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.htt_mass);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <539> {
-  constexpr static const char* name = "puppiCA15Jets/ptCorrDown";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <539> {
+    constexpr static const char* name = "puppiCA15Jets/ptCorrDown";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.ptCorrDown);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <540> {
-  constexpr static const char* name = "puppiCA15Jets/deepCSVbb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <540> {
+    constexpr static const char* name = "puppiCA15Jets/deepCSVbb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.deepCSVbb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <541> {
-  constexpr static const char* name = "puppiCA15Jets/tau2";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <541> {
+    constexpr static const char* name = "puppiCA15Jets/tau2";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.tau2);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <542> {
-  constexpr static const char* name = "puppiCA15Jets/tau3";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <542> {
+    constexpr static const char* name = "puppiCA15Jets/tau3";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.tau3);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <543> {
-  constexpr static const char* name = "puppiCA15Jets/puid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <543> {
+    constexpr static const char* name = "puppiCA15Jets/puid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.puid);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <544> {
-  constexpr static const char* name = "puppiCA15Jets/tau1";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <544> {
+    constexpr static const char* name = "puppiCA15Jets/tau1";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.tau1);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <545> {
-  constexpr static const char* name = "puppiCA15Jets/mSD";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <545> {
+    constexpr static const char* name = "puppiCA15Jets/mSD";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.mSD);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <546> {
-  constexpr static const char* name = "puppiCA15Jets/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <546> {
+    constexpr static const char* name = "puppiCA15Jets/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.e());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <547> {
-  constexpr static const char* name = "puppiCA15Jets/deepCMVAcc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <547> {
+    constexpr static const char* name = "puppiCA15Jets/deepCMVAcc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.deepCMVAcc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <548> {
-  constexpr static const char* name = "puppiCA15Jets/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <548> {
+    constexpr static const char* name = "puppiCA15Jets/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <549> {
-  constexpr static const char* name = "puppiCA15Jets/rawPt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <549> {
+    constexpr static const char* name = "puppiCA15Jets/rawPt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.rawPt);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <550> {
-  constexpr static const char* name = "puppiCA15Jets/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <550> {
+    constexpr static const char* name = "puppiCA15Jets/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <551> {
-  constexpr static const char* name = "puppiCA15Jets/double_sub";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <551> {
+    constexpr static const char* name = "puppiCA15Jets/double_sub";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.double_sub);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <552> {
-  constexpr static const char* name = "puppiCA15Jets/loose";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <552> {
+    constexpr static const char* name = "puppiCA15Jets/loose";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.loose);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <553> {
-  constexpr static const char* name = "puppiCA15Jets/ptSmear";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <553> {
+    constexpr static const char* name = "puppiCA15Jets/ptSmear";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.ptSmear);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <554> {
-  constexpr static const char* name = "puppiCA15Jets/deepCMVAc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <554> {
+    constexpr static const char* name = "puppiCA15Jets/deepCMVAc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.deepCMVAc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <555> {
-  constexpr static const char* name = "puppiCA15Jets/qgl";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <555> {
+    constexpr static const char* name = "puppiCA15Jets/qgl";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.qgl);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <556> {
-  constexpr static const char* name = "puppiCA15Jets/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <556> {
+    constexpr static const char* name = "puppiCA15Jets/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <557> {
-  constexpr static const char* name = "puppiCA15Jets/monojet";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <557> {
+    constexpr static const char* name = "puppiCA15Jets/monojet";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.monojet);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <558> {
-  constexpr static const char* name = "puppiCA15Jets/ptSmearDown";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <558> {
+    constexpr static const char* name = "puppiCA15Jets/ptSmearDown";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.ptSmearDown);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <559> {
-  constexpr static const char* name = "puppiCA15Jets/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <559> {
+    constexpr static const char* name = "puppiCA15Jets/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <560> {
-  constexpr static const char* name = "puppiCA15Jets/mPruned";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <560> {
+    constexpr static const char* name = "puppiCA15Jets/mPruned";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.mPruned);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <561> {
-  constexpr static const char* name = "puppiCA15Jets/tau1SD";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <561> {
+    constexpr static const char* name = "puppiCA15Jets/tau1SD";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.tau1SD);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <562> {
-  constexpr static const char* name = "puppiCA15Jets/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <562> {
+    constexpr static const char* name = "puppiCA15Jets/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <563> {
-  constexpr static const char* name = "puppiCA15Jets/csv";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <563> {
+    constexpr static const char* name = "puppiCA15Jets/csv";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.csv);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <564> {
-  constexpr static const char* name = "puppiCA15Jets/deepCSVb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <564> {
+    constexpr static const char* name = "puppiCA15Jets/deepCSVb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.deepCSVb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <565> {
-  constexpr static const char* name = "puppiCA15Jets/deepCSVc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <565> {
+    constexpr static const char* name = "puppiCA15Jets/deepCSVc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.deepCSVc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <566> {
-  constexpr static const char* name = "puppiCA15Jets/tau3SD";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <566> {
+    constexpr static const char* name = "puppiCA15Jets/tau3SD";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.tau3SD);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <567> {
-  constexpr static const char* name = "puppiCA15Jets/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <567> {
+    constexpr static const char* name = "puppiCA15Jets/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <568> {
-  constexpr static const char* name = "puppiCA15Jets/deepCSVcc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <568> {
+    constexpr static const char* name = "puppiCA15Jets/deepCSVcc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.deepCSVcc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <569> {
-  constexpr static const char* name = "puppiCA15Jets/tau2SD";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <569> {
+    constexpr static const char* name = "puppiCA15Jets/tau2SD";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.tau2SD);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <570> {
-  constexpr static const char* name = "puppiCA15Jets/ptSmearUp";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <570> {
+    constexpr static const char* name = "puppiCA15Jets/ptSmearUp";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Jets)
       output.push_back(i.ptSmearUp);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <571> {
-  constexpr static const char* name = "puppiCA15Subjets/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.puppiCA15Subjets.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <571> {
+    constexpr static const char* name = "puppiCA15Subjets/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.puppiCA15Subjets.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <572> {
-  constexpr static const char* name = "puppiCA15Subjets/deepCMVAudsg";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <572> {
+    constexpr static const char* name = "puppiCA15Subjets/deepCMVAudsg";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.deepCMVAudsg);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <573> {
-  constexpr static const char* name = "puppiCA15Subjets/deepCMVAbb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <573> {
+    constexpr static const char* name = "puppiCA15Subjets/deepCMVAbb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.deepCMVAbb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <574> {
-  constexpr static const char* name = "puppiCA15Subjets/deepCSVudsg";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <574> {
+    constexpr static const char* name = "puppiCA15Subjets/deepCSVudsg";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.deepCSVudsg);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <575> {
-  constexpr static const char* name = "puppiCA15Subjets/cmva";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <575> {
+    constexpr static const char* name = "puppiCA15Subjets/cmva";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.cmva);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <576> {
-  constexpr static const char* name = "puppiCA15Subjets/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <576> {
+    constexpr static const char* name = "puppiCA15Subjets/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <577> {
-  constexpr static const char* name = "puppiCA15Subjets/deepCSVbb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <577> {
+    constexpr static const char* name = "puppiCA15Subjets/deepCSVbb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.deepCSVbb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <578> {
-  constexpr static const char* name = "puppiCA15Subjets/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <578> {
+    constexpr static const char* name = "puppiCA15Subjets/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <579> {
-  constexpr static const char* name = "puppiCA15Subjets/deepCMVAb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <579> {
+    constexpr static const char* name = "puppiCA15Subjets/deepCMVAb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.deepCMVAb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <580> {
-  constexpr static const char* name = "puppiCA15Subjets/deepCMVAc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <580> {
+    constexpr static const char* name = "puppiCA15Subjets/deepCMVAc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.deepCMVAc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <581> {
-  constexpr static const char* name = "puppiCA15Subjets/qgl";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <581> {
+    constexpr static const char* name = "puppiCA15Subjets/qgl";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.qgl);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <582> {
-  constexpr static const char* name = "puppiCA15Subjets/csv";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <582> {
+    constexpr static const char* name = "puppiCA15Subjets/csv";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.csv);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <583> {
-  constexpr static const char* name = "puppiCA15Subjets/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <583> {
+    constexpr static const char* name = "puppiCA15Subjets/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.e());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <584> {
-  constexpr static const char* name = "puppiCA15Subjets/deepCMVAcc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <584> {
+    constexpr static const char* name = "puppiCA15Subjets/deepCMVAcc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.deepCMVAcc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <585> {
-  constexpr static const char* name = "puppiCA15Subjets/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <585> {
+    constexpr static const char* name = "puppiCA15Subjets/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <586> {
-  constexpr static const char* name = "puppiCA15Subjets/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <586> {
+    constexpr static const char* name = "puppiCA15Subjets/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <587> {
-  constexpr static const char* name = "puppiCA15Subjets/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <587> {
+    constexpr static const char* name = "puppiCA15Subjets/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <588> {
-  constexpr static const char* name = "puppiCA15Subjets/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <588> {
+    constexpr static const char* name = "puppiCA15Subjets/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <589> {
-  constexpr static const char* name = "puppiCA15Subjets/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <589> {
+    constexpr static const char* name = "puppiCA15Subjets/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <590> {
-  constexpr static const char* name = "puppiCA15Subjets/deepCSVb";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <590> {
+    constexpr static const char* name = "puppiCA15Subjets/deepCSVb";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.deepCSVb);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <591> {
-  constexpr static const char* name = "puppiCA15Subjets/deepCSVc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <591> {
+    constexpr static const char* name = "puppiCA15Subjets/deepCSVc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.deepCSVc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <592> {
-  constexpr static const char* name = "puppiCA15Subjets/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <592> {
+    constexpr static const char* name = "puppiCA15Subjets/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <593> {
-  constexpr static const char* name = "puppiCA15Subjets/deepCSVcc";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <593> {
+    constexpr static const char* name = "puppiCA15Subjets/deepCSVcc";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.puppiCA15Subjets)
       output.push_back(i.deepCSVcc);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <594> {
-  constexpr static const char* name = "ak4GenJets/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.ak4GenJets.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <594> {
+    constexpr static const char* name = "ak4GenJets/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.ak4GenJets.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <595> {
-  constexpr static const char* name = "ak4GenJets/partonFlavor";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <595> {
+    constexpr static const char* name = "ak4GenJets/partonFlavor";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak4GenJets)
       output.push_back(i.partonFlavor);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <596> {
-  constexpr static const char* name = "ak4GenJets/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <596> {
+    constexpr static const char* name = "ak4GenJets/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak4GenJets)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <597> {
-  constexpr static const char* name = "ak4GenJets/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <597> {
+    constexpr static const char* name = "ak4GenJets/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak4GenJets)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <598> {
-  constexpr static const char* name = "ak4GenJets/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <598> {
+    constexpr static const char* name = "ak4GenJets/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak4GenJets)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <599> {
-  constexpr static const char* name = "ak4GenJets/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <599> {
+    constexpr static const char* name = "ak4GenJets/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak4GenJets)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <600> {
-  constexpr static const char* name = "ak4GenJets/pdgid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <600> {
+    constexpr static const char* name = "ak4GenJets/pdgid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak4GenJets)
       output.push_back(i.pdgid);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <601> {
-  constexpr static const char* name = "ak4GenJets/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <601> {
+    constexpr static const char* name = "ak4GenJets/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak4GenJets)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <602> {
-  constexpr static const char* name = "ak4GenJets/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <602> {
+    constexpr static const char* name = "ak4GenJets/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak4GenJets)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <603> {
-  constexpr static const char* name = "ak4GenJets/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <603> {
+    constexpr static const char* name = "ak4GenJets/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak4GenJets)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <604> {
-  constexpr static const char* name = "ak4GenJets/numB";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <604> {
+    constexpr static const char* name = "ak4GenJets/numB";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak4GenJets)
       output.push_back(i.numB);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <605> {
-  constexpr static const char* name = "ak4GenJets/numC";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <605> {
+    constexpr static const char* name = "ak4GenJets/numC";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak4GenJets)
       output.push_back(i.numC);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <606> {
-  constexpr static const char* name = "ak4GenJets/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <606> {
+    constexpr static const char* name = "ak4GenJets/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak4GenJets)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <607> {
-  constexpr static const char* name = "ak4GenJets/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <607> {
+    constexpr static const char* name = "ak4GenJets/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak4GenJets)
       output.push_back(i.e());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <608> {
-  constexpr static const char* name = "ak8GenJets/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.ak8GenJets.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <608> {
+    constexpr static const char* name = "ak8GenJets/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.ak8GenJets.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <609> {
-  constexpr static const char* name = "ak8GenJets/partonFlavor";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <609> {
+    constexpr static const char* name = "ak8GenJets/partonFlavor";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak8GenJets)
       output.push_back(i.partonFlavor);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <610> {
-  constexpr static const char* name = "ak8GenJets/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <610> {
+    constexpr static const char* name = "ak8GenJets/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak8GenJets)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <611> {
-  constexpr static const char* name = "ak8GenJets/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <611> {
+    constexpr static const char* name = "ak8GenJets/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak8GenJets)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <612> {
-  constexpr static const char* name = "ak8GenJets/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <612> {
+    constexpr static const char* name = "ak8GenJets/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak8GenJets)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <613> {
-  constexpr static const char* name = "ak8GenJets/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <613> {
+    constexpr static const char* name = "ak8GenJets/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak8GenJets)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <614> {
-  constexpr static const char* name = "ak8GenJets/pdgid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <614> {
+    constexpr static const char* name = "ak8GenJets/pdgid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak8GenJets)
       output.push_back(i.pdgid);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <615> {
-  constexpr static const char* name = "ak8GenJets/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <615> {
+    constexpr static const char* name = "ak8GenJets/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak8GenJets)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <616> {
-  constexpr static const char* name = "ak8GenJets/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <616> {
+    constexpr static const char* name = "ak8GenJets/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak8GenJets)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <617> {
-  constexpr static const char* name = "ak8GenJets/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <617> {
+    constexpr static const char* name = "ak8GenJets/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak8GenJets)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <618> {
-  constexpr static const char* name = "ak8GenJets/numB";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <618> {
+    constexpr static const char* name = "ak8GenJets/numB";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak8GenJets)
       output.push_back(i.numB);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <619> {
-  constexpr static const char* name = "ak8GenJets/numC";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <619> {
+    constexpr static const char* name = "ak8GenJets/numC";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak8GenJets)
       output.push_back(i.numC);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <620> {
-  constexpr static const char* name = "ak8GenJets/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <620> {
+    constexpr static const char* name = "ak8GenJets/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak8GenJets)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <621> {
-  constexpr static const char* name = "ak8GenJets/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <621> {
+    constexpr static const char* name = "ak8GenJets/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ak8GenJets)
       output.push_back(i.e());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <622> {
-  constexpr static const char* name = "ca15GenJets/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.ca15GenJets.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <622> {
+    constexpr static const char* name = "ca15GenJets/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.ca15GenJets.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <623> {
-  constexpr static const char* name = "ca15GenJets/partonFlavor";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <623> {
+    constexpr static const char* name = "ca15GenJets/partonFlavor";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ca15GenJets)
       output.push_back(i.partonFlavor);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <624> {
-  constexpr static const char* name = "ca15GenJets/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <624> {
+    constexpr static const char* name = "ca15GenJets/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ca15GenJets)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <625> {
-  constexpr static const char* name = "ca15GenJets/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <625> {
+    constexpr static const char* name = "ca15GenJets/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ca15GenJets)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <626> {
-  constexpr static const char* name = "ca15GenJets/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <626> {
+    constexpr static const char* name = "ca15GenJets/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ca15GenJets)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <627> {
-  constexpr static const char* name = "ca15GenJets/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <627> {
+    constexpr static const char* name = "ca15GenJets/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ca15GenJets)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <628> {
-  constexpr static const char* name = "ca15GenJets/pdgid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <628> {
+    constexpr static const char* name = "ca15GenJets/pdgid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ca15GenJets)
       output.push_back(i.pdgid);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <629> {
-  constexpr static const char* name = "ca15GenJets/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <629> {
+    constexpr static const char* name = "ca15GenJets/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ca15GenJets)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <630> {
-  constexpr static const char* name = "ca15GenJets/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <630> {
+    constexpr static const char* name = "ca15GenJets/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ca15GenJets)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <631> {
-  constexpr static const char* name = "ca15GenJets/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <631> {
+    constexpr static const char* name = "ca15GenJets/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ca15GenJets)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <632> {
-  constexpr static const char* name = "ca15GenJets/numB";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <632> {
+    constexpr static const char* name = "ca15GenJets/numB";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ca15GenJets)
       output.push_back(i.numB);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <633> {
-  constexpr static const char* name = "ca15GenJets/numC";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <633> {
+    constexpr static const char* name = "ca15GenJets/numC";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ca15GenJets)
       output.push_back(i.numC);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <634> {
-  constexpr static const char* name = "ca15GenJets/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <634> {
+    constexpr static const char* name = "ca15GenJets/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ca15GenJets)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <635> {
-  constexpr static const char* name = "ca15GenJets/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <635> {
+    constexpr static const char* name = "ca15GenJets/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.ca15GenJets)
       output.push_back(i.e());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <636> {
-  constexpr static const char* name = "genParticles/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.genParticles.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <636> {
+    constexpr static const char* name = "genParticles/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.genParticles.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <637> {
-  constexpr static const char* name = "genParticles/parent_isValid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <637> {
+    constexpr static const char* name = "genParticles/parent_isValid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.genParticles)
       output.push_back(i.parent.isValid());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <638> {
-  constexpr static const char* name = "genParticles/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <638> {
+    constexpr static const char* name = "genParticles/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.genParticles)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <639> {
-  constexpr static const char* name = "genParticles/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <639> {
+    constexpr static const char* name = "genParticles/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.genParticles)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <640> {
-  constexpr static const char* name = "genParticles/statusFlags";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <640> {
+    constexpr static const char* name = "genParticles/statusFlags";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.genParticles)
       output.push_back(i.statusFlags);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <641> {
-  constexpr static const char* name = "genParticles/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <641> {
+    constexpr static const char* name = "genParticles/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.genParticles)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <642> {
-  constexpr static const char* name = "genParticles/pdgid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <642> {
+    constexpr static const char* name = "genParticles/pdgid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.genParticles)
       output.push_back(i.pdgid);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <643> {
-  constexpr static const char* name = "genParticles/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <643> {
+    constexpr static const char* name = "genParticles/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.genParticles)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <644> {
-  constexpr static const char* name = "genParticles/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <644> {
+    constexpr static const char* name = "genParticles/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.genParticles)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <645> {
-  constexpr static const char* name = "genParticles/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <645> {
+    constexpr static const char* name = "genParticles/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.genParticles)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <646> {
-  constexpr static const char* name = "genParticles/finalState";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <646> {
+    constexpr static const char* name = "genParticles/finalState";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.genParticles)
       output.push_back(i.finalState);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <647> {
-  constexpr static const char* name = "genParticles/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <647> {
+    constexpr static const char* name = "genParticles/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.genParticles)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <648> {
-  constexpr static const char* name = "genParticles/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <648> {
+    constexpr static const char* name = "genParticles/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.genParticles)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <649> {
-  constexpr static const char* name = "genParticles/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <649> {
+    constexpr static const char* name = "genParticles/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.genParticles)
       output.push_back(i.e());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <650> {
-  constexpr static const char* name = "genVertex/y";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.genVertex.y)};
-    return output;
-  }
-};
+  template <>
+  struct plotter <650> {
+    constexpr static const char* name = "genVertex/y";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.genVertex.y)};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <651> {
-  constexpr static const char* name = "genVertex/x";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.genVertex.x)};
-    return output;
-  }
-};
+  template <>
+  struct plotter <651> {
+    constexpr static const char* name = "genVertex/x";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.genVertex.x)};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <652> {
-  constexpr static const char* name = "genVertex/z";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.genVertex.z)};
-    return output;
-  }
-};
+  template <>
+  struct plotter <652> {
+    constexpr static const char* name = "genVertex/z";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.genVertex.z)};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <653> {
-  constexpr static const char* name = "partons/size";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.partons.size())};
-    return output;
-  }
-};
+  template <>
+  struct plotter <653> {
+    constexpr static const char* name = "partons/size";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.partons.size())};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <654> {
-  constexpr static const char* name = "partons/pt";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <654> {
+    constexpr static const char* name = "partons/pt";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.partons)
       output.push_back(i.pt());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <655> {
-  constexpr static const char* name = "partons/p";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <655> {
+    constexpr static const char* name = "partons/p";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.partons)
       output.push_back(i.p());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <656> {
-  constexpr static const char* name = "partons/eta";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <656> {
+    constexpr static const char* name = "partons/eta";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.partons)
       output.push_back(i.eta());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <657> {
-  constexpr static const char* name = "partons/m";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <657> {
+    constexpr static const char* name = "partons/m";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.partons)
       output.push_back(i.m());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <658> {
-  constexpr static const char* name = "partons/pdgid";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <658> {
+    constexpr static const char* name = "partons/pdgid";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.partons)
       output.push_back(i.pdgid);
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <659> {
-  constexpr static const char* name = "partons/phi";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <659> {
+    constexpr static const char* name = "partons/phi";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.partons)
       output.push_back(i.phi());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <660> {
-  constexpr static const char* name = "partons/pz";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <660> {
+    constexpr static const char* name = "partons/pz";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.partons)
       output.push_back(i.pz());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <661> {
-  constexpr static const char* name = "partons/py";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <661> {
+    constexpr static const char* name = "partons/py";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.partons)
       output.push_back(i.py());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <662> {
-  constexpr static const char* name = "partons/px";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <662> {
+    constexpr static const char* name = "partons/px";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.partons)
       output.push_back(i.px());
 
-    return output;
-  }
-};
+      return output;
+    }
+  };
 
 
-template <>
-struct plotter <663> {
-  constexpr static const char* name = "partons/e";
-  std::vector<float> operator () (panda::Event& event) {
-
+  template <>
+  struct plotter <663> {
+    constexpr static const char* name = "partons/e";
+    std::vector<float> operator () (panda::Event& event) {
+  
     std::vector<float> output;
     for (auto& i : event.partons)
       output.push_back(i.e());
 
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <664> {
-  constexpr static const char* name = "pfMet/phi";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.pfMet.phi)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <665> {
-  constexpr static const char* name = "pfMet/phiUnclUp";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.pfMet.phiUnclUp)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <666> {
-  constexpr static const char* name = "pfMet/sumETRaw";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.pfMet.sumETRaw)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <667> {
-  constexpr static const char* name = "pfMet/ptCorrUp";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.pfMet.ptCorrUp)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <668> {
-  constexpr static const char* name = "pfMet/pt";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.pfMet.pt)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <669> {
-  constexpr static const char* name = "pfMet/ptCorrDown";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.pfMet.ptCorrDown)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <670> {
-  constexpr static const char* name = "pfMet/phiCorrUp";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.pfMet.phiCorrUp)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <671> {
-  constexpr static const char* name = "pfMet/phiUnclDown";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.pfMet.phiUnclDown)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <672> {
-  constexpr static const char* name = "pfMet/ptUnclDown";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.pfMet.ptUnclDown)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <673> {
-  constexpr static const char* name = "pfMet/phiCorrDown";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.pfMet.phiCorrDown)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <674> {
-  constexpr static const char* name = "pfMet/ptUnclUp";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.pfMet.ptUnclUp)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <675> {
-  constexpr static const char* name = "puppiMet/phi";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.puppiMet.phi)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <676> {
-  constexpr static const char* name = "puppiMet/phiUnclUp";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.puppiMet.phiUnclUp)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <677> {
-  constexpr static const char* name = "puppiMet/sumETRaw";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.puppiMet.sumETRaw)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <678> {
-  constexpr static const char* name = "puppiMet/ptCorrUp";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.puppiMet.ptCorrUp)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <679> {
-  constexpr static const char* name = "puppiMet/pt";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.puppiMet.pt)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <680> {
-  constexpr static const char* name = "puppiMet/ptCorrDown";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.puppiMet.ptCorrDown)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <681> {
-  constexpr static const char* name = "puppiMet/phiCorrUp";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.puppiMet.phiCorrUp)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <682> {
-  constexpr static const char* name = "puppiMet/phiUnclDown";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.puppiMet.phiUnclDown)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <683> {
-  constexpr static const char* name = "puppiMet/ptUnclDown";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.puppiMet.ptUnclDown)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <684> {
-  constexpr static const char* name = "puppiMet/phiCorrDown";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.puppiMet.phiCorrDown)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <685> {
-  constexpr static const char* name = "puppiMet/ptUnclUp";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.puppiMet.ptUnclUp)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <686> {
-  constexpr static const char* name = "rawMet/phi";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.rawMet.phi)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <687> {
-  constexpr static const char* name = "rawMet/pt";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.rawMet.pt)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <688> {
-  constexpr static const char* name = "caloMet/phi";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.caloMet.phi)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <689> {
-  constexpr static const char* name = "caloMet/pt";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.caloMet.pt)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <690> {
-  constexpr static const char* name = "noMuMet/phi";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.noMuMet.phi)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <691> {
-  constexpr static const char* name = "noMuMet/pt";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.noMuMet.pt)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <692> {
-  constexpr static const char* name = "noHFMet/phi";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.noHFMet.phi)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <693> {
-  constexpr static const char* name = "noHFMet/pt";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.noHFMet.pt)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <694> {
-  constexpr static const char* name = "trkMet/phi";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.trkMet.phi)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <695> {
-  constexpr static const char* name = "trkMet/pt";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.trkMet.pt)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <696> {
-  constexpr static const char* name = "neutralMet/phi";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.neutralMet.phi)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <697> {
-  constexpr static const char* name = "neutralMet/pt";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.neutralMet.pt)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <698> {
-  constexpr static const char* name = "photonMet/phi";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.photonMet.phi)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <699> {
-  constexpr static const char* name = "photonMet/pt";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.photonMet.pt)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <700> {
-  constexpr static const char* name = "hfMet/phi";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.hfMet.phi)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <701> {
-  constexpr static const char* name = "hfMet/pt";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.hfMet.pt)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <702> {
-  constexpr static const char* name = "genMet/phi";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.genMet.phi)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <703> {
-  constexpr static const char* name = "genMet/pt";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.genMet.pt)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <704> {
-  constexpr static const char* name = "metMuOnlyFix/phi";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metMuOnlyFix.phi)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <705> {
-  constexpr static const char* name = "metMuOnlyFix/phiUnclUp";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metMuOnlyFix.phiUnclUp)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <706> {
-  constexpr static const char* name = "metMuOnlyFix/sumETRaw";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metMuOnlyFix.sumETRaw)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <707> {
-  constexpr static const char* name = "metMuOnlyFix/ptCorrUp";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metMuOnlyFix.ptCorrUp)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <708> {
-  constexpr static const char* name = "metMuOnlyFix/pt";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metMuOnlyFix.pt)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <709> {
-  constexpr static const char* name = "metMuOnlyFix/ptCorrDown";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metMuOnlyFix.ptCorrDown)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <710> {
-  constexpr static const char* name = "metMuOnlyFix/phiCorrUp";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metMuOnlyFix.phiCorrUp)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <711> {
-  constexpr static const char* name = "metMuOnlyFix/phiUnclDown";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metMuOnlyFix.phiUnclDown)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <712> {
-  constexpr static const char* name = "metMuOnlyFix/ptUnclDown";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metMuOnlyFix.ptUnclDown)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <713> {
-  constexpr static const char* name = "metMuOnlyFix/phiCorrDown";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metMuOnlyFix.phiCorrDown)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <714> {
-  constexpr static const char* name = "metMuOnlyFix/ptUnclUp";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metMuOnlyFix.ptUnclUp)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <715> {
-  constexpr static const char* name = "metFilters/duplicateMuons";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metFilters.duplicateMuons)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <716> {
-  constexpr static const char* name = "metFilters/badMuons";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metFilters.badMuons)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <717> {
-  constexpr static const char* name = "metFilters/globalHalo16";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metFilters.globalHalo16)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <718> {
-  constexpr static const char* name = "metFilters/badsc";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metFilters.badsc)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <719> {
-  constexpr static const char* name = "metFilters/hbheIso";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metFilters.hbheIso)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <720> {
-  constexpr static const char* name = "metFilters/hbhe";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metFilters.hbhe)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <721> {
-  constexpr static const char* name = "metFilters/badPFMuons";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metFilters.badPFMuons)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <722> {
-  constexpr static const char* name = "metFilters/goodVertices";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metFilters.goodVertices)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <723> {
-  constexpr static const char* name = "metFilters/ecalDeadCell";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metFilters.ecalDeadCell)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <724> {
-  constexpr static const char* name = "metFilters/badChargedHadrons";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metFilters.badChargedHadrons)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <725> {
-  constexpr static const char* name = "metFilters/pass";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.metFilters.pass())};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <726> {
-  constexpr static const char* name = "recoil/max";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.recoil.max)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <727> {
-  constexpr static const char* name = "recoil/monoE";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.recoil.monoE)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <728> {
-  constexpr static const char* name = "recoil/diE";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.recoil.diE)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <729> {
-  constexpr static const char* name = "recoil/monoMu";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.recoil.monoMu)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <730> {
-  constexpr static const char* name = "recoil/met";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.recoil.met)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <731> {
-  constexpr static const char* name = "recoil/diMu";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.recoil.diMu)};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <732> {
-  constexpr static const char* name = "recoil/any";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.recoil.any())};
-    return output;
-  }
-};
-
-
-template <>
-struct plotter <733> {
-  constexpr static const char* name = "recoil/gamma";
-  std::vector<float> operator () (panda::Event& event) {
-    std::vector<float> output {float(event.recoil.gamma)};
-    return output;
-  }
-};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <664> {
+    constexpr static const char* name = "pfMet/phi";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.pfMet.phi)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <665> {
+    constexpr static const char* name = "pfMet/phiUnclUp";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.pfMet.phiUnclUp)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <666> {
+    constexpr static const char* name = "pfMet/sumETRaw";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.pfMet.sumETRaw)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <667> {
+    constexpr static const char* name = "pfMet/ptCorrUp";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.pfMet.ptCorrUp)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <668> {
+    constexpr static const char* name = "pfMet/pt";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.pfMet.pt)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <669> {
+    constexpr static const char* name = "pfMet/ptCorrDown";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.pfMet.ptCorrDown)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <670> {
+    constexpr static const char* name = "pfMet/phiCorrUp";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.pfMet.phiCorrUp)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <671> {
+    constexpr static const char* name = "pfMet/phiUnclDown";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.pfMet.phiUnclDown)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <672> {
+    constexpr static const char* name = "pfMet/ptUnclDown";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.pfMet.ptUnclDown)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <673> {
+    constexpr static const char* name = "pfMet/phiCorrDown";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.pfMet.phiCorrDown)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <674> {
+    constexpr static const char* name = "pfMet/ptUnclUp";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.pfMet.ptUnclUp)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <675> {
+    constexpr static const char* name = "puppiMet/phi";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.puppiMet.phi)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <676> {
+    constexpr static const char* name = "puppiMet/phiUnclUp";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.puppiMet.phiUnclUp)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <677> {
+    constexpr static const char* name = "puppiMet/sumETRaw";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.puppiMet.sumETRaw)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <678> {
+    constexpr static const char* name = "puppiMet/ptCorrUp";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.puppiMet.ptCorrUp)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <679> {
+    constexpr static const char* name = "puppiMet/pt";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.puppiMet.pt)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <680> {
+    constexpr static const char* name = "puppiMet/ptCorrDown";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.puppiMet.ptCorrDown)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <681> {
+    constexpr static const char* name = "puppiMet/phiCorrUp";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.puppiMet.phiCorrUp)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <682> {
+    constexpr static const char* name = "puppiMet/phiUnclDown";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.puppiMet.phiUnclDown)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <683> {
+    constexpr static const char* name = "puppiMet/ptUnclDown";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.puppiMet.ptUnclDown)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <684> {
+    constexpr static const char* name = "puppiMet/phiCorrDown";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.puppiMet.phiCorrDown)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <685> {
+    constexpr static const char* name = "puppiMet/ptUnclUp";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.puppiMet.ptUnclUp)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <686> {
+    constexpr static const char* name = "rawMet/phi";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.rawMet.phi)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <687> {
+    constexpr static const char* name = "rawMet/pt";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.rawMet.pt)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <688> {
+    constexpr static const char* name = "caloMet/phi";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.caloMet.phi)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <689> {
+    constexpr static const char* name = "caloMet/pt";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.caloMet.pt)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <690> {
+    constexpr static const char* name = "noMuMet/phi";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.noMuMet.phi)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <691> {
+    constexpr static const char* name = "noMuMet/pt";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.noMuMet.pt)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <692> {
+    constexpr static const char* name = "noHFMet/phi";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.noHFMet.phi)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <693> {
+    constexpr static const char* name = "noHFMet/pt";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.noHFMet.pt)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <694> {
+    constexpr static const char* name = "trkMet/phi";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.trkMet.phi)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <695> {
+    constexpr static const char* name = "trkMet/pt";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.trkMet.pt)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <696> {
+    constexpr static const char* name = "neutralMet/phi";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.neutralMet.phi)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <697> {
+    constexpr static const char* name = "neutralMet/pt";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.neutralMet.pt)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <698> {
+    constexpr static const char* name = "photonMet/phi";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.photonMet.phi)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <699> {
+    constexpr static const char* name = "photonMet/pt";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.photonMet.pt)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <700> {
+    constexpr static const char* name = "hfMet/phi";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.hfMet.phi)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <701> {
+    constexpr static const char* name = "hfMet/pt";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.hfMet.pt)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <702> {
+    constexpr static const char* name = "genMet/phi";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.genMet.phi)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <703> {
+    constexpr static const char* name = "genMet/pt";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.genMet.pt)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <704> {
+    constexpr static const char* name = "metMuOnlyFix/phi";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metMuOnlyFix.phi)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <705> {
+    constexpr static const char* name = "metMuOnlyFix/phiUnclUp";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metMuOnlyFix.phiUnclUp)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <706> {
+    constexpr static const char* name = "metMuOnlyFix/sumETRaw";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metMuOnlyFix.sumETRaw)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <707> {
+    constexpr static const char* name = "metMuOnlyFix/ptCorrUp";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metMuOnlyFix.ptCorrUp)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <708> {
+    constexpr static const char* name = "metMuOnlyFix/pt";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metMuOnlyFix.pt)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <709> {
+    constexpr static const char* name = "metMuOnlyFix/ptCorrDown";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metMuOnlyFix.ptCorrDown)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <710> {
+    constexpr static const char* name = "metMuOnlyFix/phiCorrUp";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metMuOnlyFix.phiCorrUp)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <711> {
+    constexpr static const char* name = "metMuOnlyFix/phiUnclDown";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metMuOnlyFix.phiUnclDown)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <712> {
+    constexpr static const char* name = "metMuOnlyFix/ptUnclDown";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metMuOnlyFix.ptUnclDown)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <713> {
+    constexpr static const char* name = "metMuOnlyFix/phiCorrDown";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metMuOnlyFix.phiCorrDown)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <714> {
+    constexpr static const char* name = "metMuOnlyFix/ptUnclUp";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metMuOnlyFix.ptUnclUp)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <715> {
+    constexpr static const char* name = "metFilters/duplicateMuons";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metFilters.duplicateMuons)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <716> {
+    constexpr static const char* name = "metFilters/badMuons";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metFilters.badMuons)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <717> {
+    constexpr static const char* name = "metFilters/globalHalo16";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metFilters.globalHalo16)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <718> {
+    constexpr static const char* name = "metFilters/badsc";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metFilters.badsc)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <719> {
+    constexpr static const char* name = "metFilters/hbheIso";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metFilters.hbheIso)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <720> {
+    constexpr static const char* name = "metFilters/hbhe";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metFilters.hbhe)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <721> {
+    constexpr static const char* name = "metFilters/badPFMuons";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metFilters.badPFMuons)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <722> {
+    constexpr static const char* name = "metFilters/goodVertices";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metFilters.goodVertices)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <723> {
+    constexpr static const char* name = "metFilters/ecalDeadCell";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metFilters.ecalDeadCell)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <724> {
+    constexpr static const char* name = "metFilters/badChargedHadrons";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metFilters.badChargedHadrons)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <725> {
+    constexpr static const char* name = "metFilters/pass";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.metFilters.pass())};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <726> {
+    constexpr static const char* name = "recoil/max";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.recoil.max)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <727> {
+    constexpr static const char* name = "recoil/monoE";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.recoil.monoE)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <728> {
+    constexpr static const char* name = "recoil/diE";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.recoil.diE)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <729> {
+    constexpr static const char* name = "recoil/monoMu";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.recoil.monoMu)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <730> {
+    constexpr static const char* name = "recoil/met";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.recoil.met)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <731> {
+    constexpr static const char* name = "recoil/diMu";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.recoil.diMu)};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <732> {
+    constexpr static const char* name = "recoil/any";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.recoil.any())};
+      return output;
+    }
+  };
+
+
+  template <>
+  struct plotter <733> {
+    constexpr static const char* name = "recoil/gamma";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output {float(event.recoil.gamma)};
+      return output;
+    }
+  };
 
 #define NUM_PLOTS 734
+
+};
 
 #endif

--- a/RelVal/interface/TemplateMagic.h
+++ b/RelVal/interface/TemplateMagic.h
@@ -11,50 +11,52 @@
 // For all of these, the function action should be different for each branch
 //     (represented as the int passed first to each function)
 
-// FillFunc also should be passed to plot_looper with an event tree
-// This calls the () operator for the plotters in EnumerateBranches.h
-typedef std::function<void(int, std::vector<float>)> FillFunc;
-typedef std::function<void(int)> ActionFunc;
-// This also grabs the plot names from the plotters in EnumerateBranches.h
-typedef std::function<void(int, const char*)> NamedActionFunc;
+namespace testpanda {
+  // FillFunc also should be passed to plot_looper with an event tree
+  // This calls the () operator for the plotters in EnumerateBranches.h
+  typedef std::function<void(int, std::vector<float>)> FillFunc;
+  typedef std::function<void(int)> ActionFunc;
+  // This also grabs the plot names from the plotters in EnumerateBranches.h
+  typedef std::function<void(int, const char*)> NamedActionFunc;
 
-// This let's us loop over the branches with recursive templating
-// Call the filler and then call the next branch
+  // This let's us loop over the branches with recursive templating
+  // Call the filler and then call the next branch
 
-template <int P>
-struct plot_looper {
+  template <int P>
+  struct plot_looper {
 
-  void operator () (panda::Event& event, FillFunc& filler) {
-    filler(P, plotter<P>()(event));
-    plot_looper<P + 1>()(event, filler);
+    void operator () (panda::Event& event, FillFunc& filler) {
+      filler(P, plotter<P>()(event));
+      plot_looper<P + 1>()(event, filler);
+    };
+
+    void operator () (ActionFunc& actor) {
+      actor(P);
+      plot_looper<P + 1>()(actor);
+    }
+
+    void operator () (NamedActionFunc& actor) {
+      actor(P, plotter<P>::name);
+      plot_looper<P + 1>()(actor);
+    }
+
   };
 
-  void operator () (ActionFunc& actor) {
-    actor(P);
-    plot_looper<P + 1>()(actor);
-  }
+  // Have to terminate at some point
 
-  void operator () (NamedActionFunc& actor) {
-    actor(P, plotter<P>::name);
-    plot_looper<P + 1>()(actor);
-  }
+  // Make sure that NUM_PLOTS is defined correctly
+  static_assert(NUM_PLOTS, "No plots will be made");
+  static_assert(plotter<NUM_PLOTS - 1>::name, "NUM_PLOTS improperly set");
+  static_assert(plotter<NUM_PLOTS>::name == nullptr, "NUM_PLOTS improperly set");
 
-};
+  // Override the recursive behavior
 
-// Have to terminate at some point
-
-// Make sure that NUM_PLOTS is defined correctly
-static_assert(NUM_PLOTS, "No plots will be made");
-static_assert(plotter<NUM_PLOTS - 1>::name, "NUM_PLOTS improperly set");
-static_assert(plotter<NUM_PLOTS>::name == nullptr, "NUM_PLOTS improperly set");
-
-// Override the recursive behavior
-
-template <>
-struct plot_looper<NUM_PLOTS> {
-  void operator ()(panda::Event&, FillFunc&) { };
-  void operator ()(ActionFunc&) { };
-  void operator ()(NamedActionFunc&) { };
+  template <>
+    struct plot_looper<NUM_PLOTS> {
+    void operator ()(panda::Event&, FillFunc&) { };
+    void operator ()(ActionFunc&) { };
+    void operator ()(NamedActionFunc&) { };
+  };
 };
 
 #endif

--- a/RelVal/web/index.php
+++ b/RelVal/web/index.php
@@ -25,17 +25,20 @@ function list_directory($directory) {
     uasort($objs, 'put_common_in_front');
 
     foreach ($objs as $obj) {
-      printf('<header onclick=reveal("%s")>' . "\n", $obj);
+      $glob_check = glob($directory . '/' . $obj . '/*_FLAG.txt');
+      $warn = (count($glob_check) == 0) ? '' : ' warn';
+      printf('<div class="header%s" onclick=reveal("%s")>' . "\n", $warn, $obj);
       printf('<h3>%s</h3>' . "\n", $obj);
-      echo '</header>' . "\n";
+      echo '</div>' . "\n";
       printf('<div style="display:none;" class="plots" id="%s">' . "\n", $obj);
       $plots = scandir($directory . '/' . $obj);
       foreach ($plots as $plot) {
         $file_parts = pathinfo($plot);
         if ($file_parts['extension'] == 'pdf' and substr($file_parts['filename'], -4) != '_log') {
           $base = $directory . '/' . $obj . '/' . $file_parts['filename'];
+          $warn = (file_exists($base . '_FLAG.txt')) ? ' warn' : '';
           $plot_id = $obj . '/' . $file_parts['filename'];
-          echo '<span class="plot">';
+          printf('<span class="plot%s">', $warn);
           printf('<span class="plot_head">%s ' .
                  '<span class="lin_indicator" id="%s_status-lin">linear</span>' .
                  '<span style="display:none;" class="log_indicator" id="%s_status-log">log</span> <br> ' .
@@ -58,9 +61,19 @@ function list_directory($directory) {
         return filemtime($directory . '/' . $a) < filemtime($directory . '/' . $b);
       });
 
-    foreach ($objs as $dir)
-      printf('<a href="?d=%s"><header><h3>%s</h3></header></a><br>' . "\n", ltrim($directory . '/', './') . $dir, $dir);
-
+    echo '<br>';
+    foreach ($objs as $dir) {
+      $fulldir = ltrim($directory . '/', './') . $dir;
+      $metafile = $fulldir . '/metadata.txt';
+      $roomy = '';
+      $meta = '';
+      if (file_exists($metafile)) {
+        $roomy = ' roomy';
+        $meta = sprintf('<a href="%s"><div class="metalink"><h3>metadata</h3></div></a>', $metafile);
+      }
+      printf('<a href="?d=%s"><div class="header%s"><h3>%s</h3></div></a>' . "\n", $fulldir, $roomy, $dir);
+      echo $meta . '<br>';
+    }
   }
 }
 

--- a/RelVal/web/index.php
+++ b/RelVal/web/index.php
@@ -54,7 +54,11 @@ function list_directory($directory) {
 
   } else {
 
-    foreach (array_reverse($objs) as $dir)
+    usort($objs, function($a, $b) use ($directory) {
+        return filemtime($directory . '/' . $a) < filemtime($directory . '/' . $b);
+      });
+
+    foreach ($objs as $dir)
       printf('<a href="?d=%s"><header><h3>%s</h3></header></a><br>' . "\n", ltrim($directory . '/', './') . $dir, $dir);
 
   }

--- a/RelVal/web/index.php
+++ b/RelVal/web/index.php
@@ -69,7 +69,8 @@ function list_directory($directory) {
       $meta = '';
       if (file_exists($metafile)) {
         $roomy = ' roomy';
-        $meta = sprintf('<a href="%s"><div class="metalink"><h3>metadata</h3></div></a>', $metafile);
+        $meta = sprintf('<a href="%s"><div class="metalink"><h3>metadata</h3></div></a><a href="%s"><div class="indexlink"><h3>index</h3></div></a>',
+                        $metafile, $fulldir);
       }
       printf('<a href="?d=%s"><div class="header%s"><h3>%s</h3></div></a>' . "\n", $fulldir, $roomy, $dir);
       echo $meta . '<br>';

--- a/RelVal/web/index.php
+++ b/RelVal/web/index.php
@@ -54,7 +54,7 @@ function list_directory($directory) {
 
   } else {
 
-    foreach ($objs as $dir)
+    foreach (array_reverse($objs) as $dir)
       printf('<a href="?d=%s"><header><h3>%s</h3></header></a><br>' . "\n", ltrim($directory . '/', './') . $dir, $dir);
 
   }

--- a/RelVal/web/index.php
+++ b/RelVal/web/index.php
@@ -9,6 +9,57 @@ function has_no_dot($a) {
   return strpos($a, '.') === FALSE;
 }
 
+function list_directory($directory) {
+  $directory = ltrim($directory, '/');
+  if (!file_exists($directory) or strpos($directory, '..') !== FALSE)
+    $directory = '.';
+
+  $objs = array_filter(scandir($directory), 'has_no_dot');
+
+  $meta_file = $directory . '/metadata.txt';
+  if (file_exists($meta_file)) {
+    echo '<div class="metadata">' . "\n";
+    echo nl2br(file_get_contents($meta_file));
+    echo '</div>' . "\n";
+
+    uasort($objs, 'put_common_in_front');
+
+    foreach ($objs as $obj) {
+      printf('<header onclick=reveal("%s")>' . "\n", $obj);
+      printf('<h3>%s</h3>' . "\n", $obj);
+      echo '</header>' . "\n";
+      printf('<div style="display:none;" class="plots" id="%s">' . "\n", $obj);
+      $plots = scandir($directory . '/' . $obj);
+      foreach ($plots as $plot) {
+        $file_parts = pathinfo($plot);
+        if ($file_parts['extension'] == 'pdf' and substr($file_parts['filename'], -4) != '_log') {
+          $base = $directory . '/' . $obj . '/' . $file_parts['filename'];
+          $plot_id = $obj . '/' . $file_parts['filename'];
+          echo '<span class="plot">';
+          printf('<span class="plot_head">%s ' .
+                 '<span class="lin_indicator" id="%s_status-lin">linear</span>' .
+                 '<span style="display:none;" class="log_indicator" id="%s_status-log">log</span> <br> ' .
+                 '<button class="log_button" onclick=swap_log("%s")>toggle log plots</button>' .
+                 '</span>',
+                 $plot_id, $plot_id, $plot_id, $plot_id);
+          printf('<span id="%s"><a href="%s.pdf" target="_blank"> <img src="%s.png" width="100%s"></a></span>',
+                 $plot_id, $base, $base, '%');
+          printf('<span style="display:none;" id="%s_log"><a href="%s_log.pdf" target="_blank"> <img src="%s_log.png" width="100%s"></a></span>',
+                 $plot_id, $base, $base, '%');
+           echo '</span>' . "\n";
+        }
+      }
+      echo '</div>' . "\n";
+    }
+
+  } else {
+
+    foreach ($objs as $dir)
+      printf('<a href="?d=%s"><header><h3>%s</h3></header></a><br>' . "\n", ltrim($directory . '/', './') . $dir, $dir);
+
+  }
+}
+
 function put_common_in_front($a, $b) {
   if ($a == 'common')
     return -1;
@@ -19,54 +70,9 @@ function put_common_in_front($a, $b) {
 
 $dirs = array_filter(scandir('.', 1), 'has_no_dot');
 
-if (isset($_GET['d']) && in_array($_GET['d'], $dirs)) {
+$directory = isset($_GET['d']) ? $_GET['d'] : '.';
 
-  $directory = $_GET['d'];
-  $objs = array_filter(scandir($directory), 'has_no_dot');
-
-  $meta_file = $directory . '/metadata.txt';
-  if (file_exists($meta_file)) {
-    echo '<div class="metadata">' . "\n";
-    echo nl2br(file_get_contents($meta_file));
-    echo '</div>' . "\n";
-  }
-
-  uasort($objs, 'put_common_in_front');
-
-  foreach ($objs as $obj) {
-    printf('<header onclick=reveal("%s")>' . "\n", $obj);
-    printf('<h3>%s</h3>' . "\n", $obj);
-    echo '</header>' . "\n";
-    printf('<div style="display:none;" class="plots" id="%s">' . "\n", $obj);
-    $plots = scandir($directory . '/' . $obj);
-    foreach ($plots as $plot) {
-      $file_parts = pathinfo($plot);
-      if ($file_parts['extension'] == 'pdf' and substr($file_parts['filename'], -4) != '_log') {
-        $base = $directory . '/' . $obj . '/' . $file_parts['filename'];
-        $plot_id = $obj . '/' . $file_parts['filename'];
-        echo '<span class="plot">';
-        printf('<span class="plot_head">%s ' .
-               '<span class="lin_indicator" id="%s_status-lin">linear</span>' .
-               '<span style="display:none;" class="log_indicator" id="%s_status-log">log</span> <br> ' .
-               '<button class="log_button" onclick=swap_log("%s")>toggle log plots</button>' .
-               '</span>',
-               $plot_id, $plot_id, $plot_id, $plot_id);
-        printf('<span id="%s"><a href="%s.pdf" target="_blank"> <img src="%s.png" width="100%s"></a></span>',
-               $plot_id, $base, $base, '%');
-        printf('<span style="display:none;" id="%s_log"><a href="%s_log.pdf" target="_blank"> <img src="%s_log.png" width="100%s"></a></span>',
-               $plot_id, $base, $base, '%');
-         echo '</span>' . "\n";
-      }
-    }
-    echo '</div>' . "\n";
-  }
-
-} else {
-
-  foreach ($dirs as $dir)
-    printf('<a href="?d=%s"><header><h3>%s</h3></header></a><br>' . "\n", $dir, $dir);
-
-}
+list_directory($directory);
 
 include('footer.html');
 

--- a/RelVal/web/stylin.css
+++ b/RelVal/web/stylin.css
@@ -1,12 +1,29 @@
-header {
+.header {
     clear: both;
     background-color: #ccffff;
     padding: 1em;
-    margin:0.5em;
+    margin:0.5em 0em 0.5em 0em;
+    overflow:hidden;
 }
 
-header:hover {
+.header:hover {
+    background-color: #bbeeee;
+}
+
+.roomy {
+    float:left;
+    width:80%;
+}
+
+.metalink {
+    padding: 1em;
+    margin:0.5em 0em 0.5em 0em;
     background-color: #dddddd;
+    overflow:hidden;
+}
+
+.metalink:hover {
+    background-color: #cccccc;
 }
 
 h3 {
@@ -15,8 +32,11 @@ h3 {
 }
 
 .plot {
+    box-sizing: border-box;
     float: left;
-    width: 25%;
+    margin:1px;
+    width: calc(25% - 2px);
+    border: #ffffff 2px solid;
 }
 
 .plot_head {
@@ -46,4 +66,16 @@ h3 {
     font-size: 95%;
     line-height: 140%;
     background-color: #dddddd;
+}
+
+div.warn {
+    background-color:  #ffcccc;
+}
+
+div.warn:hover {
+    background-color:  #eebbbb;
+}
+
+span.warn {
+    border-color: #ff0000;
 }

--- a/RelVal/web/stylin.css
+++ b/RelVal/web/stylin.css
@@ -12,18 +12,31 @@
 
 .roomy {
     float:left;
-    width:80%;
+    width:70%;
 }
 
 .metalink {
     padding: 1em;
     margin:0.5em 0em 0.5em 0em;
     background-color: #dddddd;
+    float: left;
+    width: 15%;
     overflow:hidden;
 }
 
 .metalink:hover {
     background-color: #cccccc;
+}
+
+.indexlink {
+    padding: 1em;
+    margin:0.5em 0em 0.5em 0em;
+    background-color: #ffffff;
+    overflow:hidden;
+}
+
+.indexlink:hover {
+    background-color: #eeeeee;
 }
 
 h3 {

--- a/defs/panda.def
+++ b/defs/panda.def
@@ -357,7 +357,7 @@ matchedPF/PFCandRef
 matchedGen/GenParticleRef
 
 [GenJet>ParticleM]
-pdgid/S
+pdgid/S // Filled with hadron flavor
 partonFlavor/S
 numB/S
 numC/S

--- a/lib/panda/output.py
+++ b/lib/panda/output.py
@@ -48,7 +48,7 @@ class FileOutput(object):
         self._file.write('\n')
 
     def writeline(self, line):
-        self._file.write(('  ' * self.indent) + line + '\n')
+        self._file.write((('  ' * self.indent) + line + '\n').replace('//', '//<')) # Replace simple comments in .def files with doxygen-style back comments
 
     def writelines(self, lines, line_end = ''):
         indented_lines = []

--- a/lib/panda/output.py
+++ b/lib/panda/output.py
@@ -48,7 +48,7 @@ class FileOutput(object):
         self._file.write('\n')
 
     def writeline(self, line):
-        self._file.write((('  ' * self.indent) + line + '\n').replace('//', '//<')) # Replace simple comments in .def files with doxygen-style back comments
+        self._file.write((('  ' * self.indent) + line + '\n').replace('//', '///<')) # Replace simple comments in .def files with doxygen-style back comments
 
     def writelines(self, lines, line_end = ''):
         indented_lines = []

--- a/lib/panda/relval.py
+++ b/lib/panda/relval.py
@@ -9,27 +9,30 @@ header = """#ifndef IWILLSEEYOULATER
 #include <vector>
 #include "PandaTree/Objects/interface/Event.h"
 
+namespace testpanda {
 
-template <int P>
-struct plotter {
-  constexpr static const char* name = nullptr;
-};
+  template <int P>
+  struct plotter {
+    constexpr static const char* name = nullptr;
+  };
 """
 
 # Each defined structure must follow this format
 template = """
-template <>
-struct plotter <%i> {
-  constexpr static const char* name = "%s/%s";
-  std::vector<float> operator () (panda::Event& event) {
-%s
-    return output;
-  }
-};
+  template <>
+  struct plotter <%i> {
+    constexpr static const char* name = "%s/%s";
+    std::vector<float> operator () (panda::Event& event) {
+  %s
+      return output;
+    }
+  };
 """
 
 # Ending of EnumerateBranches.h
 footer = """
+};
+
 #endif"""
 
 

--- a/lib/panda/relval.py
+++ b/lib/panda/relval.py
@@ -23,7 +23,7 @@ template = """
   struct plotter <%i> {
     constexpr static const char* name = "%s/%s";
     std::vector<float> operator () (panda::Event& event) {
-  %s
+      %s
       return output;
     }
   };
@@ -92,7 +92,7 @@ def write_header(trees, file_name):
                     template % (num_plots,            # Which plot we're defining
                                 'common',             # The output directory of the plot
                                 plot.rstrip('()'),    # The name of the plot file (without extension)
-                                '    std::vector<float> output {float(event.%s)};' % plot))  # The vector of values that fills the histogram
+                                'std::vector<float> output {float(event.%s)};' % plot))  # The vector of values that fills the histogram
                 num_plots += 1
 
             for obj in tree.objbranches:
@@ -106,7 +106,7 @@ def write_header(trees, file_name):
 
 
                 # Two ways to fill the histograms whether or not this is a collection
-                action_string = '    std::vector<float> output {float(event.' + obj.name + '.%s)};'
+                action_string = 'std::vector<float> output {float(event.' + obj.name + '.%s)};'
                 if obj.conttype == 'Collection':
 
                     # Throw in size of the collection
@@ -114,11 +114,9 @@ def write_header(trees, file_name):
                     writer.writeline(template % (num_plots, obj.name, plot.rstrip('()'), action_string % plot))
                     num_plots += 1
 
-                    action_string = """
-    std::vector<float> output;
-    for (auto& i : event.{0})
-      output.push_back(i.%s);
-""".format(obj.name)
+                    action_string = """std::vector<float> output;
+      for (auto& i : event.{0})
+        output.push_back(i.%s);""".format(obj.name)
 
 
                 # Print sizes of references


### PR DESCRIPTION
I fooled around with a bunch of things since 008 that I think will be useful in this round.

- First, a minor thing that actually account for the vast majority of "number of lines changed": I put the automatically generated header files and other template tricks into a proper namespace. The main reason for this is the following page annoyed me: https://codedocs.xyz/PandaPhysics/PandaTree/annotated.html (entirely my fault). The new page will look like https://codedocs.xyz/dabercro/PandaTree/annotated.html
- I added a Jenkinsfile that our Jenkins server (https://t3serv003.mit.edu/, only accessible from the T3) can (but doesn't yet for PandaPhysics) run on. It does things like this https://github.com/dabercro/PandaTree/pull/4#issuecomment-360790839. I think it would be worthwhile testing it out on this PR, but it might be more educational if someone else sets it up for PandaPhysics. If anyone wants to mess around, make an account on the server (which unfortunately still uses it's own separate auth database), let me know, and I can add you as an admin. I'll also be back next week if we want to wait until then.
- In response to #96 I made the relval plots page more colorful. It draws attention to some surprisingly unfilled branches. Browse http://t3serv001.mit.edu/%7Ejenkins/relval/?d=dabercro/PandaTree/PR-4/1 for example test plots and anyone who has seen these before can note the new coloring. Those plots are for 80X files though. We will of course want to update to testing on a range of the 009 samples.
- Change inline comments into comments picked up by doxygen. Members commented with `//` at the ends of the lines of the `.def` files will be picked up by doxygen and added to our codedocs pages. An example: https://codedocs.xyz/dabercro/PandaTree/classpanda_1_1Lepton.html#pub-attribs