### PR TITLE
Only download plots that are revealed.

### DIFF
--- a/RelVal/web/index.php
+++ b/RelVal/web/index.php
@@ -32,26 +32,22 @@ function list_directory($directory) {
       echo '</div>' . "\n";
       printf('<div style="display:none;" class="plots" id="%s">' . "\n", $obj);
       $plots = scandir($directory . '/' . $obj);
+      echo '{"plots": [';
+      $nocomma = TRUE;
       foreach ($plots as $plot) {
         $file_parts = pathinfo($plot);
         if ($file_parts['extension'] == 'pdf' and substr($file_parts['filename'], -4) != '_log') {
           $base = $directory . '/' . $obj . '/' . $file_parts['filename'];
           $warn = (file_exists($base . '_FLAG.txt')) ? ' warn' : '';
           $plot_id = $obj . '/' . $file_parts['filename'];
-          printf('<span class="plot%s">', $warn);
-          printf('<span class="plot_head">%s ' .
-                 '<span class="lin_indicator" id="%s_status-lin">linear</span>' .
-                 '<span style="display:none;" class="log_indicator" id="%s_status-log">log</span> <br> ' .
-                 '<button class="log_button" onclick=swap_log("%s")>toggle log plots</button>' .
-                 '</span>',
-                 $plot_id, $plot_id, $plot_id, $plot_id);
-          printf('<span id="%s"><a href="%s.pdf" target="_blank"> <img src="%s.png" width="100%s"></a></span>',
-                 $plot_id, $base, $base, '%');
-          printf('<span style="display:none;" id="%s_log"><a href="%s_log.pdf" target="_blank"> <img src="%s_log.png" width="100%s"></a></span>',
-                 $plot_id, $base, $base, '%');
-           echo '</span>' . "\n";
+          if ($nocomma)
+            $nocomma = FALSE;
+          else
+            printf(', ');
+          printf('{"base": "%s", "warn": "%s", "id": "%s"}', $base, $warn, $plot_id);
         }
       }
+      echo "]}\n";
       echo '</div>' . "\n";
     }
 

--- a/RelVal/web/reveal.js
+++ b/RelVal/web/reveal.js
@@ -6,20 +6,23 @@ function reveal(id) {
     else
         div.style.display = "none";
 
-    if (JSON.parse(div.innerHTML) || JSON.parse(null)) {
+    try {
         var plots = JSON.parse(div.innerHTML).plots;
         div.innerHTML = '';
         plots.forEach(function (obj) {
                 div.innerHTML += '<span class="plot' + obj.warn + '">' +
-                    ('<span class="plot_head">%s <span class="lin_indicator" id="%s_status-lin">linear</span>' +
-                     '<span style="display:none;" class="log_indicator" id="%s_status-log">log</span> <br> ' +
-                     '<button class="log_button" onclick=swap_log("%s")>toggle log plots</button></span>').replace('%s', obj.id) +
+                    ('<span class="plot_head">ID <span class="lin_indicator" id="ID_status-lin">linear</span>' +
+                     '<span style="display:none;" class="log_indicator" id="ID_status-log">log</span> <br> ' +
+                     '<button class="log_button" onclick=swap_log("ID")>toggle log plots</button></span>').replace(/ID/g, obj.id) +
                     '<span id="' + obj.id + '"><a href="' + obj.base + '.pdf" target="_blank"> <img src="' + obj.base +
                     '.png" width="100%"></a></span>' +
                     '<span style="display:none;" id="' + obj.id + '_log"><a href="' + obj.base + '_log.pdf" target="_blank"> <img src="' + obj.base +
                     '_log.png" width="100%"></a></span>' +
                     '</span>';
             });
+    }
+    catch(e) {
+        // Not valid JSON. Do nothing.
     }
 }
 

--- a/RelVal/web/reveal.js
+++ b/RelVal/web/reveal.js
@@ -6,6 +6,21 @@ function reveal(id) {
     else
         div.style.display = "none";
 
+    if (JSON.parse(div.innerHTML) || JSON.parse(null)) {
+        var plots = JSON.parse(div.innerHTML).plots;
+        div.innerHTML = '';
+        plots.forEach(function (obj) {
+                div.innerHTML += '<span class="plot' + obj.warn + '">' +
+                    ('<span class="plot_head">%s <span class="lin_indicator" id="%s_status-lin">linear</span>' +
+                     '<span style="display:none;" class="log_indicator" id="%s_status-log">log</span> <br> ' +
+                     '<button class="log_button" onclick=swap_log("%s")>toggle log plots</button></span>').replace('%s', obj.id) +
+                    '<span id="' + obj.id + '"><a href="' + obj.base + '.pdf" target="_blank"> <img src="' + obj.base +
+                    '.png" width="100%"></a></span>' +
+                    '<span style="display:none;" id="' + obj.id + '_log"><a href="' + obj.base + '_log.pdf" target="_blank"> <img src="' + obj.base +
+                    '_log.png" width="100%"></a></span>' +
+                    '</span>';
+            });
+    }
 }
 
 function swap_log(id_base) {


### PR DESCRIPTION
This is minor, but was annoying me. Before, the default behavior of the relval page was to download all the plots at the beginning, and keep them hidden. This could be very slow since there are a lot of plots. With this plots for a given physics object will only be downloaded the first time the object is revealed.