### PR TITLE
A flag to know which collection a gen particle is from

### DIFF
--- a/Objects/interface/GenParticle.h
+++ b/Objects/interface/GenParticle.h
@@ -44,6 +44,7 @@ namespace panda {
       */
       Int_t* pdgid{0};
       Bool_t* finalState{0};
+      Bool_t* miniaodPacked{0};
       UShort_t* statusFlags{0};
       ContainerBase const* parentContainer_{0};
       Short_t* parent_{0};
@@ -85,6 +86,7 @@ namespace panda {
     */
     Int_t& pdgid;
     Bool_t& finalState;
+    Bool_t& miniaodPacked;
     UShort_t& statusFlags;
     Ref<GenParticle> parent;
 

--- a/Objects/interface/UnpackedGenParticle.h
+++ b/Objects/interface/UnpackedGenParticle.h
@@ -26,6 +26,7 @@ namespace panda {
       */
       Int_t* pdgid{0};
       Bool_t* finalState{0};
+      Bool_t* miniaodPacked{0};
       UShort_t* statusFlags{0};
       ContainerBase const* parentContainer_{0};
       Short_t* parent_{0};
@@ -61,6 +62,7 @@ namespace panda {
 
     Int_t& pdgid;
     Bool_t& finalState;
+    Bool_t& miniaodPacked;
     UShort_t& statusFlags;
     Ref<UnpackedGenParticle> parent;
 

--- a/Objects/src/GenParticle.cc
+++ b/Objects/src/GenParticle.cc
@@ -24,7 +24,7 @@ panda::GenParticle::getListOfBranches()
 {
   utils::BranchList blist;
   blist += PackedParticle::getListOfBranches();
-  blist += {"pdgid", "finalState", "statusFlags", "parent_"};
+  blist += {"pdgid", "finalState", "miniaodPacked", "statusFlags", "parent_"};
   return blist;
 }
 
@@ -35,6 +35,7 @@ panda::GenParticle::datastore::allocate(UInt_t _nmax)
 
   pdgid = new Int_t[nmax_];
   finalState = new Bool_t[nmax_];
+  miniaodPacked = new Bool_t[nmax_];
   statusFlags = new UShort_t[nmax_];
   parent_ = new Short_t[nmax_];
 }
@@ -48,6 +49,8 @@ panda::GenParticle::datastore::deallocate()
   pdgid = 0;
   delete [] finalState;
   finalState = 0;
+  delete [] miniaodPacked;
+  miniaodPacked = 0;
   delete [] statusFlags;
   statusFlags = 0;
   delete [] parent_;
@@ -61,6 +64,7 @@ panda::GenParticle::datastore::setStatus(TTree& _tree, TString const& _name, uti
 
   utils::setStatus(_tree, _name, "pdgid", _branches);
   utils::setStatus(_tree, _name, "finalState", _branches);
+  utils::setStatus(_tree, _name, "miniaodPacked", _branches);
   utils::setStatus(_tree, _name, "statusFlags", _branches);
   utils::setStatus(_tree, _name, "parent_", _branches);
 }
@@ -72,6 +76,7 @@ panda::GenParticle::datastore::getStatus(TTree& _tree, TString const& _name) con
 
   blist.push_back(utils::getStatus(_tree, _name, "pdgid"));
   blist.push_back(utils::getStatus(_tree, _name, "finalState"));
+  blist.push_back(utils::getStatus(_tree, _name, "miniaodPacked"));
   blist.push_back(utils::getStatus(_tree, _name, "statusFlags"));
   blist.push_back(utils::getStatus(_tree, _name, "parent_"));
 
@@ -85,6 +90,7 @@ panda::GenParticle::datastore::setAddress(TTree& _tree, TString const& _name, ut
 
   utils::setAddress(_tree, _name, "pdgid", pdgid, _branches, _setStatus);
   utils::setAddress(_tree, _name, "finalState", finalState, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "miniaodPacked", miniaodPacked, _branches, _setStatus);
   utils::setAddress(_tree, _name, "statusFlags", statusFlags, _branches, _setStatus);
   utils::setAddress(_tree, _name, "parent_", parent_, _branches, _setStatus);
 }
@@ -98,6 +104,7 @@ panda::GenParticle::datastore::book(TTree& _tree, TString const& _name, utils::B
 
   utils::book(_tree, _name, "pdgid", size, 'I', pdgid, _branches);
   utils::book(_tree, _name, "finalState", size, 'O', finalState, _branches);
+  utils::book(_tree, _name, "miniaodPacked", size, 'O', miniaodPacked, _branches);
   utils::book(_tree, _name, "statusFlags", size, 's', statusFlags, _branches);
   utils::book(_tree, _name, "parent_", size, 'S', parent_, _branches);
 }
@@ -109,6 +116,7 @@ panda::GenParticle::datastore::releaseTree(TTree& _tree, TString const& _name)
 
   utils::resetAddress(_tree, _name, "pdgid");
   utils::resetAddress(_tree, _name, "finalState");
+  utils::resetAddress(_tree, _name, "miniaodPacked");
   utils::resetAddress(_tree, _name, "statusFlags");
   utils::resetAddress(_tree, _name, "parent_");
 }
@@ -131,6 +139,7 @@ panda::GenParticle::GenParticle(char const* _name/* = ""*/) :
   PackedParticle(new GenParticleArray(1, _name)),
   pdgid(gStore.getData(this).pdgid[0]),
   finalState(gStore.getData(this).finalState[0]),
+  miniaodPacked(gStore.getData(this).miniaodPacked[0]),
   statusFlags(gStore.getData(this).statusFlags[0]),
   parent(gStore.getData(this).parentContainer_, gStore.getData(this).parent_[0])
 {
@@ -140,6 +149,7 @@ panda::GenParticle::GenParticle(GenParticle const& _src) :
   PackedParticle(new GenParticleArray(1, _src.getName())),
   pdgid(gStore.getData(this).pdgid[0]),
   finalState(gStore.getData(this).finalState[0]),
+  miniaodPacked(gStore.getData(this).miniaodPacked[0]),
   statusFlags(gStore.getData(this).statusFlags[0]),
   parent(gStore.getData(this).parentContainer_, gStore.getData(this).parent_[0])
 {
@@ -147,6 +157,7 @@ panda::GenParticle::GenParticle(GenParticle const& _src) :
 
   pdgid = _src.pdgid;
   finalState = _src.finalState;
+  miniaodPacked = _src.miniaodPacked;
   statusFlags = _src.statusFlags;
   parent = _src.parent;
 }
@@ -155,6 +166,7 @@ panda::GenParticle::GenParticle(datastore& _data, UInt_t _idx) :
   PackedParticle(_data, _idx),
   pdgid(_data.pdgid[_idx]),
   finalState(_data.finalState[_idx]),
+  miniaodPacked(_data.miniaodPacked[_idx]),
   statusFlags(_data.statusFlags[_idx]),
   parent(_data.parentContainer_, _data.parent_[_idx])
 {
@@ -164,6 +176,7 @@ panda::GenParticle::GenParticle(ArrayBase* _array) :
   PackedParticle(_array),
   pdgid(gStore.getData(this).pdgid[0]),
   finalState(gStore.getData(this).finalState[0]),
+  miniaodPacked(gStore.getData(this).miniaodPacked[0]),
   statusFlags(gStore.getData(this).statusFlags[0]),
   parent(gStore.getData(this).parentContainer_, gStore.getData(this).parent_[0])
 {
@@ -191,6 +204,7 @@ panda::GenParticle::operator=(GenParticle const& _src)
 
   pdgid = _src.pdgid;
   finalState = _src.finalState;
+  miniaodPacked = _src.miniaodPacked;
   statusFlags = _src.statusFlags;
   parent = _src.parent;
 
@@ -207,6 +221,7 @@ panda::GenParticle::doBook_(TTree& _tree, TString const& _name, utils::BranchLis
 
   utils::book(_tree, _name, "pdgid", "", 'I', &pdgid, _branches);
   utils::book(_tree, _name, "finalState", "", 'O', &finalState, _branches);
+  utils::book(_tree, _name, "miniaodPacked", "", 'O', &miniaodPacked, _branches);
   utils::book(_tree, _name, "statusFlags", "", 's', &statusFlags, _branches);
   utils::book(_tree, _name, "parent_", "", 'S', gStore.getData(this).parent_, _branches);
 }
@@ -218,6 +233,7 @@ panda::GenParticle::doInit_()
 
   pdgid = 0;
   finalState = false;
+  miniaodPacked = false;
   statusFlags = 0;
   parent.init();
 
@@ -244,6 +260,7 @@ panda::GenParticle::dump(std::ostream& _out/* = std::cout*/) const
 
   _out << "pdgid = " << pdgid << std::endl;
   _out << "finalState = " << finalState << std::endl;
+  _out << "miniaodPacked = " << miniaodPacked << std::endl;
   _out << "statusFlags = " << statusFlags << std::endl;
   _out << "parent = " << parent << std::endl;
 }

--- a/Objects/src/UnpackedGenParticle.cc
+++ b/Objects/src/UnpackedGenParticle.cc
@@ -6,7 +6,7 @@ panda::UnpackedGenParticle::getListOfBranches()
 {
   utils::BranchList blist;
   blist += ParticleM::getListOfBranches();
-  blist += {"pdgid", "finalState", "statusFlags", "parent_"};
+  blist += {"pdgid", "finalState", "miniaodPacked", "statusFlags", "parent_"};
   return blist;
 }
 
@@ -17,6 +17,7 @@ panda::UnpackedGenParticle::datastore::allocate(UInt_t _nmax)
 
   pdgid = new Int_t[nmax_];
   finalState = new Bool_t[nmax_];
+  miniaodPacked = new Bool_t[nmax_];
   statusFlags = new UShort_t[nmax_];
   parent_ = new Short_t[nmax_];
 }
@@ -30,6 +31,8 @@ panda::UnpackedGenParticle::datastore::deallocate()
   pdgid = 0;
   delete [] finalState;
   finalState = 0;
+  delete [] miniaodPacked;
+  miniaodPacked = 0;
   delete [] statusFlags;
   statusFlags = 0;
   delete [] parent_;
@@ -43,6 +46,7 @@ panda::UnpackedGenParticle::datastore::setStatus(TTree& _tree, TString const& _n
 
   utils::setStatus(_tree, _name, "pdgid", _branches);
   utils::setStatus(_tree, _name, "finalState", _branches);
+  utils::setStatus(_tree, _name, "miniaodPacked", _branches);
   utils::setStatus(_tree, _name, "statusFlags", _branches);
   utils::setStatus(_tree, _name, "parent_", _branches);
 }
@@ -54,6 +58,7 @@ panda::UnpackedGenParticle::datastore::getStatus(TTree& _tree, TString const& _n
 
   blist.push_back(utils::getStatus(_tree, _name, "pdgid"));
   blist.push_back(utils::getStatus(_tree, _name, "finalState"));
+  blist.push_back(utils::getStatus(_tree, _name, "miniaodPacked"));
   blist.push_back(utils::getStatus(_tree, _name, "statusFlags"));
   blist.push_back(utils::getStatus(_tree, _name, "parent_"));
 
@@ -67,6 +72,7 @@ panda::UnpackedGenParticle::datastore::setAddress(TTree& _tree, TString const& _
 
   utils::setAddress(_tree, _name, "pdgid", pdgid, _branches, _setStatus);
   utils::setAddress(_tree, _name, "finalState", finalState, _branches, _setStatus);
+  utils::setAddress(_tree, _name, "miniaodPacked", miniaodPacked, _branches, _setStatus);
   utils::setAddress(_tree, _name, "statusFlags", statusFlags, _branches, _setStatus);
   utils::setAddress(_tree, _name, "parent_", parent_, _branches, _setStatus);
 }
@@ -80,6 +86,7 @@ panda::UnpackedGenParticle::datastore::book(TTree& _tree, TString const& _name, 
 
   utils::book(_tree, _name, "pdgid", size, 'I', pdgid, _branches);
   utils::book(_tree, _name, "finalState", size, 'O', finalState, _branches);
+  utils::book(_tree, _name, "miniaodPacked", size, 'O', miniaodPacked, _branches);
   utils::book(_tree, _name, "statusFlags", size, 's', statusFlags, _branches);
   utils::book(_tree, _name, "parent_", size, 'S', parent_, _branches);
 }
@@ -91,6 +98,7 @@ panda::UnpackedGenParticle::datastore::releaseTree(TTree& _tree, TString const& 
 
   utils::resetAddress(_tree, _name, "pdgid");
   utils::resetAddress(_tree, _name, "finalState");
+  utils::resetAddress(_tree, _name, "miniaodPacked");
   utils::resetAddress(_tree, _name, "statusFlags");
   utils::resetAddress(_tree, _name, "parent_");
 }
@@ -113,6 +121,7 @@ panda::UnpackedGenParticle::UnpackedGenParticle(char const* _name/* = ""*/) :
   ParticleM(new UnpackedGenParticleArray(1, _name)),
   pdgid(gStore.getData(this).pdgid[0]),
   finalState(gStore.getData(this).finalState[0]),
+  miniaodPacked(gStore.getData(this).miniaodPacked[0]),
   statusFlags(gStore.getData(this).statusFlags[0]),
   parent(gStore.getData(this).parentContainer_, gStore.getData(this).parent_[0])
 {
@@ -122,6 +131,7 @@ panda::UnpackedGenParticle::UnpackedGenParticle(UnpackedGenParticle const& _src)
   ParticleM(new UnpackedGenParticleArray(1, _src.getName())),
   pdgid(gStore.getData(this).pdgid[0]),
   finalState(gStore.getData(this).finalState[0]),
+  miniaodPacked(gStore.getData(this).miniaodPacked[0]),
   statusFlags(gStore.getData(this).statusFlags[0]),
   parent(gStore.getData(this).parentContainer_, gStore.getData(this).parent_[0])
 {
@@ -129,6 +139,7 @@ panda::UnpackedGenParticle::UnpackedGenParticle(UnpackedGenParticle const& _src)
 
   pdgid = _src.pdgid;
   finalState = _src.finalState;
+  miniaodPacked = _src.miniaodPacked;
   statusFlags = _src.statusFlags;
   parent = _src.parent;
 }
@@ -137,6 +148,7 @@ panda::UnpackedGenParticle::UnpackedGenParticle(datastore& _data, UInt_t _idx) :
   ParticleM(_data, _idx),
   pdgid(_data.pdgid[_idx]),
   finalState(_data.finalState[_idx]),
+  miniaodPacked(_data.miniaodPacked[_idx]),
   statusFlags(_data.statusFlags[_idx]),
   parent(_data.parentContainer_, _data.parent_[_idx])
 {
@@ -146,6 +158,7 @@ panda::UnpackedGenParticle::UnpackedGenParticle(ArrayBase* _array) :
   ParticleM(_array),
   pdgid(gStore.getData(this).pdgid[0]),
   finalState(gStore.getData(this).finalState[0]),
+  miniaodPacked(gStore.getData(this).miniaodPacked[0]),
   statusFlags(gStore.getData(this).statusFlags[0]),
   parent(gStore.getData(this).parentContainer_, gStore.getData(this).parent_[0])
 {
@@ -173,6 +186,7 @@ panda::UnpackedGenParticle::operator=(UnpackedGenParticle const& _src)
 
   pdgid = _src.pdgid;
   finalState = _src.finalState;
+  miniaodPacked = _src.miniaodPacked;
   statusFlags = _src.statusFlags;
   parent = _src.parent;
 
@@ -189,6 +203,7 @@ panda::UnpackedGenParticle::doBook_(TTree& _tree, TString const& _name, utils::B
 
   utils::book(_tree, _name, "pdgid", "", 'I', &pdgid, _branches);
   utils::book(_tree, _name, "finalState", "", 'O', &finalState, _branches);
+  utils::book(_tree, _name, "miniaodPacked", "", 'O', &miniaodPacked, _branches);
   utils::book(_tree, _name, "statusFlags", "", 's', &statusFlags, _branches);
   utils::book(_tree, _name, "parent_", "", 'S', gStore.getData(this).parent_, _branches);
 }
@@ -200,6 +215,7 @@ panda::UnpackedGenParticle::doInit_()
 
   pdgid = 0;
   finalState = false;
+  miniaodPacked = false;
   statusFlags = 0;
   parent.init();
 
@@ -222,6 +238,7 @@ panda::UnpackedGenParticle::dump(std::ostream& _out/* = std::cout*/) const
 
   _out << "pdgid = " << pdgid << std::endl;
   _out << "finalState = " << finalState << std::endl;
+  _out << "miniaodPacked = " << miniaodPacked << std::endl;
   _out << "statusFlags = " << statusFlags << std::endl;
   _out << "parent = " << parent << std::endl;
 }

--- a/RelVal/interface/EnumerateBranches.h
+++ b/RelVal/interface/EnumerateBranches.h
@@ -7795,22 +7795,22 @@ namespace testpanda {
 
   template <>
   struct plotter <714> {
-    constexpr static const char* name = "genParticles/phi";
+    constexpr static const char* name = "genParticles/miniaodPacked";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output;
       for (auto& i : event.genParticles)
-        output.push_back(i.phi());
+        output.push_back(i.miniaodPacked);
       return output;
     }
   };
 
   template <>
   struct plotter <715> {
-    constexpr static const char* name = "genParticles/pz";
+    constexpr static const char* name = "genParticles/phi";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output;
       for (auto& i : event.genParticles)
-        output.push_back(i.pz());
+        output.push_back(i.phi());
       return output;
     }
   };
@@ -7850,6 +7850,17 @@ namespace testpanda {
 
   template <>
   struct plotter <719> {
+    constexpr static const char* name = "genParticles/pz";
+    std::vector<float> operator () (panda::Event& event) {
+      std::vector<float> output;
+      for (auto& i : event.genParticles)
+        output.push_back(i.pz());
+      return output;
+    }
+  };
+
+  template <>
+  struct plotter <720> {
     constexpr static const char* name = "genParticles/px";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output;
@@ -7860,7 +7871,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <720> {
+  struct plotter <721> {
     constexpr static const char* name = "genParticles/e";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output;
@@ -7871,7 +7882,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <721> {
+  struct plotter <722> {
     constexpr static const char* name = "genVertex/y";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.genVertex.y)};
@@ -7880,7 +7891,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <722> {
+  struct plotter <723> {
     constexpr static const char* name = "genVertex/x";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.genVertex.x)};
@@ -7889,7 +7900,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <723> {
+  struct plotter <724> {
     constexpr static const char* name = "genVertex/z";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.genVertex.z)};
@@ -7898,7 +7909,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <724> {
+  struct plotter <725> {
     constexpr static const char* name = "partons/size";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.partons.size())};
@@ -7907,7 +7918,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <725> {
+  struct plotter <726> {
     constexpr static const char* name = "partons/pt";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output;
@@ -7918,7 +7929,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <726> {
+  struct plotter <727> {
     constexpr static const char* name = "partons/p";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output;
@@ -7929,7 +7940,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <727> {
+  struct plotter <728> {
     constexpr static const char* name = "partons/eta";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output;
@@ -7940,7 +7951,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <728> {
+  struct plotter <729> {
     constexpr static const char* name = "partons/m";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output;
@@ -7951,7 +7962,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <729> {
+  struct plotter <730> {
     constexpr static const char* name = "partons/pdgid";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output;
@@ -7962,7 +7973,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <730> {
+  struct plotter <731> {
     constexpr static const char* name = "partons/phi";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output;
@@ -7973,7 +7984,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <731> {
+  struct plotter <732> {
     constexpr static const char* name = "partons/pz";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output;
@@ -7984,7 +7995,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <732> {
+  struct plotter <733> {
     constexpr static const char* name = "partons/py";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output;
@@ -7995,7 +8006,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <733> {
+  struct plotter <734> {
     constexpr static const char* name = "partons/px";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output;
@@ -8006,7 +8017,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <734> {
+  struct plotter <735> {
     constexpr static const char* name = "partons/e";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output;
@@ -8017,7 +8028,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <735> {
+  struct plotter <736> {
     constexpr static const char* name = "pfMet/phi";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.pfMet.phi)};
@@ -8026,7 +8037,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <736> {
+  struct plotter <737> {
     constexpr static const char* name = "pfMet/phiUnclUp";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.pfMet.phiUnclUp)};
@@ -8035,7 +8046,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <737> {
+  struct plotter <738> {
     constexpr static const char* name = "pfMet/sumETRaw";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.pfMet.sumETRaw)};
@@ -8044,7 +8055,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <738> {
+  struct plotter <739> {
     constexpr static const char* name = "pfMet/ptCorrUp";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.pfMet.ptCorrUp)};
@@ -8053,7 +8064,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <739> {
+  struct plotter <740> {
     constexpr static const char* name = "pfMet/pt";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.pfMet.pt)};
@@ -8062,7 +8073,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <740> {
+  struct plotter <741> {
     constexpr static const char* name = "pfMet/ptCorrDown";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.pfMet.ptCorrDown)};
@@ -8071,7 +8082,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <741> {
+  struct plotter <742> {
     constexpr static const char* name = "pfMet/phiCorrUp";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.pfMet.phiCorrUp)};
@@ -8080,7 +8091,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <742> {
+  struct plotter <743> {
     constexpr static const char* name = "pfMet/phiUnclDown";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.pfMet.phiUnclDown)};
@@ -8089,7 +8100,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <743> {
+  struct plotter <744> {
     constexpr static const char* name = "pfMet/ptUnclDown";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.pfMet.ptUnclDown)};
@@ -8098,7 +8109,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <744> {
+  struct plotter <745> {
     constexpr static const char* name = "pfMet/significance";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.pfMet.significance)};
@@ -8107,7 +8118,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <745> {
+  struct plotter <746> {
     constexpr static const char* name = "pfMet/phiCorrDown";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.pfMet.phiCorrDown)};
@@ -8116,7 +8127,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <746> {
+  struct plotter <747> {
     constexpr static const char* name = "pfMet/ptUnclUp";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.pfMet.ptUnclUp)};
@@ -8125,7 +8136,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <747> {
+  struct plotter <748> {
     constexpr static const char* name = "puppiMet/phi";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.puppiMet.phi)};
@@ -8134,7 +8145,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <748> {
+  struct plotter <749> {
     constexpr static const char* name = "puppiMet/phiUnclUp";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.puppiMet.phiUnclUp)};
@@ -8143,7 +8154,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <749> {
+  struct plotter <750> {
     constexpr static const char* name = "puppiMet/sumETRaw";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.puppiMet.sumETRaw)};
@@ -8152,7 +8163,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <750> {
+  struct plotter <751> {
     constexpr static const char* name = "puppiMet/ptCorrUp";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.puppiMet.ptCorrUp)};
@@ -8161,7 +8172,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <751> {
+  struct plotter <752> {
     constexpr static const char* name = "puppiMet/pt";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.puppiMet.pt)};
@@ -8170,7 +8181,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <752> {
+  struct plotter <753> {
     constexpr static const char* name = "puppiMet/ptCorrDown";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.puppiMet.ptCorrDown)};
@@ -8179,7 +8190,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <753> {
+  struct plotter <754> {
     constexpr static const char* name = "puppiMet/phiCorrUp";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.puppiMet.phiCorrUp)};
@@ -8188,7 +8199,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <754> {
+  struct plotter <755> {
     constexpr static const char* name = "puppiMet/phiUnclDown";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.puppiMet.phiUnclDown)};
@@ -8197,7 +8208,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <755> {
+  struct plotter <756> {
     constexpr static const char* name = "puppiMet/ptUnclDown";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.puppiMet.ptUnclDown)};
@@ -8206,7 +8217,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <756> {
+  struct plotter <757> {
     constexpr static const char* name = "puppiMet/significance";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.puppiMet.significance)};
@@ -8215,7 +8226,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <757> {
+  struct plotter <758> {
     constexpr static const char* name = "puppiMet/phiCorrDown";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.puppiMet.phiCorrDown)};
@@ -8224,7 +8235,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <758> {
+  struct plotter <759> {
     constexpr static const char* name = "puppiMet/ptUnclUp";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.puppiMet.ptUnclUp)};
@@ -8233,7 +8244,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <759> {
+  struct plotter <760> {
     constexpr static const char* name = "rawMet/phi";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.rawMet.phi)};
@@ -8242,7 +8253,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <760> {
+  struct plotter <761> {
     constexpr static const char* name = "rawMet/pt";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.rawMet.pt)};
@@ -8251,7 +8262,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <761> {
+  struct plotter <762> {
     constexpr static const char* name = "caloMet/phi";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.caloMet.phi)};
@@ -8260,7 +8271,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <762> {
+  struct plotter <763> {
     constexpr static const char* name = "caloMet/pt";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.caloMet.pt)};
@@ -8269,7 +8280,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <763> {
+  struct plotter <764> {
     constexpr static const char* name = "noMuMet/phi";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.noMuMet.phi)};
@@ -8278,7 +8289,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <764> {
+  struct plotter <765> {
     constexpr static const char* name = "noMuMet/pt";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.noMuMet.pt)};
@@ -8287,7 +8298,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <765> {
+  struct plotter <766> {
     constexpr static const char* name = "noHFMet/phi";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.noHFMet.phi)};
@@ -8296,7 +8307,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <766> {
+  struct plotter <767> {
     constexpr static const char* name = "noHFMet/pt";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.noHFMet.pt)};
@@ -8305,7 +8316,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <767> {
+  struct plotter <768> {
     constexpr static const char* name = "trkMet/phi";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.trkMet.phi)};
@@ -8314,7 +8325,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <768> {
+  struct plotter <769> {
     constexpr static const char* name = "trkMet/pt";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.trkMet.pt)};
@@ -8323,7 +8334,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <769> {
+  struct plotter <770> {
     constexpr static const char* name = "neutralMet/phi";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.neutralMet.phi)};
@@ -8332,7 +8343,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <770> {
+  struct plotter <771> {
     constexpr static const char* name = "neutralMet/pt";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.neutralMet.pt)};
@@ -8341,7 +8352,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <771> {
+  struct plotter <772> {
     constexpr static const char* name = "photonMet/phi";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.photonMet.phi)};
@@ -8350,7 +8361,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <772> {
+  struct plotter <773> {
     constexpr static const char* name = "photonMet/pt";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.photonMet.pt)};
@@ -8359,7 +8370,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <773> {
+  struct plotter <774> {
     constexpr static const char* name = "hfMet/phi";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.hfMet.phi)};
@@ -8368,7 +8379,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <774> {
+  struct plotter <775> {
     constexpr static const char* name = "hfMet/pt";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.hfMet.pt)};
@@ -8377,7 +8388,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <775> {
+  struct plotter <776> {
     constexpr static const char* name = "genMet/phi";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.genMet.phi)};
@@ -8386,7 +8397,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <776> {
+  struct plotter <777> {
     constexpr static const char* name = "genMet/pt";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.genMet.pt)};
@@ -8395,7 +8406,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <777> {
+  struct plotter <778> {
     constexpr static const char* name = "metFilters/duplicateMuons";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.metFilters.duplicateMuons)};
@@ -8404,7 +8415,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <778> {
+  struct plotter <779> {
     constexpr static const char* name = "metFilters/badMuons";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.metFilters.badMuons)};
@@ -8413,7 +8424,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <779> {
+  struct plotter <780> {
     constexpr static const char* name = "metFilters/globalHalo16";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.metFilters.globalHalo16)};
@@ -8422,7 +8433,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <780> {
+  struct plotter <781> {
     constexpr static const char* name = "metFilters/badsc";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.metFilters.badsc)};
@@ -8431,7 +8442,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <781> {
+  struct plotter <782> {
     constexpr static const char* name = "metFilters/hbheIso";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.metFilters.hbheIso)};
@@ -8440,7 +8451,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <782> {
+  struct plotter <783> {
     constexpr static const char* name = "metFilters/hbhe";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.metFilters.hbhe)};
@@ -8449,7 +8460,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <783> {
+  struct plotter <784> {
     constexpr static const char* name = "metFilters/badPFMuons";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.metFilters.badPFMuons)};
@@ -8458,7 +8469,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <784> {
+  struct plotter <785> {
     constexpr static const char* name = "metFilters/goodVertices";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.metFilters.goodVertices)};
@@ -8467,7 +8478,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <785> {
+  struct plotter <786> {
     constexpr static const char* name = "metFilters/ecalDeadCell";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.metFilters.ecalDeadCell)};
@@ -8476,7 +8487,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <786> {
+  struct plotter <787> {
     constexpr static const char* name = "metFilters/badChargedHadrons";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.metFilters.badChargedHadrons)};
@@ -8485,7 +8496,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <787> {
+  struct plotter <788> {
     constexpr static const char* name = "metFilters/pass";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.metFilters.pass())};
@@ -8494,7 +8505,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <788> {
+  struct plotter <789> {
     constexpr static const char* name = "metFilters/ecalBadCalib";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.metFilters.ecalBadCalib)};
@@ -8503,7 +8514,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <789> {
+  struct plotter <790> {
     constexpr static const char* name = "recoil/max";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.recoil.max)};
@@ -8512,7 +8523,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <790> {
+  struct plotter <791> {
     constexpr static const char* name = "recoil/monoE";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.recoil.monoE)};
@@ -8521,7 +8532,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <791> {
+  struct plotter <792> {
     constexpr static const char* name = "recoil/diE";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.recoil.diE)};
@@ -8530,7 +8541,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <792> {
+  struct plotter <793> {
     constexpr static const char* name = "recoil/monoMu";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.recoil.monoMu)};
@@ -8539,7 +8550,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <793> {
+  struct plotter <794> {
     constexpr static const char* name = "recoil/met";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.recoil.met)};
@@ -8548,7 +8559,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <794> {
+  struct plotter <795> {
     constexpr static const char* name = "recoil/diMu";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.recoil.diMu)};
@@ -8557,7 +8568,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <795> {
+  struct plotter <796> {
     constexpr static const char* name = "recoil/any";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.recoil.any())};
@@ -8566,7 +8577,7 @@ namespace testpanda {
   };
 
   template <>
-  struct plotter <796> {
+  struct plotter <797> {
     constexpr static const char* name = "recoil/gamma";
     std::vector<float> operator () (panda::Event& event) {
       std::vector<float> output {float(event.recoil.gamma)};
@@ -8574,7 +8585,7 @@ namespace testpanda {
     }
   };
 
-#define NUM_PLOTS 797
+#define NUM_PLOTS 798
 
 };
 

--- a/defs/panda.def
+++ b/defs/panda.def
@@ -90,6 +90,7 @@ enum StatusFlag {
 };
 pdgid/I
 finalState/O
+miniaodPacked/O   // True if this came from a MINIAOD packed collection
 statusFlags/s
 parent/GenParticleRef
 bool testFlag(StatusFlag f) const { return ((statusFlags >> f) & 1) == 1; }
@@ -201,6 +202,7 @@ pdgid/I
 [UnpackedGenParticle>ParticleM]
 pdgid/I
 finalState/O
+miniaodPacked/O   // True if this came from a MINIAOD packed collection
 statusFlags/s
 parent/UnpackedGenParticleRef
 bool testFlag(GenParticle::StatusFlag f) const { return ((statusFlags >> f) & 1) == 1; }


### PR DESCRIPTION
The Merged Output looks suspicious (more output particles than pruned and packed collections combined), so we're going to roll back for now. PandaAnalysis already removes duplicates. I'm adding this flag for myself so I can filter out to select the relevant gen particles.