### PR TITLE
This gets inherited

### DIFF
--- a/Utils/interface/PNode.h
+++ b/Utils/interface/PNode.h
@@ -48,7 +48,7 @@ struct PNode {
   static std::function<bool(PNode const&)> gPruningFunction;
 
   PNode() {}
-  ~PNode();
+  virtual ~PNode();
   PNode& operator=(PNode const&);
 
   std::string print() const;


### PR DESCRIPTION
GenParticleFiller in PandaProd defines a PNodeWithPtr class that inherits from PNode. Memory problems was causing the hanging when running over MC.