### PR TITLE
trigger objects was not considered as a collection

### DIFF
--- a/Objects/src/EventBase.cc
+++ b/Objects/src/EventBase.cc
@@ -7,6 +7,7 @@ panda::EventBase::EventBase() :
   objects_.insert(objects_.end(), myObjects.begin(), myObjects.end());
   /* BEGIN CUSTOM EventBase.cc.ctor */
   objects_.push_back(&triggerObjects);
+  collections_.push_back(&triggerObjects);
   rng.setSeedAddress(&eventNumber);
   /* END CUSTOM */
 }


### PR DESCRIPTION
Without being in collections_ vector, branch address is not automatically reset when there is a reallocation of the collection memory. So after an event with more than 512 (initial collection size) trigger objects, we have a reallocated vector but a branch pointing to the old memory address.