### PR TITLE
Iterator update for 93X+ and EventAnalysis class

### DIFF
--- a/Framework/interface/Iterator.h
+++ b/Framework/interface/Iterator.h
@@ -38,7 +38,7 @@ namespace panda {
       reference operator*() const { return *ptr_.obj; }
       pointer operator->() const { return ptr_.obj; }
       int operator-(self_type const& rhs) const { return ptr_.obj - rhs.operator->(); }
-      self_type& operator[](int n) const { return this->operator+(n); }
+      self_type operator[](int n) const { return this->operator+(n); }
       bool operator<(self_type const& rhs) const { return this->operator-(rhs) < 0; }
       bool operator>(self_type const& rhs) const { return this->operator-(rhs) > 0; }
       bool operator<=(self_type const& rhs) const { return !(this->operator>(rhs)); }

--- a/Framework/interface/Iterator.h
+++ b/Framework/interface/Iterator.h
@@ -22,7 +22,7 @@ namespace panda {
       typedef typename std::conditional<is_const, typename C::const_pointer, typename C::pointer>::type pointer;
 
       Iterator() {}
-      Iterator(mutable_type const& it) : ptr_(it.ptr_), unitSize_(it.unitSize_) {}
+      Iterator(mutable_type const& it) : unitSize_(it.unitSize_) { ptr_.obj = it.ptr_.obj; }
       self_type& operator++() { shiftPtr_(1); return *this; }
       self_type operator++(int) { auto itr(*this); shiftPtr_(1); return itr; }
       self_type& operator--() { shiftPtr_(-1); return *this; }
@@ -31,21 +31,30 @@ namespace panda {
       self_type& operator-=(int n) { shiftPtr_(-n); return *this; }
       self_type operator+(int n) const { auto itr(*this); return (itr += n); }
       self_type operator-(int n) const { auto itr(*this); return (itr -= n); }
-      bool operator==(mutable_type const& rhs) const { return ptr_ == rhs.ptr_; }
-      bool operator==(const_type const& rhs) const { return ptr_ == rhs.ptr_; }
-      bool operator!=(mutable_type const& rhs) const { return ptr_ != rhs.ptr_; }
-      bool operator!=(const_type const& rhs) const { return ptr_ != rhs.ptr_; }
-      reference operator*() const { return *ptr_; }
-      pointer operator->() const { return ptr_; }
+      bool operator==(mutable_type const& rhs) const { return ptr_.obj == rhs.ptr_.obj; }
+      bool operator==(const_type const& rhs) const { return ptr_.obj == rhs.ptr_.obj; }
+      bool operator!=(mutable_type const& rhs) const { return ptr_.obj != rhs.ptr_.obj; }
+      bool operator!=(const_type const& rhs) const { return ptr_.obj != rhs.ptr_.obj; }
+      reference operator*() const { return *ptr_.obj; }
+      pointer operator->() const { return ptr_.obj; }
+      int operator-(self_type const& rhs) const { return ptr_.obj - rhs.operator->(); }
+      self_type& operator[](int n) const { return this->operator+(n); }
+      bool operator<(self_type const& rhs) const { return this->operator-(rhs) < 0; }
+      bool operator>(self_type const& rhs) const { return this->operator-(rhs) > 0; }
+      bool operator<=(self_type const& rhs) const { return !(this->operator>(rhs)); }
+      bool operator>=(self_type const& rhs) const { return !(this->operator<(rhs)); }
 
     private:
-      Iterator(pointer p, unsigned unitSize) : ptr_(p), unitSize_(unitSize) {}
+      Iterator(pointer p, unsigned unitSize) : unitSize_(unitSize) { ptr_.obj = p; }
+
+      void shiftPtr_(int shift) { ptr_.ch += unitSize_ * shift; }
 
       typedef typename std::conditional<is_const, char const*, char*>::type char_pointer;
 
-      void shiftPtr_(int shift) { reinterpret_cast<char_pointer&>(ptr_) += unitSize_ * shift; }
-
-      pointer ptr_{0};
+      union Ptr {
+        pointer obj;
+        char_pointer ch;
+      } ptr_;
       unsigned const unitSize_{0};
     };
 

--- a/Framework/interface/RefVector.h
+++ b/Framework/interface/RefVector.h
@@ -125,7 +125,7 @@ namespace panda {
       int operator-(self_type const& rhs) const { 
         return this->operator*().operator->() - (*rhs).operator->(); 
       }
-      self_type& operator[](int n) const { return this->operator+(n); }
+      self_type operator[](int n) const { return this->operator+(n); }
       bool operator<(self_type const& rhs) const { return this->operator-(rhs) < 0; }
       bool operator>(self_type const& rhs) const { return this->operator-(rhs) > 0; }
       bool operator<=(self_type const& rhs) const { return !(this->operator>(rhs)); }

--- a/Framework/interface/RefVector.h
+++ b/Framework/interface/RefVector.h
@@ -106,6 +106,7 @@ namespace panda {
       typedef typename std::conditional<is_const, const_ref_type, ref_type>::type value_type;
       typedef refvector_type::RefHolder<is_const> ptr_type;
       typedef typename std::conditional<is_const, Indices::const_iterator, Indices::iterator>::type internal_type;
+      typedef int difference_type;
 
       RefVectorIterator() {}
       RefVectorIterator(self_type const& it) : container_(it.container_), itr_(it.itr_) {}
@@ -121,6 +122,14 @@ namespace panda {
       bool operator!=(self_type const& rhs) const { return itr_ != rhs.itr_; }
       value_type operator*() const { return value_type(*container_, *itr_); }
       ptr_type operator->() const { return ptr_type(*container_, *itr_); }
+      int operator-(self_type const& rhs) const { 
+        return this->operator*().operator->() - (*rhs).operator->(); 
+      }
+      self_type& operator[](int n) const { return this->operator+(n); }
+      bool operator<(self_type const& rhs) const { return this->operator-(rhs) < 0; }
+      bool operator>(self_type const& rhs) const { return this->operator-(rhs) > 0; }
+      bool operator<=(self_type const& rhs) const { return !(this->operator>(rhs)); }
+      bool operator>=(self_type const& rhs) const { return !(this->operator<(rhs)); }
 
     private:
       RefVectorIterator(ContainerBase const*& v, internal_type const& i) : container_(&v), itr_(i) {}

--- a/Objects/LinkDef.h
+++ b/Objects/LinkDef.h
@@ -34,6 +34,7 @@
 #include "PandaTree/Objects/interface/Event.h"
 #include "PandaTree/Objects/interface/Run.h"
 #include "PandaTree/Objects/interface/EventMonophoton.h"
+#include "PandaTree/Objects/interface/EventAnalysis.h"
 #include "PandaTree/Objects/interface/EventTP.h"
 #include "PandaTree/Objects/interface/EventTPEG.h"
 #include "PandaTree/Objects/interface/EventTPEEG.h"
@@ -296,6 +297,7 @@
 #pragma link C++ class panda::Event;
 #pragma link C++ class panda::Run;
 #pragma link C++ class panda::EventMonophoton;
+#pragma link C++ class panda::EventAnalysis;
 #pragma link C++ class panda::EventTP;
 #pragma link C++ class panda::EventTPEG;
 #pragma link C++ class panda::EventTPEEG;

--- a/Objects/interface/EventAnalysis.h
+++ b/Objects/interface/EventAnalysis.h
@@ -1,0 +1,43 @@
+#ifndef PandaTree_Objects_EventAnalysis_h
+#define PandaTree_Objects_EventAnalysis_h
+#include "Event.h"
+#include "Constants.h"
+#include "UnpackedGenParticle.h"
+
+namespace panda {
+
+  class EventAnalysis : public Event {
+  public:
+    EventAnalysis();
+    EventAnalysis(EventAnalysis const&);
+    ~EventAnalysis();
+    EventAnalysis& operator=(EventAnalysis const&);
+
+    void print(std::ostream& = std::cout, UInt_t level = 1) const override;
+    void dump(std::ostream& = std::cout) const override;
+
+    UnpackedGenParticleCollection genParticlesU = UnpackedGenParticleCollection("genParticlesU", 256);
+
+    static utils::BranchList getListOfBranches(Bool_t direct = kFALSE);
+
+  protected:
+    void doSetStatus_(TTree&, utils::BranchList const&) override;
+    utils::BranchList doGetStatus_(TTree&) const override;
+    utils::BranchList doGetBranchNames_() const override;
+    void doSetAddress_(TTree&, utils::BranchList const&, Bool_t setStatus) override;
+    void doBook_(TTree&, utils::BranchList const&) override;
+    void doGetEntry_(TTree&) override;
+    void doInit_() override;
+    void doUnlink_(TTree&) override;
+
+  public:
+    /* BEGIN CUSTOM EventAnalysis.h.classdef */
+    /* END CUSTOM */
+  };
+
+  /* BEGIN CUSTOM EventAnalysis.h.global */
+  /* END CUSTOM */
+
+}
+
+#endif

--- a/Objects/src/EventAnalysis.cc
+++ b/Objects/src/EventAnalysis.cc
@@ -1,0 +1,147 @@
+#include "../interface/EventAnalysis.h"
+
+panda::EventAnalysis::EventAnalysis() :
+  Event()
+{
+  std::vector<Object*> myObjects{{&genParticlesU}};
+  objects_.insert(objects_.end(), myObjects.begin(), myObjects.end());
+  std::vector<CollectionBase*> myCollections{{&genParticlesU}};
+  collections_.insert(collections_.end(), myCollections.begin(), myCollections.end());
+  /* BEGIN CUSTOM EventAnalysis.cc.ctor */
+  /* END CUSTOM */
+}
+
+panda::EventAnalysis::EventAnalysis(EventAnalysis const& _src) :
+  Event(_src),
+  genParticlesU(_src.genParticlesU)
+{
+  std::vector<Object*> myObjects{{&genParticlesU}};
+  objects_.insert(objects_.end(), myObjects.begin(), myObjects.end());
+  std::vector<CollectionBase*> myCollections{{&genParticlesU}};
+  collections_.insert(collections_.end(), myCollections.begin(), myCollections.end());
+  /* BEGIN CUSTOM EventAnalysis.cc.copy_ctor */
+  /* END CUSTOM */
+}
+
+panda::EventAnalysis::~EventAnalysis()
+{
+  /* BEGIN CUSTOM EventAnalysis.cc.dtor */
+  /* END CUSTOM */
+}
+
+panda::EventAnalysis&
+panda::EventAnalysis::operator=(EventAnalysis const& _src)
+{
+  Event::operator=(_src);
+
+  /* BEGIN CUSTOM EventAnalysis.cc.operator= */
+  /* END CUSTOM */
+
+  genParticlesU = _src.genParticlesU;
+
+  return *this;
+}
+
+void
+panda::EventAnalysis::print(std::ostream& _out/* = std::cout*/, UInt_t _level/* = 1*/) const
+{
+  /* BEGIN CUSTOM EventAnalysis.cc.print */
+  dump(_out);
+  /* END CUSTOM */
+}
+
+void
+panda::EventAnalysis::dump(std::ostream& _out/* = std::cout*/) const
+{
+  Event::dump(_out);
+
+  genParticlesU.dump(_out);
+
+}
+/*static*/
+panda::utils::BranchList
+panda::EventAnalysis::getListOfBranches(Bool_t _direct/* = kFALSE*/)
+{
+  utils::BranchList blist;
+  blist += Event::getListOfBranches(_direct);
+
+  blist += {};
+  if (!_direct) {
+    blist += UnpackedGenParticle::getListOfBranches().fullNames("genParticlesU");
+  }
+  /* BEGIN CUSTOM EventAnalysis.cc.getListOfBranches_ */
+  /* END CUSTOM */
+  return blist;
+}
+
+/*protected*/
+void
+panda::EventAnalysis::doSetStatus_(TTree& _tree, utils::BranchList const& _branches)
+{
+  Event::doSetStatus_(_tree, _branches);
+}
+
+/*protected*/
+panda::utils::BranchList
+panda::EventAnalysis::doGetStatus_(TTree& _tree) const
+{
+  utils::BranchList blist;
+  blist += Event::doGetStatus_(_tree);
+
+  return blist;
+}
+
+/*protected*/
+panda::utils::BranchList
+panda::EventAnalysis::doGetBranchNames_() const
+{
+  return getListOfBranches(true);
+}
+
+/*protected*/
+void
+panda::EventAnalysis::doSetAddress_(TTree& _tree, utils::BranchList const& _branches, Bool_t _setStatus)
+{
+  Event::doSetAddress_(_tree, _branches, _setStatus);
+
+}
+
+/*protected*/
+void
+panda::EventAnalysis::doBook_(TTree& _tree, utils::BranchList const& _branches)
+{
+  Event::doBook_(_tree, _branches);
+
+}
+
+/*protected*/
+void
+panda::EventAnalysis::doGetEntry_(TTree& _tree)
+{
+  Event::doGetEntry_(_tree);
+
+  /* BEGIN CUSTOM EventAnalysis.cc.doGetEntry_ */
+  /* END CUSTOM */
+}
+
+void
+panda::EventAnalysis::doInit_()
+{
+  Event::doInit_();
+
+  /* BEGIN CUSTOM EventAnalysis.cc.doInit_ */
+  /* END CUSTOM */
+}
+
+void
+panda::EventAnalysis::doUnlink_(TTree& _tree)
+{
+  Event::doUnlink_(_tree);
+
+  /* BEGIN CUSTOM EventAnalysis.cc.doUnlink_ */
+  /* END CUSTOM */
+}
+
+
+/* BEGIN CUSTOM EventAnalysis.cc.global */
+/* END CUSTOM */

--- a/Objects/src/EventAnalysis.cc
+++ b/Objects/src/EventAnalysis.cc
@@ -7,6 +7,8 @@ panda::EventAnalysis::EventAnalysis() :
   objects_.insert(objects_.end(), myObjects.begin(), myObjects.end());
   std::vector<CollectionBase*> myCollections{{&genParticlesU}};
   collections_.insert(collections_.end(), myCollections.begin(), myCollections.end());
+
+  genParticlesU.data.parentContainer_ = &genParticlesU;
   /* BEGIN CUSTOM EventAnalysis.cc.ctor */
   /* END CUSTOM */
 }
@@ -19,6 +21,8 @@ panda::EventAnalysis::EventAnalysis(EventAnalysis const& _src) :
   objects_.insert(objects_.end(), myObjects.begin(), myObjects.end());
   std::vector<CollectionBase*> myCollections{{&genParticlesU}};
   collections_.insert(collections_.end(), myCollections.begin(), myCollections.end());
+
+  genParticlesU.data.parentContainer_ = &genParticlesU;
   /* BEGIN CUSTOM EventAnalysis.cc.copy_ctor */
   /* END CUSTOM */
 }
@@ -38,6 +42,8 @@ panda::EventAnalysis::operator=(EventAnalysis const& _src)
   /* END CUSTOM */
 
   genParticlesU = _src.genParticlesU;
+
+  genParticlesU.data.parentContainer_ = &genParticlesU;
 
   return *this;
 }

--- a/defs/pandaanalysis.def
+++ b/defs/pandaanalysis.def
@@ -1,0 +1,4 @@
+<require panda>
+
+{EventAnalysis>Event}
+genParticlesU/UnpackedGenParticleCollection(256)

--- a/defs/pandaanalysis.def
+++ b/defs/pandaanalysis.def
@@ -2,3 +2,4 @@
 
 {EventAnalysis>Event}
 genParticlesU/UnpackedGenParticleCollection(256)
+genParticlesU.parent->genParticlesU


### PR DESCRIPTION
- Needed to modify the `Iterator` and `RefVector` classes slightly for the gcc that comes with 93X+.
- Added an `EventAnalysis` class that inherits from `Event`, to make reading gen-only panda files transparent. 