### PR TITLE
tweaked trigger objects

### DIFF
--- a/Objects/interface/EventBase.h
+++ b/Objects/interface/EventBase.h
@@ -77,7 +77,7 @@ namespace panda {
      * By default, all trigger objects are loaded into the triggerObjects map at each call to getEntry.
      * Once a call to this function is made, only the objects for the registered filter will be loaded.
      */
-    void registerTriggerObjects(char const* filter) { registeredTriggerFilters_.emplace_back(filter); }
+    void registerTriggerObjects(char const* filter) { triggerObjects.registerFilter(filter); }
 
     //! Repeatable random number generator, initialized to be empty
     RRNG rng{0,0,nullptr};
@@ -94,12 +94,6 @@ namespace panda {
      event tree -> tree number, run tree 
      */
     std::map<TTree*, std::pair<Int_t, TTree*>> runTrees_;
-
-    //! List of trigger object filter names to use
-    std::vector<TString> registeredTriggerFilters_{};
-
-    //! Trigger filter mask generated from registeredTriggerFilters for each run
-    std::vector<bool> triggerFilterMask_{};
 
     /* END CUSTOM */
   };

--- a/Objects/interface/HLTObjectStore.h
+++ b/Objects/interface/HLTObjectStore.h
@@ -22,15 +22,33 @@ namespace panda {
     void setFilterObjectKeys(std::vector<TString> const& filters);
 
     //! Fill the filterObjects map for each event. Not to be called by users.
-    void makeMap(std::vector<bool> const& mask);
+    void makeMap();
+
+    //! Use to declare a trigger filter name (key in the triggerObjects map) to be used in the analysis.
+    /*!
+     * By default, all trigger objects are loaded into the triggerObjects map at each call to getEntry.
+     * Once a call to this function is made, only the objects for the registered filter will be loaded.
+     */
+    void registerFilter(char const* filter) { registeredFilters_.emplace(filter); }
+
+    //! If set to true, return an empty vector when non-existent filter is asked for
+    void setIgnoreMissing(Bool_t b) { ignoreMissing_ = b; }
 
     //! filterObjects_.at() with warnings. To be called by users.
     HLTObjectVector const& filterObjects(char const* filter) const;
 
   protected:
-    std::map<TString, HLTObjectVector> filterObjects_{};
-    //! internal-use pointers to the values of filterObjects_
-    std::vector<HLTObjectVector*> objectVectors_{};
+    Bool_t ignoreMissing_{false};
+    //! List of trigger object filter names to use
+    std::set<TString> registeredFilters_{};
+    //! Map from filter name to the outer index of objectVectors
+    std::map<TString, UInt_t> nameToSlot_{};
+    //! Map from filter index to objectVectors slot
+    std::vector<Int_t> indexToSlot_{};
+    //! Vector of vector of pointers to the objects. Outer index for filters
+    std::vector<HLTObjectVector> objectVectors_{};
+    //! Empty vector as a return value to filterObjects when ignoreMissing is true
+    static HLTObjectVector const emptyVector_;
   };
 
 }

--- a/Objects/src/EventBase.cc
+++ b/Objects/src/EventBase.cc
@@ -48,6 +48,8 @@ panda::EventBase::operator=(EventBase const& _src)
   rng = _src.rng;
   rng.setSeedAddress(&eventNumber);
   triggerObjects = _src.triggerObjects;
+
+  readRunTree_ = _src.readRunTree_;
   /* END CUSTOM */
 
   runNumber = _src.runNumber;
@@ -223,7 +225,7 @@ panda::EventBase::doGetEntry_(TTree& _tree)
   }
 
   if (triggerObjects.size() != 0 && run.hlt.filters)
-    triggerObjects.makeMap(triggerFilterMask_);
+    triggerObjects.makeMap();
 
   rng.generate();
 
@@ -266,27 +268,10 @@ panda::EventBase::triggerFired(UInt_t _token) const
 void
 panda::EventBase::setTriggerFilters_()
 {
+  if (triggerObjects.size() == 0 || !run.hlt.filters)
+    return;
 
-  if (triggerObjects.size() != 0 && run.hlt.filters) {
-    triggerObjects.setFilterObjectKeys(*run.hlt.filters);
-
-    if (registeredTriggerFilters_.empty()) {
-      // if no filters are registered, don't mask
-      triggerFilterMask_.resize(run.hlt.filters->size(), true);
-    }
-    else {
-      // else only allow the registered filters
-      triggerFilterMask_.resize(run.hlt.filters->size(), false);
-      for (unsigned fidx(0); fidx != run.hlt.filters->size(); ++fidx) {
-        for (auto& filter : registeredTriggerFilters_) {
-          if (filter == run.hlt.filters->at(fidx)) {
-            triggerFilterMask_[fidx] = true;
-            break;
-          }
-        }
-      }
-    }
-  }
+  triggerObjects.setFilterObjectKeys(*run.hlt.filters);
 }
 
 /* END CUSTOM */

--- a/Objects/src/EventMonophoton.cc
+++ b/Objects/src/EventMonophoton.cc
@@ -304,6 +304,7 @@ panda::EventMonophoton::copy(Event const& _src)
   weight = _src.weight;
 
   triggers = _src.triggers;
+  triggerObjects = _src.triggerObjects;
 
   npv = _src.npv;
   npvTrue = _src.npvTrue;


### PR DESCRIPTION
- Slightly reduced memory footprint of trigger objects by only creating object pointer vectors for registered filters
- More importantly, added "ignoreMissing" flag. If true and an unknown filter is passed to filterObjects(), can return an empty vector.