### PR TITLE
Speed up trigger object loading

### DIFF
--- a/Objects/interface/EventBase.h
+++ b/Objects/interface/EventBase.h
@@ -83,6 +83,9 @@ namespace panda {
     RRNG rng{0,0,nullptr};
 
   private:
+    //! Update the triggerFilterMask at run transitions
+    void setTriggerFilters_();
+
     //! Flag to set run synch feature on/off
     Bool_t readRunTree_{kTRUE};
 

--- a/Objects/interface/EventBase.h
+++ b/Objects/interface/EventBase.h
@@ -72,6 +72,13 @@ namespace panda {
     //! Trigger object collection with additional features.
     HLTObjectStore triggerObjects = HLTObjectStore("triggerObjects");
 
+    //! Use to declare a trigger filter name (key in the triggerObjects map) to be used in the analysis.
+    /*!
+     * By default, all trigger objects are loaded into the triggerObjects map at each call to getEntry.
+     * Once a call to this function is made, only the objects for the registered filter will be loaded.
+     */
+    void registerTriggerObjects(char const* filter) { registeredTriggerFilters_.emplace_back(filter); }
+
     //! Repeatable random number generator, initialized to be empty
     RRNG rng{0,0,nullptr};
 
@@ -84,6 +91,12 @@ namespace panda {
      event tree -> tree number, run tree 
      */
     std::map<TTree*, std::pair<Int_t, TTree*>> runTrees_;
+
+    //! List of trigger object filter names to use
+    std::vector<TString> registeredTriggerFilters_{};
+
+    //! Trigger filter mask generated from registeredTriggerFilters for each run
+    std::vector<bool> triggerFilterMask_{};
 
     /* END CUSTOM */
   };

--- a/Objects/interface/HLTObjectStore.h
+++ b/Objects/interface/HLTObjectStore.h
@@ -18,11 +18,19 @@ namespace panda {
     ~HLTObjectStore() {}
     HLTObjectStore& operator=(HLTObjectStore const&);
 
-    void makeMap(std::vector<TString> const& filters);
+    //! Reset the filterObjects map for each run. Not to be called by users.
+    void setFilterObjectKeys(std::vector<TString> const& filters);
+
+    //! Fill the filterObjects map for each event. Not to be called by users.
+    void makeMap(std::vector<bool> const& mask);
+
+    //! filterObjects_.at() with warnings. To be called by users.
     HLTObjectVector const& filterObjects(char const* filter) const;
 
   protected:
     std::map<TString, HLTObjectVector> filterObjects_{};
+    //! internal-use pointers to the values of filterObjects_
+    std::vector<HLTObjectVector*> objectVectors_{};
   };
 
 }

--- a/Objects/interface/Run.h
+++ b/Objects/interface/Run.h
@@ -72,7 +72,7 @@ namespace panda {
     UInt_t triggerSize() const { return triggerPaths().size(); }
 
     //! Check for updates
-    void findEntry(TTree& runTree, UInt_t runNumber);
+    bool findEntry(TTree& runTree, UInt_t runNumber);
 
     //! Reset inputTree_, inputTreeNumber_, and hltMenuCache_
     void resetCache();

--- a/Objects/src/EventBase.cc
+++ b/Objects/src/EventBase.cc
@@ -178,7 +178,10 @@ panda::EventBase::doGetEntry_(TTree& _tree)
 
     if (_tree.GetTreeNumber() == rItr->second.first) {
       // We are on the same tree. Just check for run number transition (and update the trigger table if necessary)
-      run.findEntry(*rItr->second.second, runNumber);
+      if (run.findEntry(*rItr->second.second, runNumber)) {
+        // there was a run transition
+        setTriggerFilters_();
+      }
     }
     else {
       // There was a file transition in the input
@@ -209,26 +212,7 @@ panda::EventBase::doGetEntry_(TTree& _tree)
         // Now cue the run object to the given run number
         run.findEntry(*rItr->second.second, runNumber);
 
-        if (triggerObjects.size() != 0 && run.hlt.filters) {
-          triggerObjects.setFilterObjectKeys(*run.hlt.filters);
-
-          if (registeredTriggerFilters_.empty()) {
-            // if no filters are registered, don't mask
-            triggerFilterMask_.resize(run.hlt.filters->size(), true);
-          }
-          else {
-            // else only allow the registered filters
-            triggerFilterMask_.resize(run.hlt.filters->size(), false);
-            for (unsigned fidx(0); fidx != run.hlt.filters->size(); ++fidx) {
-              for (auto& filter : registeredTriggerFilters_) {
-                if (filter == run.hlt.filters->at(fidx)) {
-                  triggerFilterMask_[fidx] = true;
-                  break;
-                }
-              }
-            }
-          }
-        }
+        setTriggerFilters_();
       }
       else {
         rItr->second.second = 0;
@@ -276,6 +260,32 @@ panda::EventBase::triggerFired(UInt_t _token) const
     return triggers.pass(idx);
   else
     return false;
+}
+
+void
+panda::EventBase::setTriggerFilters_()
+{
+
+  if (triggerObjects.size() != 0 && run.hlt.filters) {
+    triggerObjects.setFilterObjectKeys(*run.hlt.filters);
+
+    if (registeredTriggerFilters_.empty()) {
+      // if no filters are registered, don't mask
+      triggerFilterMask_.resize(run.hlt.filters->size(), true);
+    }
+    else {
+      // else only allow the registered filters
+      triggerFilterMask_.resize(run.hlt.filters->size(), false);
+      for (unsigned fidx(0); fidx != run.hlt.filters->size(); ++fidx) {
+        for (auto& filter : registeredTriggerFilters_) {
+          if (filter == run.hlt.filters->at(fidx)) {
+            triggerFilterMask_[fidx] = true;
+            break;
+          }
+        }
+      }
+    }
+  }
 }
 
 /* END CUSTOM */

--- a/Objects/src/HLTObjectStore.cc
+++ b/Objects/src/HLTObjectStore.cc
@@ -39,23 +39,29 @@ panda::HLTObjectStore::operator=(HLTObjectStore const& _rhs)
 }
 
 void
-panda::HLTObjectStore::makeMap(std::vector<TString> const& _filters)
+panda::HLTObjectStore::setFilterObjectKeys(std::vector<TString> const& _filters)
 {
-  std::vector<HLTObjectVector> objects(_filters.size());
+  filterObjects_.clear();
+  if (_filters.size() > objectVectors_.size())
+    objectVectors_.resize(_filters.size());
 
+  for (UShort_t fidx(0); fidx != _filters.size(); ++fidx)
+    objectVectors_[fidx] = &filterObjects_[_filters[fidx]];
+}
+
+void
+panda::HLTObjectStore::makeMap(std::vector<bool> const& _mask)
+{
   for (auto& obj : *this) {
     for (UShort_t fidx : *obj.filters) {
-      if (fidx < _filters.size())
-        objects[fidx].push_back(&obj);
+      if (fidx < _mask.size()) {
+        if (_mask[fidx])
+          objectVectors_[fidx]->push_back(&obj);
+      }
       else
         throw std::runtime_error("List of filters passed to HLTObjectStore::makeMap too short");
     }
   }
-
-  filterObjects_.clear();
-
-  for (unsigned fidx(0); fidx != _filters.size(); ++fidx)
-    filterObjects_.emplace(_filters[fidx], objects[fidx]);
 }
 
 panda::HLTObjectStore::HLTObjectVector const&

--- a/Objects/src/HLTObjectStore.cc
+++ b/Objects/src/HLTObjectStore.cc
@@ -59,7 +59,7 @@ panda::HLTObjectStore::makeMap(std::vector<bool> const& _mask)
           objectVectors_[fidx]->push_back(&obj);
       }
       else
-        throw std::runtime_error("Invalid trigger filter index %d found in trigger objects. There is very likely a bug in HLTObjectStore or EventBase.");
+        throw std::runtime_error(TString::Format("Invalid trigger filter index %d found in trigger objects. There is very likely a bug in HLTObjectStore or EventBase.", fidx).Data());
     }
   }
 }

--- a/Objects/src/HLTObjectStore.cc
+++ b/Objects/src/HLTObjectStore.cc
@@ -52,6 +52,9 @@ panda::HLTObjectStore::setFilterObjectKeys(std::vector<TString> const& _filters)
 void
 panda::HLTObjectStore::makeMap(std::vector<bool> const& _mask)
 {
+  for (auto* objv : objectVectors_)
+    objv->clear();
+
   for (auto& obj : *this) {
     for (UShort_t fidx : *obj.filters) {
       if (fidx < _mask.size()) {

--- a/Objects/src/HLTObjectStore.cc
+++ b/Objects/src/HLTObjectStore.cc
@@ -59,7 +59,7 @@ panda::HLTObjectStore::makeMap(std::vector<bool> const& _mask)
           objectVectors_[fidx]->push_back(&obj);
       }
       else
-        throw std::runtime_error("List of filters passed to HLTObjectStore::makeMap too short");
+        throw std::runtime_error("Invalid trigger filter index %d found in trigger objects. There is very likely a bug in HLTObjectStore or EventBase.");
     }
   }
 }

--- a/Objects/src/Run.cc
+++ b/Objects/src/Run.cc
@@ -250,7 +250,7 @@ panda::Run::triggerPaths() const
   return *hlt.paths;
 }
 
-void
+bool
 panda::Run::findEntry(TTree& _runTree, UInt_t _runNumber)
 {
   // Known issue: if this function is called with a new tree but with the same run number as the previous call,
@@ -259,7 +259,7 @@ panda::Run::findEntry(TTree& _runTree, UInt_t _runNumber)
   // (EventBase::doGetEntry_ does that).
 
   if (_runNumber == runNumber)
-    return;
+    return false;
 
   long iEntry(0);
   while (_runTree.GetEntry(iEntry++) > 0) {
@@ -272,6 +272,8 @@ panda::Run::findEntry(TTree& _runTree, UInt_t _runNumber)
   }
 
   doGetEntry_(_runTree);
+
+  return true;
 }
 
 void


### PR DESCRIPTION
- Was recreating the entire trigger filter -> object vector map at each event, with creation of a vector of vectors as a temporary
- Dropped the temporary vector
- Map now created at run / file transition. Only the object vector is refilled at each run
- `EventBase` (and so `Event`) now has `registerTriggerObjects(const char* filtername)` which can be used to limit the object vectors to be filled. Filters must be registered beforehand; they are checked only at the run transitions.