### PR TITLE
New PUPPI compression

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
                for f in /mnt/hadoop/scratch/jenkins/panda/$PANDA_PROD_USER/PandaProd/$PANDA_PROD_BRANCH/*
                do
                    BASE=$(echo $f | perl -ne '/\\/([\\w-]+)\\.root/ && print "$1"')
-                   testpanda $f ${JOB_NAME}/${BUILD_NUMBER}/$(tail -n1 $HOME/miniaod/$BASE.txt)
+                   NEW_PUPPI=1 testpanda $f ${JOB_NAME}/${BUILD_NUMBER}/$(tail -n1 $HOME/miniaod/$BASE.txt)
                done
                '''
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,11 +2,11 @@ pipeline {
   agent any
 
   environment {
-    SCRAM_ARCH = 'slc6_amd64_gcc630'
+    SCRAM_ARCH = 'slc6_amd64_gcc700'
     DOSRC = 'source /cvmfs/cms.cern.ch/cmsset_default.sh'
-    CMSSW_VERSION = 'CMSSW_9_4_6'
-    PANDA_PROD_USER = 'PandaPhysics'
-    PANDA_PROD_BRANCH = 'master'
+    CMSSW_VERSION = 'CMSSW_10_2_4_patch1'
+    PANDA_PROD_USER = 'dabercro'
+    PANDA_PROD_BRANCH = '2018D'
   }
 
   stages {

--- a/Objects/interface/GenParticle.h
+++ b/Objects/interface/GenParticle.h
@@ -86,7 +86,7 @@ namespace panda {
     */
     Int_t& pdgid;
     Bool_t& finalState;
-    Bool_t& miniaodPacked;
+    Bool_t& miniaodPacked; ///< True if this came from a MINIAOD packed collection
     UShort_t& statusFlags;
     Ref<GenParticle> parent;
 

--- a/Objects/interface/PFCand.h
+++ b/Objects/interface/PFCand.h
@@ -117,7 +117,7 @@ namespace panda {
     static bool newPuppi;
 
   public:
-    void useNewPuppi() { newPuppi = true; }
+    static void useNewPuppi() { newPuppi = true; }
 
     /* END CUSTOM */
 

--- a/Objects/interface/PFCand.h
+++ b/Objects/interface/PFCand.h
@@ -113,7 +113,12 @@ namespace panda {
     mutable double puppiW_{0.};
     mutable double puppiWNoLep_{0.};
 
+  private:
+    static bool newPuppi;
+
   public:
+    void useNewPuppi() { newPuppi = true; }
+
     /* END CUSTOM */
 
     static utils::BranchList getListOfBranches();

--- a/Objects/interface/UnpackedGenParticle.h
+++ b/Objects/interface/UnpackedGenParticle.h
@@ -62,7 +62,7 @@ namespace panda {
 
     Int_t& pdgid;
     Bool_t& finalState;
-    Bool_t& miniaodPacked;
+    Bool_t& miniaodPacked; ///< True if this came from a MINIAOD packed collection
     UShort_t& statusFlags;
     Ref<UnpackedGenParticle> parent;
 

--- a/Objects/src/PFCand.cc
+++ b/Objects/src/PFCand.cc
@@ -328,6 +328,10 @@ panda::PFCand::packMore_()
 // Can be set to true by calling panda::PFCand::useNewPuppi()
 bool panda::PFCand::newPuppi = std::getenv("NEW_PUPPI");
 
+template<typename T> double boundUnpack (const T weight) {
+  return static_cast<double>(static_cast<const T>(weight))/std::numeric_limits<T>::max();
+}
+
 void
 panda::PFCand::unpackMore_() const
 {
@@ -336,17 +340,12 @@ panda::PFCand::unpackMore_() const
    * We should probably also change PandaTree to store and expect explicitly bound PUPPI weights someday,
    * But for now, let's not break 009 and 012.
    *
-   * It's (unfortunately) the analyzer's responsibility to set the variable below.
+   * It's (unfortunately) the analyzer's responsibility to set newPuppi
    */
 
-  using packedPuppiType_10_2 = uint8_t;
-  auto boundUnpack = [] (const std::remove_reference<decltype(packedPuppiW)>::type weight) {
-    return static_cast<double>(static_cast<const packedPuppiType_10_2>(weight))/(std::numeric_limits<packedPuppiType_10_2>::max());
-  };
-
   if (newPuppi) {
-    puppiW_ = boundUnpack(packedPuppiW);
-    puppiWNoLep_ = boundUnpack(packedPuppiWNoLepDiff + packedPuppiW);
+    puppiW_ = boundUnpack<uint8_t>(packedPuppiW);
+    puppiWNoLep_ = boundUnpack<int8_t>(packedPuppiWNoLepDiff) + boundUnpack<uint8_t>(packedPuppiW);
   }
   else {
     puppiW_ = PackingHelper::singleton().unpack8LogBound(packedPuppiW, -2., 0., 64) * 0.5 + 0.5;

--- a/Objects/src/PFCand.cc
+++ b/Objects/src/PFCand.cc
@@ -325,6 +325,9 @@ panda::PFCand::packMore_()
   packedPuppiWNoLepDiff = PackingHelper::singleton().pack8LogBound((puppiWNoLep_ - 0.5) * 2., -2., 0., 64) - packedPuppiW;
 }
 
+// Can be set to true by calling panda::PFCand::useNewPuppi()
+bool panda::PFCand::newPuppi = std::getenv("NEW_PUPPI");
+
 void
 panda::PFCand::unpackMore_() const
 {
@@ -335,8 +338,6 @@ panda::PFCand::unpackMore_() const
    *
    * It's (unfortunately) the analyzer's responsibility to set the variable below.
    */
-
-  static bool newPuppi = std::getenv("NEW_PUPPI");
 
   using packedPuppiType_10_2 = uint8_t;
   auto boundUnpack = [] (const std::remove_reference<decltype(packedPuppiW)>::type weight) {

--- a/Objects/src/PFCand.cc
+++ b/Objects/src/PFCand.cc
@@ -328,8 +328,10 @@ panda::PFCand::packMore_()
 // Can be set to true by calling panda::PFCand::useNewPuppi()
 bool panda::PFCand::newPuppi = std::getenv("NEW_PUPPI");
 
-template<typename T> double boundUnpack (const T weight) {
-  return static_cast<double>(static_cast<const T>(weight))/std::numeric_limits<T>::max();
+namespace {
+  template<typename T> double boundUnpack (const T weight) {
+    return static_cast<double>(static_cast<const T>(weight))/std::numeric_limits<T>::max();
+  }
 }
 
 void


### PR DESCRIPTION
CMSSW_10_2_4 and after has a different way of packing PUPPI weights: https://github.com/ahinzmann/cmssw/commit/85e34d9dfc022d057ce0ffad4650c6c366a5b870

This is an attempt to keep PandaTree backwards compatible with pandaf/009 and pandaf/012, but still provide an easy way to get the correct weights in analysis code. By default, PandaTree behaves the old way. The new unpacking is activated by one of two ways:
- Set the environment variable `NEW_PUPPI`
- Call the function `panda::PFCand::useNewPuppi()`