### PR TITLE
Add a corrector

### DIFF
--- a/Utils/BuildFile.xml
+++ b/Utils/BuildFile.xml
@@ -1,5 +1,7 @@
 <use name="root"/>
+<use name="boost"/>
 <use name="PandaTree/Objects"/>
+<use name="CondFormats/JetMETObjects"/>
 <export>
   <lib name="1"/>
 </export>

--- a/Utils/interface/JECCorrector.h
+++ b/Utils/interface/JECCorrector.h
@@ -1,0 +1,46 @@
+#ifndef PANDATREE_UTILS_JECCORRECTOR_H
+#define PANDATREE_UTILS_JECCORRECTOR_H
+
+
+#include "PandaTree/Objects/interface/Event.h"
+
+#include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
+#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h"
+
+
+namespace panda {
+  /**
+     @brief A wrapper for CMSSW's FactorizedJetCorrector for Panda JetCollections
+  */
+  class JECCorrector {
+  public:
+    /**
+       @param files_base Directory location and beginning of file name. e.g. "data/Autumn18_V3_MC"
+       @param jet_type Type of jet to correct. e.g. "AK4PFchs"
+    */
+    JECCorrector (const std::string& files_base, const std::string& jet_type);
+
+    /// Must be called at the beginning of each event to update the corrected values
+    void update_event (const panda::Event& event, const panda::JetCollection& jets, const Met& raw_met);
+
+    const JetCollection& get_jets () const;
+    const Met& get_met () const;
+
+  private:
+
+    /// Holds the corrected jets
+    JetCollection m_corrected_jets {};
+
+    /// Holds the corrected MET
+    Met m_corrected_met {};
+
+    /// A vector of the JetCorrectorParameters, initialized by panda::JECCorrector::load_params
+    std::vector<JetCorrectorParameters> m_corrector_params;
+    /// The FactorizedJetCorrector that is used underneath
+    FactorizedJetCorrector m_corrector;
+
+  };
+}
+
+
+#endif

--- a/Utils/interface/JECCorrector.h
+++ b/Utils/interface/JECCorrector.h
@@ -21,10 +21,10 @@ namespace panda {
     JECCorrector (const std::string& files_base, const std::string& jet_type);
 
     /// Must be called at the beginning of each event to update the corrected values
-    void update_event (const panda::Event& event, const panda::JetCollection& jets, const Met& raw_met);
+    void update_event (const panda::Event& event, const panda::JetCollection& jets, const RecoMet& met);
 
     const JetCollection& get_jets () const;
-    const Met& get_met () const;
+    const RecoMet& get_met () const;
 
   private:
 
@@ -32,7 +32,7 @@ namespace panda {
     JetCollection m_corrected_jets {};
 
     /// Holds the corrected MET
-    Met m_corrected_met {};
+    RecoMet m_corrected_met {};
 
     /// A vector of the JetCorrectorParameters, initialized by panda::JECCorrector::load_params
     std::vector<JetCorrectorParameters> m_corrector_params;

--- a/Utils/src/JECCorrector.cc
+++ b/Utils/src/JECCorrector.cc
@@ -1,0 +1,98 @@
+#include <iostream>
+#include <exception>
+
+#include <boost/filesystem.hpp>
+
+#include "PandaTree/Utils/interface/JECCorrector.h"
+
+
+using namespace panda;
+
+
+namespace {
+
+  // Used to initialize the JetCorrectionParameters
+  std::vector<JetCorrectorParameters> load_params (const std::string& files_base, const std::string& jet_type) {
+
+    std::vector<JetCorrectorParameters> output {};
+
+    const std::vector<std::string> levels = {
+      "L1FastJet",
+      "L2Relative",
+      "L3Absolute",
+      "L2L3Residual"
+    };
+
+    for (const auto& level : levels) {
+
+      const std::string correction_file = files_base + "_" + level + "_" + jet_type + ".txt";
+
+      if (not boost::filesystem::exists(correction_file)) {
+        std::cerr << "Cannot find correction file: " << correction_file << std::endl;
+        throw std::runtime_error {"No file"};
+      }
+
+      output.emplace_back(correction_file);
+    }
+
+    return output;
+
+  }
+
+}
+
+
+JECCorrector::JECCorrector (const std::string& files_base, const std::string& jet_type) :
+  m_corrector_params {load_params(files_base, jet_type)},
+  m_corrector {m_corrector_params} {}
+
+
+void JECCorrector::update_event (const panda::Event& event, const panda::JetCollection& jets, const Met& raw_met) {
+
+  // Copy jets over
+  m_corrected_jets = jets;
+
+  auto new_met = raw_met.v();
+  TVector2 met_correction {};
+
+  m_corrector.setNPV(event.npv);
+  m_corrector.setRho(event.rho);
+
+  for (auto& jet : m_corrected_jets) {
+    m_corrector.setJetEta(jet.eta());
+    m_corrector.setJetPt(jet.rawPt);
+    m_corrector.setJetE(jet.e());
+    m_corrector.setJetPhi(jet.phi());
+    m_corrector.setJetEMF(jet.cef + jet.nef); // Check that this is right
+    m_corrector.setJetA(jet.area);
+
+    auto scale = m_corrector.getCorrection();
+
+    // Use 1.0 minus new so that we don't have to flip phi.
+    // This adds to MET if scale > 1 and points in opposite direction
+    // Subtracts if scale < 1 and points in opposite direction
+    met_correction.SetMagPhi((1.0 - scale) * jet.rawPt, jet.phi());
+
+    new_met += met_correction;
+
+    jet.setPtEtaPhiM(scale * jet.rawPt, jet.eta(), jet.phi(), jet.m());
+  }
+
+  // Change stored MET
+  m_corrected_met.setXY(new_met.X(), new_met.Y());
+
+}
+
+
+const JetCollection& JECCorrector::get_jets () const {
+
+  return m_corrected_jets;
+
+}
+
+
+const Met& JECCorrector::get_met () const {
+
+  return m_corrected_met;
+
+}

--- a/Utils/src/JECCorrector.cc
+++ b/Utils/src/JECCorrector.cc
@@ -55,10 +55,12 @@ void JECCorrector::update_event (const panda::Event& event, const panda::JetColl
   auto new_met = raw_met.v();
   TVector2 met_correction {};
 
-  m_corrector.setNPV(event.npv);
-  m_corrector.setRho(event.rho);
-
   for (auto& jet : m_corrected_jets) {
+
+    // FactorizedJetCorrectorCalculator is stupid and resets these every time
+    m_corrector.setNPV(event.npv);
+    m_corrector.setRho(event.rho);
+
     m_corrector.setJetEta(jet.eta());
     m_corrector.setJetPt(jet.rawPt);
     m_corrector.setJetE(jet.e());
@@ -77,6 +79,8 @@ void JECCorrector::update_event (const panda::Event& event, const panda::JetColl
 
     jet.setPtEtaPhiM(scale * jet.rawPt, jet.eta(), jet.phi(), jet.m());
   }
+
+  m_corrected_jets.sort(panda::Particle::PtGreater);
 
   // Change stored MET
   m_corrected_met.setXY(new_met.X(), new_met.Y());


### PR DESCRIPTION
@dr-stringfellow Here's a rough JEC recorrector. I hope it's simple to use. The essence in my slimmer is:

```
if (not event.isData and not corr_ptr)
  corr_ptr = std::make_unique<panda::JECCorrector>("data/Autumn18_V3_MC", "AK4PFchs");

if (corr_ptr) {
  corr_ptr->update_event(event, event.chsAK4Jets, event.pfMet);  // Edited rawMet ==> pfMet
  output.pfmet = corr_ptr->get_met().pt;
  output.pfmetphi = corr_ptr->get_met().phi;
}

for (auto& jet : (corr_ptr ? corr_ptr->get_jets() : event.chsAK4Jets)) {
  // blah blah
}
```

Minor differences in variables in MC can be seen here: http://t3serv001.mit.edu/~dabercro/plotviewer/?expr=pfmet%24+%5Ejet._pt%24+n_jet&width=4&dirs%5B%5D=testhbb_old&dirs%5B%5D=testhbb